### PR TITLE
Week 2: vault file access (read, create, append)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ett Obsidian-plugin som förvandlar din vault till en lokal, privat kunskapsbas 
 
 ## MVP
 
-Ett Obsidian-plugin som lägger till en chattpanel i sidofältet. Gemma kör lokalt via Ollama och har verktyg för att skapa, läsa och uppdatera filer i vaulten.
+Ett Obsidian-plugin som lägger till en chattpanel i sidofältet. Gemma kör lokalt via Ollama med token-för-token strömning och bibehåller konversationshistorik mellan sessioner.
 
 Kärnfunktioner:
 
@@ -15,7 +15,7 @@ Kärnfunktioner:
 - **Uppdatering av befintliga sidor** — Gemma kan läsa och lägga till innehåll i existerande filer, med preview innan ändring skrivs.
 - **Sökning i vaulten** — Gemma kan slå upp innehåll i vaultens filer för att svara med citat till källor.
 
-Fejkpersonen "Jonas Berg" (dagböcker, brev, bokrecensioner) medföljer som demo-vault så allt fungerar direkt efter installation.
+Fejkpersonen "Jonas Berg" (dagböcker, brev och bokrecensioner på svenska) medföljer som demo-vault så allt fungerar direkt efter installation.
 
 ## Säkerhetsprinciper
 
@@ -31,10 +31,17 @@ TypeScript, Obsidian Plugin API, Svelte för chat-UI, Gemma via Ollama lokalt, M
 
 ## Tidsplan — 4 veckor
 
-- **Vecka 1 (grund):** Repo-setup, plugin-skelett, Ollama-integration, enkel chat-panel, persona-generering.
-- **Vecka 2 (full MVP):** Verktyg för filskapande, läsning och uppdatering. Preview-dialog. Tester på Jonas-vaulten.
-- **Vecka 3 (utökning):** Ett av röstinmatning / vault-sökning med citat / inkrementell indexering. Val efter v2-retro.
-- **Vecka 4 (polering):** Utvärdering mot 20 testfrågor, installationsguide, demo-förberedelse.
+### Vecka 1 ✅ (grund)
+- [x] Repo-setup
+- [x] Plugin-skelett
+- [x] Ollama-integration med token-strömning
+- [x] Chat-panel med konversationshistorik
+- [x] Persona-generering (Jonas Berg, svenska anteckningar)
+
+### Vecka 2 (full MVP)
+- [ ] Verktyg för filskapande, läsning och uppdatering
+- [ ] Preview-dialog
+- [ ] Tester på Jonas-vaulten
 
 **Slutacceptans:** en ny person installerar pluginet, följer README, och har en fungerande chatt som kan skapa filer i sin vault inom 20 min på en typisk 8 GB-bärbar.
 

