### PR TITLE
test(rag): cover OllamaEmbedder and add end-to-end pipeline integration test

### DIFF
--- a/src/services/ollama-embedder.test.ts
+++ b/src/services/ollama-embedder.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OllamaEmbedder } from "./ollama-embedder";
+
+interface FetchCall {
+  url: string;
+  body: { model: string; input: string[] };
+}
+
+function mockFetch(
+  responder: (call: FetchCall) => { ok: boolean; status?: number; statusText?: string; json: unknown },
+): { calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as FetchCall["body"];
+    const call = { url, body };
+    calls.push(call);
+    const r = responder(call);
+    return {
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      statusText: r.statusText ?? (r.ok ? "OK" : "ERR"),
+      json: async () => r.json,
+    } as Response;
+  });
+  return { calls };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("OllamaEmbedder", () => {
+  it("returns [] for empty input without calling fetch", async () => {
+    const { calls } = mockFetch(() => ({ ok: true, json: { embeddings: [] } }));
+    const e = new OllamaEmbedder({ dim: 4 });
+    expect(await e.embed([])).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("posts to /api/embed with the configured model and the batch's texts", async () => {
+    const { calls } = mockFetch(({ body }) => ({
+      ok: true,
+      json: { embeddings: body.input.map(() => [1, 0, 0, 0]) },
+    }));
+    const e = new OllamaEmbedder({ baseUrl: "http://h:1", model: "m1", dim: 4 });
+    await e.embed([
+      { id: "a", text: "alpha" },
+      { id: "b", text: "beta" },
+    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://h:1/api/embed");
+    expect(calls[0].body).toEqual({ model: "m1", input: ["alpha", "beta"] });
+  });
+
+  it("preserves request ids in result order", async () => {
+    mockFetch(({ body }) => ({
+      ok: true,
+      json: { embeddings: body.input.map((_, i) => [i + 1, 0, 0, 0]) },
+    }));
+    const e = new OllamaEmbedder({ dim: 4, batchSize: 32 });
+    const out = await e.embed([
+      { id: "x", text: "x" },
+      { id: "y", text: "y" },
+      { id: "z", text: "z" },
+    ]);
+    expect(out.map((r) => r.id)).toEqual(["x", "y", "z"]);
+  });
+
+  it("L2-normalizes vectors so dot product == cosine", async () => {
+    mockFetch(() => ({ ok: true, json: { embeddings: [[3, 4, 0, 0]] } }));
+    const e = new OllamaEmbedder({ dim: 4 });
+    const [r] = await e.embed([{ id: "a", text: "a" }]);
+    const norm = Math.sqrt(r.vec.reduce((s, v) => s + v * v, 0));
+    expect(norm).toBeCloseTo(1, 6);
+    expect(r.vec[0]).toBeCloseTo(0.6, 6);
+    expect(r.vec[1]).toBeCloseTo(0.8, 6);
+  });
+
+  it("leaves a zero vector at zero (no NaN from divide-by-zero)", async () => {
+    mockFetch(() => ({ ok: true, json: { embeddings: [[0, 0, 0, 0]] } }));
+    const e = new OllamaEmbedder({ dim: 4 });
+    const [r] = await e.embed([{ id: "a", text: "a" }]);
+    for (const v of r.vec) expect(v).toBe(0);
+  });
+
+  it("splits inputs across batches of at most batchSize and preserves order", async () => {
+    const { calls } = mockFetch(({ body }) => ({
+      ok: true,
+      json: { embeddings: body.input.map(() => [1, 0]) },
+    }));
+    const e = new OllamaEmbedder({ dim: 2, batchSize: 2 });
+    const out = await e.embed([
+      { id: "a", text: "a" },
+      { id: "b", text: "b" },
+      { id: "c", text: "c" },
+      { id: "d", text: "d" },
+      { id: "e", text: "e" },
+    ]);
+    expect(calls).toHaveLength(3);
+    expect(calls.map((c) => c.body.input)).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+      ["e"],
+    ]);
+    expect(out.map((r) => r.id)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("throws when Ollama returns the wrong number of embeddings", async () => {
+    mockFetch(() => ({ ok: true, json: { embeddings: [[1, 0]] } }));
+    const e = new OllamaEmbedder({ dim: 2 });
+    await expect(
+      e.embed([
+        { id: "a", text: "a" },
+        { id: "b", text: "b" },
+      ]),
+    ).rejects.toThrow(/returned 1 embeddings for 2 inputs/);
+  });
+
+  it("throws on dim mismatch, naming the model", async () => {
+    mockFetch(() => ({ ok: true, json: { embeddings: [[1, 0, 0]] } }));
+    const e = new OllamaEmbedder({ model: "wrong-dim", dim: 4 });
+    await expect(e.embed([{ id: "a", text: "a" }])).rejects.toThrow(
+      /dim 3, expected 4 for model wrong-dim/,
+    );
+  });
+
+  it("throws on non-ok HTTP response", async () => {
+    mockFetch(() => ({ ok: false, status: 503, statusText: "down", json: {} }));
+    const e = new OllamaEmbedder({ dim: 4 });
+    await expect(e.embed([{ id: "a", text: "a" }])).rejects.toThrow(/503 down/);
+  });
+
+  it("exposes model and dim from constructor opts", () => {
+    const e = new OllamaEmbedder({ model: "custom", dim: 7 });
+    expect(e.model).toBe("custom");
+    expect(e.dim).toBe(7);
+  });
+});

--- a/src/services/rag-pipeline.integration.test.ts
+++ b/src/services/rag-pipeline.integration.test.ts
@@ -1,0 +1,233 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
+import { MockEmbedder } from "../contracts/mocks/mock-embedder";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { BinaryVectorStore } from "./binary-vector-store";
+import { EmbeddingService, type EmbeddingEvent } from "./embedding-service";
+import { HashGatedIngestionPipeline } from "./ingestion-pipeline";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { IngestionRunner } from "./ingestion-runner";
+import { MarkdownChunker } from "./markdown-chunker";
+
+/**
+ * End-to-end RAG pipeline test (pre-chat scope).
+ *
+ * Wires the same components that `src/services/index.ts` builds at plugin
+ * load: vault → chunker → ingestion pipeline → runner → embedding service →
+ * BinaryVectorStore. Verifies the chain processes vault events into
+ * persisted vectors, skips unchanged content on warm reload, evicts orphans
+ * on edit, and resets cleanly on model swap.
+ */
+
+const DIM = 16;
+const MODEL = "mock-embedder";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "gemmera-rag-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+interface Harness {
+  vault: MockVaultService;
+  ingestionStore: InMemoryIngestionStore;
+  queue: InMemoryJobQueue;
+  runner: IngestionRunner;
+  embedder: MockEmbedder;
+  vectorStore: BinaryVectorStore;
+  service: EmbeddingService;
+  events: EmbeddingEvent[];
+  drain: () => Promise<void>;
+}
+
+function harness(model = MODEL, files: Record<string, string> = {}): Harness {
+  const vault = new MockVaultService(files);
+  const ingestionStore = new InMemoryIngestionStore();
+  const pipeline = new HashGatedIngestionPipeline(vault, new MarkdownChunker(), ingestionStore);
+  const queue = new InMemoryJobQueue();
+  const runner = new IngestionRunner(queue, pipeline, ingestionStore);
+  const embedder = new MockEmbedder({ model, dim: DIM });
+  const vectorStore = new BinaryVectorStore(
+    join(dir, "vectors.bin"),
+    join(dir, "vectors.json"),
+    model,
+    DIM,
+  );
+  const service = new EmbeddingService(runner, embedder, vectorStore, ingestionStore);
+  runner.start();
+  service.start();
+
+  const events: EmbeddingEvent[] = [];
+  service.onEvent((e) => events.push(e));
+
+  const drain = async () => {
+    await runner.drainNow();
+    await service.flush();
+  };
+
+  return { vault, ingestionStore, queue, runner, embedder, vectorStore, service, events, drain };
+}
+
+const NOTE_A = `# Trip notes\n\nWent hiking near Sundsvall in late autumn.\n\n## Day one\n\nLong walk along the coast. The wind was sharp.\n`;
+const NOTE_B = `# Project log\n\n## Week 3\n\nWired the embedder service into the plugin lifecycle.\n`;
+
+describe("RAG pipeline integration (pre-chat)", () => {
+  it("cold start: indexes every markdown file and persists vectors", async () => {
+    const h = harness(MODEL, { "a.md": NOTE_A, "b.md": NOTE_B });
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    h.queue.enqueue({ kind: "index", path: "b.md" });
+    await h.drain();
+
+    expect(await h.vectorStore.count()).toBeGreaterThan(0);
+    expect(await h.ingestionStore.list()).toEqual(["a.md", "b.md"]);
+
+    // Every embedded chunk's hash is present in the vector store.
+    const chunksA = await h.ingestionStore.getChunks("a.md");
+    const chunksB = await h.ingestionStore.getChunks("b.md");
+    for (const c of [...chunksA, ...chunksB]) {
+      expect(await h.vectorStore.has(c.contentHash)).toBe(true);
+    }
+
+    expect(h.events.some((e) => e.kind === "embedded")).toBe(true);
+    expect(h.events.some((e) => e.kind === "error")).toBe(false);
+  });
+
+  it("warm reload: re-enqueueing the same content does not re-embed", async () => {
+    const h = harness(MODEL, { "a.md": NOTE_A });
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+    const baselineCalls = h.embedder.calls;
+    const baselineCount = await h.vectorStore.count();
+
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+
+    expect(h.embedder.calls).toBe(baselineCalls); // pipeline returned `skip`
+    expect(await h.vectorStore.count()).toBe(baselineCount);
+  });
+
+  it("edit: only the changed chunks are re-embedded; orphan chunks are evicted", async () => {
+    const h = harness(MODEL, { "a.md": NOTE_A });
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+    const beforeChunks = await h.ingestionStore.getChunks("a.md");
+    const beforeCount = await h.vectorStore.count();
+    expect(beforeChunks.length).toBeGreaterThan(0);
+
+    // Replace the body entirely so all old chunk hashes are stale.
+    h.vault.setFile("a.md", `# Trip notes\n\nCompletely rewritten body.\n`);
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+
+    for (const c of beforeChunks) {
+      expect(await h.vectorStore.has(c.contentHash)).toBe(false);
+    }
+    const afterChunks = await h.ingestionStore.getChunks("a.md");
+    for (const c of afterChunks) {
+      expect(await h.vectorStore.has(c.contentHash)).toBe(true);
+    }
+    expect(await h.vectorStore.count()).toBe(afterChunks.length);
+    expect(h.events.some((e) => e.kind === "evicted")).toBe(true);
+    void beforeCount;
+  });
+
+  it("delete job: ingestion entry is removed; vectors persist as content-addressed cache", async () => {
+    const h = harness(MODEL, { "a.md": NOTE_A });
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+    const chunks = await h.ingestionStore.getChunks("a.md");
+    const countBefore = await h.vectorStore.count();
+    expect(chunks.length).toBeGreaterThan(0);
+
+    h.queue.enqueue({ kind: "delete", path: "a.md" });
+    await h.drain();
+
+    expect(await h.ingestionStore.get("a.md")).toBeNull();
+    // Embedding service intentionally treats `deleted` as a no-op — vectors
+    // are content-addressed and may be referenced again. Verify that contract.
+    expect(await h.vectorStore.count()).toBe(countBefore);
+  });
+
+  it("rename job: ingestion entry moves to new path; content-addressed vectors stay live", async () => {
+    const h = harness(MODEL, { "a.md": NOTE_A });
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+    const chunks = await h.ingestionStore.getChunks("a.md");
+
+    h.queue.enqueue({ kind: "rename", from: "a.md", to: "renamed.md" });
+    await h.drain();
+
+    expect(await h.ingestionStore.get("a.md")).toBeNull();
+    expect(await h.ingestionStore.get("renamed.md")).not.toBeNull();
+    for (const c of chunks) {
+      expect(await h.vectorStore.has(c.contentHash)).toBe(true);
+    }
+  });
+
+  it("metadata-only change: frontmatter edit preserves vectors and skips embedding", async () => {
+    const h = harness(MODEL, { "a.md": `---\ntitle: A\n---\n${NOTE_A}` });
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+    const callsAfterFirst = h.embedder.calls;
+    const countAfterFirst = await h.vectorStore.count();
+
+    // Same body, different frontmatter → bodyHash unchanged, contentHash changes.
+    h.vault.setFile("a.md", `---\ntitle: A (edited)\n---\n${NOTE_A}`);
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    await h.drain();
+
+    expect(h.embedder.calls).toBe(callsAfterFirst);
+    expect(await h.vectorStore.count()).toBe(countAfterFirst);
+  });
+
+  it("model swap: existing vectors are reset and the next ingest re-embeds everything", async () => {
+    // First indexing run under model A, against the same on-disk store paths.
+    const a = harness("model-a", { "a.md": NOTE_A });
+    a.queue.enqueue({ kind: "index", path: "a.md" });
+    await a.drain();
+    const chunks = await a.ingestionStore.getChunks("a.md");
+    expect(await a.vectorStore.count()).toBe(chunks.length);
+    await a.runner.stop();
+    await a.service.stop();
+
+    // Second run under model B reuses the same dir → BinaryVectorStore detects
+    // the model mismatch on load and resets. EmbeddingService must re-embed.
+    const b = harness("model-b", { "a.md": NOTE_A });
+    expect(await b.vectorStore.count()).toBe(0); // reset on construction-load
+    b.queue.enqueue({ kind: "index", path: "a.md" });
+    await b.drain();
+
+    expect(b.embedder.calls).toBeGreaterThan(0);
+    expect(await b.vectorStore.count()).toBe(chunks.length);
+    expect(b.vectorStore.metadata().model).toBe("model-b");
+  });
+
+  it("embedder error on one job does not poison the queue", async () => {
+    const h = harness(MODEL, { "a.md": NOTE_A, "b.md": NOTE_B });
+    let calls = 0;
+    vi.spyOn(h.embedder, "embed").mockImplementation(async (reqs) => {
+      calls++;
+      if (calls === 1) throw new Error("ollama down");
+      return reqs.map((r) => ({ id: r.id, vec: new Float32Array(DIM) }));
+    });
+
+    h.queue.enqueue({ kind: "index", path: "a.md" });
+    h.queue.enqueue({ kind: "index", path: "b.md" });
+    await h.drain();
+
+    expect(h.events.some((e) => e.kind === "error")).toBe(true);
+    expect(h.events.some((e) => e.kind === "embedded")).toBe(true);
+    // b.md's chunks survived the failure of a.md.
+    const chunksB = await h.ingestionStore.getChunks("b.md");
+    for (const c of chunksB) {
+      expect(await h.vectorStore.has(c.contentHash)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What
Adds two test files filling the most material gaps in the pre-chat RAG implementation:

- `src/services/ollama-embedder.test.ts` — 10 tests for the production `OllamaEmbedder` (previously untested): HTTP shape, batch splitting, id ordering, L2 normalization, zero-vector safety, dim/count mismatch errors, HTTP failures.
- `src/services/rag-pipeline.integration.test.ts` — 8 end-to-end tests that wire the same chain `src/services/index.ts` builds at plugin load (vault → chunker → ingestion pipeline → runner → embedding service → `BinaryVectorStore` on a temp dir): cold start, warm reload skip, edit with orphan eviction, delete/rename behavior, frontmatter-only edits, model swap full re-embed, and embedder-failure isolation across jobs.

No source changes — every new test passed on first run, so the pre-chat pipeline is behaving as designed.

## Why
- Closes the verification gap on the model-swap acceptance criterion in #11 (re-embed on model change). The integration test exercises the same path Obsidian would: same on-disk store, two consecutive runs with different model names, every chunk re-embedded under the new model.
- `OllamaEmbedder` was the only embedder shipping in production but had no test coverage.
- Component-level tests existed for every link in the chain, but no test exercised them wired together. The integration test catches wiring regressions that pass per-component but break the system.

Baseline before this PR: 112 tests / 15 files. After: 130 tests / 17 files. All green, typecheck clean.

## How to test
- `npm test` — full suite passes.
- `npx vitest run src/services/ollama-embedder.test.ts src/services/rag-pipeline.integration.test.ts` — runs just the new files.
- `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)