### PR TITLE
feat: Ollama streaming chat integration

### DIFF
--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -2,6 +2,11 @@ const OLLAMA_BASE = "http://127.0.0.1:11434";
 
 export type OllamaStatus = "running" | "installed" | "missing";
 
+export interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export async function detectOllama(): Promise<OllamaStatus> {
   try {
     const res = await fetch(`${OLLAMA_BASE}/api/tags`, { signal: AbortSignal.timeout(2000) });
@@ -17,4 +22,46 @@ export async function listModels(): Promise<string[]> {
   if (!res.ok) throw new Error("Ollama not reachable");
   const data = await res.json() as { models: { name: string }[] };
   return data.models.map((m) => m.name);
+}
+
+export async function pickGemmaModel(): Promise<string> {
+  const models = await listModels();
+  const gemma = models.find((m) => m.startsWith("gemma"));
+  return gemma ?? "gemma3:latest";
+}
+
+export async function chat(
+  model: string,
+  history: Message[],
+  onToken: (token: string) => void,
+  signal?: AbortSignal,
+): Promise<string> {
+  const res = await fetch(`${OLLAMA_BASE}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, messages: history, stream: true }),
+    signal,
+  });
+
+  if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
+  if (!res.body) throw new Error("No response body");
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let full = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    for (const line of decoder.decode(value).split("\n")) {
+      if (!line.trim()) continue;
+      const chunk = JSON.parse(line) as { message?: { content: string }; done: boolean };
+      if (chunk.message?.content) {
+        full += chunk.message.content;
+        onToken(chunk.message.content);
+      }
+    }
+  }
+
+  return full;
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,11 +1,14 @@
 import { ItemView, WorkspaceLeaf } from "obsidian";
-import { detectOllama } from "./ollama";
+import { detectOllama, pickGemmaModel, chat, Message } from "./ollama";
 
 export const VIEW_TYPE = "gemmera-chat";
 
 export class GemmeraChatView extends ItemView {
   private messagesEl: HTMLElement;
   private inputEl: HTMLTextAreaElement;
+  private sendBtn: HTMLButtonElement;
+  private history: Message[] = [];
+  private model = "gemma3:latest";
 
   constructor(leaf: WorkspaceLeaf) {
     super(leaf);
@@ -31,6 +34,7 @@ export class GemmeraChatView extends ItemView {
     // Status bar
     const statusEl = container.createEl("div", { cls: "gemmera-status" });
     this.checkOllamaStatus(statusEl);
+    pickGemmaModel().then((m) => { this.model = m; }).catch(() => {});
 
     // Messages area
     this.messagesEl = container.createEl("div", { cls: "gemmera-messages" });
@@ -41,11 +45,11 @@ export class GemmeraChatView extends ItemView {
       cls: "gemmera-input",
       attr: { placeholder: "Skriv ett meddelande...", rows: "3" },
     });
-    const sendBtn = inputArea.createEl("button", {
+    this.sendBtn = inputArea.createEl("button", {
       cls: "gemmera-send",
       text: "Skicka",
     });
-    sendBtn.addEventListener("click", () => this.handleSend());
+    this.sendBtn.addEventListener("click", () => this.handleSend());
     this.inputEl.addEventListener("keydown", (e) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
@@ -70,13 +74,45 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  private handleSend(): void {
+  private async handleSend(): Promise<void> {
     const text = this.inputEl.value.trim();
     if (!text) return;
-    this.appendMessage("user", text);
+
     this.inputEl.value = "";
-    // LLM call will be wired in a later issue
-    this.appendMessage("assistant", "(Ollama-integration kommer i nästa steg)");
+    this.setInputDisabled(true);
+
+    this.history.push({ role: "user", content: text });
+    this.appendMessage("user", text);
+
+    const { el: assistantEl, textEl } = this.appendStreamingMessage();
+
+    try {
+      const reply = await chat(this.model, this.history, (token) => {
+        textEl.textContent += token;
+        this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+      });
+      this.history.push({ role: "assistant", content: reply });
+    } catch (err) {
+      textEl.textContent = `Fel: ${err instanceof Error ? err.message : "okänt fel"}`;
+      assistantEl.addClass("gemmera-message--error");
+      this.history.pop();
+    } finally {
+      this.setInputDisabled(false);
+      this.inputEl.focus();
+    }
+  }
+
+  private setInputDisabled(disabled: boolean): void {
+    this.inputEl.disabled = disabled;
+    this.sendBtn.disabled = disabled;
+  }
+
+  private appendStreamingMessage(): { el: HTMLElement; textEl: HTMLElement } {
+    const el = this.messagesEl.createEl("div", { cls: "gemmera-message gemmera-message--assistant" });
+    el.createEl("span", { cls: "gemmera-message__role", text: "Gemma" });
+    const textEl = el.createEl("p", { cls: "gemmera-message__text", text: "" });
+    this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+    return { el, textEl };
   }
 
   private appendMessage(role: "user" | "assistant", text: string): void {
@@ -85,4 +121,5 @@ export class GemmeraChatView extends ItemView {
     msg.createEl("p", { cls: "gemmera-message__text", text });
     this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
   }
+
 }


### PR DESCRIPTION
## Summary

- Adds `chat()` to `ollama.ts` with token-by-token streaming via the Ollama `/api/chat` endpoint
- Adds `pickGemmaModel()` to auto-select an installed Gemma model (falls back to `gemma3:latest`)
- Wires up `handleSend()` in the chat panel — replaces the placeholder stub with a real streaming call, tracks conversation history, disables input during generation, and shows errors on failure

## Test plan

- [ ] Start Ollama locally with a Gemma model installed (`ollama pull gemma3:latest`)
- [ ] Open the Gemmera panel in Obsidian — status bar should show "Ollama: körs"
- [ ] Send a message and verify tokens stream in live
- [ ] Send multiple messages and verify conversation history is maintained
- [ ] Stop Ollama and send a message — verify error message appears in the bubble
- [ ] Verify input and send button are disabled during generation and re-enabled after

🤖 Generated with [Claude Code](https://claude.com/claude-code)