--- a/src/AppendFileModal.ts
+++ b/src/AppendFileModal.ts
@@ -1,0 +1,45 @@
+import { App, Modal } from "obsidian";
+
+export class AppendFileModal extends Modal {
+  private filename: string;
+  private content: string;
+  private onConfirm: (filename: string, content: string) => void;
+
+  constructor(
+    app: App,
+    filename: string,
+    content: string,
+    onConfirm: (filename: string, content: string) => void,
+  ) {
+    super(app);
+    this.filename = filename;
+    this.content = content;
+    this.onConfirm = onConfirm;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("gemmera-modal");
+
+    contentEl.createEl("h2", { text: "Lägg till i anteckning?" });
+    contentEl.createEl("p", { text: `Fil: ${this.filename}`, cls: "gemmera-modal__filename" });
+
+    const preview = contentEl.createEl("pre", { cls: "gemmera-modal__preview" });
+    preview.textContent = this.content;
+
+    const btnRow = contentEl.createEl("div", { cls: "gemmera-modal__buttons" });
+    const confirmBtn = btnRow.createEl("button", { text: "Lägg till", cls: "mod-cta" });
+    const cancelBtn = btnRow.createEl("button", { text: "Avbryt" });
+
+    confirmBtn.addEventListener("click", () => {
+      this.onConfirm(this.filename, this.content);
+      this.close();
+    });
+    cancelBtn.addEventListener("click", () => this.close());
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/CreateFileModal.ts
+++ b/src/CreateFileModal.ts
@@ -1,0 +1,45 @@
+import { App, Modal } from "obsidian";
+
+export class CreateFileModal extends Modal {
+  private filename: string;
+  private content: string;
+  private onConfirm: (filename: string, content: string) => void;
+
+  constructor(
+    app: App,
+    filename: string,
+    content: string,
+    onConfirm: (filename: string, content: string) => void,
+  ) {
+    super(app);
+    this.filename = filename;
+    this.content = content;
+    this.onConfirm = onConfirm;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("gemmera-modal");
+
+    contentEl.createEl("h2", { text: "Skapa anteckning?" });
+    contentEl.createEl("p", { text: `Filnamn: ${this.filename}`, cls: "gemmera-modal__filename" });
+
+    const preview = contentEl.createEl("pre", { cls: "gemmera-modal__preview" });
+    preview.textContent = this.content;
+
+    const btnRow = contentEl.createEl("div", { cls: "gemmera-modal__buttons" });
+    const confirmBtn = btnRow.createEl("button", { text: "Skapa", cls: "mod-cta" });
+    const cancelBtn = btnRow.createEl("button", { text: "Avbryt" });
+
+    confirmBtn.addEventListener("click", () => {
+      this.onConfirm(this.filename, this.content);
+      this.close();
+    });
+    cancelBtn.addEventListener("click", () => this.close());
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/fileops.ts
+++ b/src/fileops.ts
@@ -1,0 +1,47 @@
+import { App } from "obsidian";
+import { CreateFileModal } from "./CreateFileModal";
+import { AppendFileModal } from "./AppendFileModal";
+
+const CREATE_RE = /:::create\s+(\S+\.md)\n([\s\S]*?):::/g;
+const APPEND_RE = /:::append\s+(\S+\.md)\n([\s\S]*?):::/g;
+
+export interface FileOp {
+  type: "create" | "append";
+  filename: string;
+  content: string;
+}
+
+export function parseFileOps(text: string): FileOp[] {
+  const ops: FileOp[] = [];
+  for (const m of text.matchAll(CREATE_RE)) {
+    ops.push({ type: "create", filename: m[1], content: m[2].trim() });
+  }
+  for (const m of text.matchAll(APPEND_RE)) {
+    ops.push({ type: "append", filename: m[1], content: m[2].trim() });
+  }
+  return ops;
+}
+
+export async function handleFileOps(app: App, ops: FileOp[]): Promise<void> {
+  for (const op of ops) {
+    if (op.type === "create") {
+      new CreateFileModal(app, op.filename, op.content, async (filename, content) => {
+        const existing = app.vault.getAbstractFileByPath(filename);
+        if (existing) {
+          console.warn(`Gemmera: ${filename} finns redan, hoppar över skapande`);
+          return;
+        }
+        await app.vault.create(filename, content);
+      }).open();
+    } else if (op.type === "append") {
+      new AppendFileModal(app, op.filename, op.content, async (filename, content) => {
+        const file = app.vault.getFileByPath(filename);
+        if (!file) {
+          console.warn(`Gemmera: ${filename} hittades inte för append`);
+          return;
+        }
+        await app.vault.append(file, "\n" + content);
+      }).open();
+    }
+  }
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,73 @@
+import { App, TFile } from "obsidian";
+
+const MAX_FILES = 3;
+const MAX_CHARS_PER_FILE = 2000;
+
+export interface SearchResult {
+  filename: string;
+  content: string;
+}
+
+export async function searchVault(app: App, query: string): Promise<SearchResult[]> {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 2);
+
+  if (terms.length === 0) return [];
+
+  const files = app.vault.getMarkdownFiles();
+  const scored: { file: TFile; score: number }[] = [];
+
+  for (const file of files) {
+    const nameScore = terms.filter((t) => file.basename.toLowerCase().includes(t)).length * 2;
+    if (nameScore === 0) {
+      const cache = app.metadataCache.getFileCache(file);
+      const headings = cache?.headings?.map((h) => h.heading.toLowerCase()).join(" ") ?? "";
+      const headingScore = terms.filter((t) => headings.includes(t)).length;
+      if (headingScore > 0) scored.push({ file, score: headingScore });
+    } else {
+      scored.push({ file, score: nameScore });
+    }
+  }
+
+  // For top candidates, do a full content search
+  const topByName = scored.sort((a, b) => b.score - a.score).slice(0, 10);
+  const results: SearchResult[] = [];
+
+  for (const { file } of topByName) {
+    const content = await app.vault.cachedRead(file);
+    const lowerContent = content.toLowerCase();
+    const contentScore = terms.filter((t) => lowerContent.includes(t)).length;
+    if (contentScore > 0) {
+      results.push({ filename: file.name, content: content.slice(0, MAX_CHARS_PER_FILE) });
+    }
+  }
+
+  // If name-based search found nothing, fall back to full content scan
+  if (results.length === 0) {
+    for (const file of files) {
+      if (results.length >= MAX_FILES) break;
+      const content = await app.vault.cachedRead(file);
+      const lowerContent = content.toLowerCase();
+      const score = terms.filter((t) => lowerContent.includes(t)).length;
+      if (score > 0) {
+        results.push({ filename: file.name, content: content.slice(0, MAX_CHARS_PER_FILE) });
+      }
+    }
+  }
+
+  return results.slice(0, MAX_FILES);
+}
+
+export function buildContextPrompt(results: SearchResult[]): string {
+  if (results.length === 0) return "";
+  const parts = results.map(
+    (r) => `### ${r.filename}\n${r.content}`,
+  );
+  return (
+    "Nedan följer relevanta anteckningar från användarens vault. " +
+    "Använd dem som kontext när du svarar:\n\n" +
+    parts.join("\n\n---\n\n")
+  );
+}

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,5 +1,6 @@
 import { ItemView, WorkspaceLeaf } from "obsidian";
 import { detectOllama, pickGemmaModel, chat, Message } from "./ollama";
+import { searchVault, buildContextPrompt } from "./search";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -87,7 +88,13 @@ export class GemmeraChatView extends ItemView {
     const { el: assistantEl, textEl } = this.appendStreamingMessage();
 
     try {
-      const reply = await chat(this.model, this.history, (token) => {
+      const searchResults = await searchVault(this.app, text);
+      const contextPrompt = buildContextPrompt(searchResults);
+      const messagesWithContext: Message[] = contextPrompt
+        ? [{ role: "user", content: contextPrompt }, { role: "assistant", content: "Förstått, jag har läst anteckningarna." }, ...this.history]
+        : this.history;
+
+      const reply = await chat(this.model, messagesWithContext, (token) => {
         textEl.textContent += token;
         this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
       });

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,6 +1,7 @@
 import { ItemView, WorkspaceLeaf } from "obsidian";
 import { detectOllama, pickGemmaModel, chat, Message } from "./ollama";
 import { searchVault, buildContextPrompt } from "./search";
+import { parseFileOps, handleFileOps } from "./fileops";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -99,6 +100,8 @@ export class GemmeraChatView extends ItemView {
         this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
       });
       this.history.push({ role: "assistant", content: reply });
+      const ops = parseFileOps(reply);
+      if (ops.length > 0) await handleFileOps(this.app, ops);
     } catch (err) {
       textEl.textContent = `Fel: ${err instanceof Error ? err.message : "okänt fel"}`;
       assistantEl.addClass("gemmera-message--error");


### PR DESCRIPTION
## Summary

- Injects relevant vault notes as context on every chat message via keyword search (`src/search.ts`)
- Parses `:::create filename.md` and `:::append filename.md` blocks in Gemma's replies
- Shows a preview modal before writing any file — user must confirm before anything is saved

## Test plan

- [ ] Ask "Vilka böcker har Jonas läst?" — Gemma should reference `laslogg_2025.md`
- [ ] Ask Gemma to create a note using `:::create test.md\ncontent\n:::` syntax — confirm modal appears
- [ ] Confirm creation — verify file appears in vault
- [ ] Ask Gemma to append to an existing note — confirm append modal appears and content is added
- [ ] Cancel in modal — verify no file is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)