### PR TITLE
feat(integration): wire Ollama LLM factory with mock fallback

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,0 +1,14 @@
+export class Notice {
+  constructor(public message: string) {}
+}
+
+export class FileSystemAdapter {
+  getFullPath(path: string): string {
+    return path;
+  }
+}
+
+export class Plugin {}
+export class WorkspaceLeaf {}
+export class ItemView {}
+export class MarkdownRenderer {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,15 @@
 import { Plugin, WorkspaceLeaf } from "obsidian";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
+import { DEFAULT_SETTINGS, GemmeraSettings } from "./settings";
 
 export default class GemmeraPlugin extends Plugin {
   private services!: Services;
+  settings!: GemmeraSettings;
 
   async onload(): Promise<void> {
-    this.services = createServices(this.app);
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    this.services = await createServices(this.app, this.settings);
     this.services.eventBridge.start();
     this.services.ingestionRunner.start();
     this.services.embeddingService.start();

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, type App } from "obsidian";
+import { FileSystemAdapter, Notice, type App } from "obsidian";
 import type {
   IndexService,
   IngestionPipeline,
@@ -10,6 +10,8 @@ import type {
   VaultService,
   VectorStore,
 } from "../contracts";
+import type { GemmeraSettings } from "../settings";
+import { MockLLMService } from "./mock-llm";
 import { OllamaLLMService } from "./ollama-llm";
 import { ObsidianVaultService } from "./real-vault";
 import { VaultLinearIndexService } from "./vault-index";
@@ -47,7 +49,21 @@ const VECTORS_JSON_PATH = ".coworkmd/vectors.json";
 const DEFAULT_EMBED_MODEL = "bge-m3";
 const DEFAULT_EMBED_DIM = 1024;
 
-export function createServices(app: App): Services {
+export async function createLLMService(
+  backend: GemmeraSettings["llmBackend"],
+): Promise<LLMService> {
+  if (backend === "mock") {
+    return new MockLLMService();
+  }
+  const ollama = new OllamaLLMService();
+  if ((await ollama.isReachable()) === "missing") {
+    new Notice("Gemmera: Ollama not reachable — falling back to mock LLM.");
+    return new MockLLMService();
+  }
+  return ollama;
+}
+
+export async function createServices(app: App, settings: GemmeraSettings): Promise<Services> {
   const vault = new ObsidianVaultService(app);
   const jobQueue = new InMemoryJobQueue();
   const pathFilter = new DefaultPathFilter();
@@ -89,7 +105,7 @@ export function createServices(app: App): Services {
   );
 
   return {
-    llm: new OllamaLLMService(),
+    llm: await createLLMService(settings.llmBackend),
     vault,
     index: new VaultLinearIndexService(vault),
     jobQueue,

--- a/src/services/llm-factory.test.ts
+++ b/src/services/llm-factory.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLLMService } from "./index";
+import { MockLLMService } from "./mock-llm";
+import { OllamaLLMService } from "./ollama-llm";
+
+vi.mock("obsidian", () => ({ Notice: vi.fn() }));
+
+describe("createLLMService", () => {
+  it("returns MockLLMService when backend is 'mock'", async () => {
+    const svc = await createLLMService("mock");
+    expect(svc).toBeInstanceOf(MockLLMService);
+  });
+
+  it("returns OllamaLLMService when Ollama is reachable", async () => {
+    vi.spyOn(OllamaLLMService.prototype, "isReachable").mockResolvedValueOnce("running");
+    const svc = await createLLMService("ollama");
+    expect(svc).toBeInstanceOf(OllamaLLMService);
+  });
+
+  it("falls back to MockLLMService and shows a Notice when Ollama is unreachable", async () => {
+    const { Notice } = await import("obsidian");
+    vi.spyOn(OllamaLLMService.prototype, "isReachable").mockResolvedValueOnce("missing");
+    const svc = await createLLMService("ollama");
+    expect(svc).toBeInstanceOf(MockLLMService);
+    expect(Notice).toHaveBeenCalledOnce();
+  });
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,8 @@
+export interface GemmeraSettings {
+  /** Dev-only: force "mock" to bypass Ollama entirely. Default is "ollama". */
+  llmBackend: "ollama" | "mock";
+}
+
+export const DEFAULT_SETTINGS: GemmeraSettings = {
+  llmBackend: "ollama",
+};

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,10 @@
 export interface GemmeraSettings {
-  /** Dev-only: force "mock" to bypass Ollama entirely. Default is "ollama". */
+  /**
+   * Dev-only: force "mock" to bypass Ollama entirely. Default is "ollama".
+   *
+   * Not exposed in the UI — change only by editing the plugin's `data.json`
+   * (or in code for tests). Intended for developers and CI, not end users.
+   */
   llmBackend: "ollama" | "mock";
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      obsidian: path.resolve(__dirname, "__mocks__/obsidian.ts"),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts"],
     environment: "node",


### PR DESCRIPTION
## What
The plugin now checks if Ollama is running when it starts. If Ollama is available it uses it as normal. If not, it falls back to the mock LLM and shows a notice to the user. There is also a dev setting to force mock mode without needing Ollama at all.

## Why
Closes #59. Before this, starting the plugin without Ollama running would silently fail. Now offline and demo use works out of the box.

## How to test
- Start Obsidian with Ollama running — chat should work as normal with real model output
- Start Obsidian with Ollama stopped — a notice should appear and chat should still work using the mock
- \`npm test\` — all tests pass

Closes #59