### PR TITLE
feat(classifier): contracts, prompt, and event-log schema (#17, #18, #19)

### DIFF
--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -1,0 +1,118 @@
+/**
+ * Classifier input/output contracts — single module consumed by both the
+ * classifier call site and the eval harness. Matches the contract in
+ * planning/classifier.md §"Input contract" and §"Output contract".
+ *
+ * LIFECYCLE: Every struct in this file is serialisable and must be safe
+ * to store in events.duckdb (see #19).
+ */
+
+// ─── Taxonomy ────────────────────────────────────────────────────────
+
+export type IntentLabel = "capture" | "ask" | "mixed" | "meta";
+
+// ─── Input ────────────────────────────────────────────────────────────
+
+export type AttachmentKind = "pdf" | "image" | "audio" | "text";
+
+export interface Attachment {
+  kind: AttachmentKind;
+  filename: string;
+}
+
+export interface ActiveFile {
+  filename: string;
+  title: string;
+}
+
+export interface RecentTurn {
+  text: string;
+  intent: IntentLabel;
+}
+
+export interface ClassifierInput {
+  /** Full message text, truncated to 8 KB with a visible marker. */
+  messageText: string;
+  /** True when the message was truncated by the pre-processor. */
+  truncated: boolean;
+  /** Attachments the user attached to the message (contents NOT included). */
+  attachments: Attachment[];
+  /** Currently open note, if any. */
+  activeFile: ActiveFile | null;
+  /** Last 3 chat turns (user text + final intent label). Always at most 3. */
+  recentTurns: RecentTurn[];
+}
+
+// ─── Output ───────────────────────────────────────────────────────────
+
+export interface ClassifierOutput {
+  label: IntentLabel;
+  /** Model-reported confidence in [0.0, 1.0]. */
+  confidence: number;
+  /** One-line human-readable rationale for the label. */
+  rationale: string;
+}
+
+// ─── Decision log entry (upstream of #19 event-log schema) ────────────
+
+/** Source of a classifier decision. "skip" means a hard signal pre-empted
+ *  the LLM call; "llm" means the model produced the output. */
+export type ClassifierSource = "skip" | "llm";
+
+export interface ClassifierDecision {
+  source: ClassifierSource;
+  input: ClassifierInput;
+  output: ClassifierOutput | null;
+  /** Wall-clock ms from input arrival to decision ready. */
+  latencyMs: number;
+  /** Prompt version ID from the intent-classifier prompt file. */
+  promptVersion: string;
+  /**
+   * Reason code when source === "skip". Null for LLM-sourced decisions.
+   * Examples: "empty-message", "attachment-only", "command-capture",
+   * "ctrl-enter", "leading-question-mark".
+   */
+  skipReason: string | null;
+}
+
+// ─── Event-log rows (#19) ─────────────────────────────────────────────
+
+/**
+ * Flattened row written to the `classifier_decision` DuckDB table.
+ * `input_json` and `output_json` are JSON-serialised `ClassifierInput`
+ * and `ClassifierOutput | null` respectively.
+ */
+export interface ClassifierDecisionRow {
+  turn_id: string;
+  ts: number;
+  source: ClassifierSource;
+  skip_reason: string | null;
+  prompt_version: string;
+  input_json: string;
+  output_json: string | null;
+  latency_ms: number;
+  confidence: number | null;
+  label: IntentLabel | null;
+}
+
+/**
+ * Row written to the `classifier_disambiguation` table when the user
+ * corrects a low-confidence classification via the disambiguation chip.
+ */
+export interface ClassifierDisambiguationRow {
+  turn_id: string;
+  ts: number;
+  original_label: IntentLabel;
+  original_confidence: number;
+  /** The label the user chose, or null when they cancelled. */
+  chosen_label: IntentLabel | null;
+  /** True when the user dismissed the chip without choosing a label. */
+  cancelled: boolean;
+}
+
+/** Writer contract for classifier event rows. Implementations write to
+ *  DuckDB (#35), an in-memory buffer for testing, or the turn inspector. */
+export interface ClassifierEventWriter {
+  writeDecision(row: ClassifierDecisionRow): Promise<void>;
+  writeDisambiguation(row: ClassifierDisambiguationRow): Promise<void>;
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -14,3 +14,4 @@ export * from "./state-machine";
 export * from "./prompts";
 export * from "./constrained-decoder";
 export * from "./hard-stops";
+export * from "./classifier";

--- a/src/services/__snapshots__/classifier-prompt.test.ts.snap
+++ b/src/services/__snapshots__/classifier-prompt.test.ts.snap
@@ -1,4 +1,7 @@
-version: 0.1.0
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`assembleClassifierPrompt > snapshot: full prompt rendered from the on-disk file against a fixed input 1`] = `
+"version: 0.1.0
 
 You are an intent classifier for a personal knowledge base plugin. Classify every user message into exactly one of four labels:
 
@@ -31,7 +34,14 @@ Classification: {"label": "ask", "confidence": 0.85, "rationale": "Follow-up ref
 
 ## Current input
 
-Message: {{messageText}}
-{{attachmentList}}
-{{activeFileLine}}
-{{recentTurnList}}
+Message: Save this as meeting notes and what did we discuss last week about API design?
+Attachments:
+- pdf: roadmap.pdf
+- image: whiteboard.jpg
+Active file: Gemmera (projects/gemmera.md)
+Recent conversation:
+- User: "start a new note about the API" → capture
+- User: "what endpoints do we have?" → ask
+- User: "save that" → capture
+"
+`;

--- a/src/services/__snapshots__/classifier-prompt.test.ts.snap
+++ b/src/services/__snapshots__/classifier-prompt.test.ts.snap
@@ -1,9 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`assembleClassifierPrompt > snapshot: full prompt rendered from the on-disk file against a fixed input 1`] = `
-"version: 0.1.0
-
-You are an intent classifier for a personal knowledge base plugin. Classify every user message into exactly one of four labels:
+exports[`assembleClassifierPrompt > snapshot: full prompt rendered from FilePromptLoader against a fixed input 1`] = `
+"You are an intent classifier for a personal knowledge base plugin. Classify every user message into exactly one of four labels:
 
 - **capture** — the user wants to save, store, or preserve content in their vault (notes, ideas, links, files, meeting minutes, summaries).
 - **ask** — the user wants to retrieve, search, or ask about content already in their vault.
@@ -42,6 +40,5 @@ Active file: Gemmera (projects/gemmera.md)
 Recent conversation:
 - User: "start a new note about the API" → capture
 - User: "what endpoints do we have?" → ask
-- User: "save that" → capture
-"
+- User: "save that" → capture"
 `;

--- a/src/services/classifier-events.test.ts
+++ b/src/services/classifier-events.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLASSIFIER_DECISION_DDL,
+  CLASSIFIER_DISAMBIGUATION_DDL,
+  CLASSIFIER_DDL,
+  InMemoryClassifierEventWriter,
+  toDecisionRow,
+  toDisambiguationRow,
+} from "./classifier-events";
+
+// ─── DDL validation ────────────────────────────────────────────────────
+
+describe("classifier DDL", () => {
+  it("classifier_decision DDL references the expected columns", () => {
+    expect(CLASSIFIER_DECISION_DDL).toContain("CREATE TABLE IF NOT EXISTS classifier_decision");
+    for (const col of [
+      "turn_id",
+      "ts",
+      "source",
+      "skip_reason",
+      "prompt_version",
+      "input_json",
+      "output_json",
+      "latency_ms",
+      "confidence",
+      "label",
+    ]) {
+      expect(CLASSIFIER_DECISION_DDL).toContain(col);
+    }
+  });
+
+  it("classifier_disambiguation DDL references the expected columns", () => {
+    expect(CLASSIFIER_DISAMBIGUATION_DDL).toContain(
+      "CREATE TABLE IF NOT EXISTS classifier_disambiguation",
+    );
+    for (const col of [
+      "turn_id",
+      "ts",
+      "original_label",
+      "original_confidence",
+      "chosen_label",
+      "cancelled",
+    ]) {
+      expect(CLASSIFIER_DISAMBIGUATION_DDL).toContain(col);
+    }
+  });
+
+  it("CLASSIFIER_DDL is ordered (decision before disambiguation)", () => {
+    expect(CLASSIFIER_DDL).toHaveLength(2);
+    expect(CLASSIFIER_DDL[0]).toContain("classifier_decision");
+    expect(CLASSIFIER_DDL[1]).toContain("classifier_disambiguation");
+  });
+});
+
+// ─── InMemoryClassifierEventWriter ─────────────────────────────────────
+
+describe("InMemoryClassifierEventWriter", () => {
+  it("stores a decision row and retrieves it in insertion order", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    await writer.writeDecision({
+      turn_id: "t1",
+      ts: 1000,
+      source: "llm",
+      skip_reason: null,
+      prompt_version: "0.1.0",
+      input_json: '{"messageText":"hello"}',
+      output_json: '{"label":"ask","confidence":0.9,"rationale":"..."}',
+      latency_ms: 42,
+      confidence: 0.9,
+      label: "ask",
+    });
+
+    expect(writer.decisions).toHaveLength(1);
+    expect(writer.decisions[0].turn_id).toBe("t1");
+    expect(writer.decisions[0].source).toBe("llm");
+    expect(writer.decisions[0].label).toBe("ask");
+  });
+
+  it("preserves insertion order for multiple decisions", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    await writer.writeDecision(makeDecision("t1"));
+    await writer.writeDecision(makeDecision("t2"));
+    await writer.writeDecision(makeDecision("t3"));
+
+    expect(writer.decisions.map((d) => d.turn_id)).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("stores disambiguation rows with chosen_label", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    await writer.writeDisambiguation({
+      turn_id: "t1",
+      ts: 2000,
+      original_label: "ask",
+      original_confidence: 0.55,
+      chosen_label: "capture",
+      cancelled: false,
+    });
+
+    expect(writer.disambiguations).toHaveLength(1);
+    expect(writer.disambiguations[0].original_label).toBe("ask");
+    expect(writer.disambiguations[0].chosen_label).toBe("capture");
+    expect(writer.disambiguations[0].cancelled).toBe(false);
+  });
+
+  it("stores a cancelled disambiguation", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    await writer.writeDisambiguation({
+      turn_id: "t1",
+      ts: 2000,
+      original_label: "mixed",
+      original_confidence: 0.45,
+      chosen_label: null,
+      cancelled: true,
+    });
+
+    expect(writer.disambiguations[0].chosen_label).toBeNull();
+    expect(writer.disambiguations[0].cancelled).toBe(true);
+  });
+
+  it("clear() empties both arrays", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    await writer.writeDecision(makeDecision("t1"));
+    await writer.writeDisambiguation({
+      turn_id: "t1",
+      ts: 2000,
+      original_label: "ask",
+      original_confidence: 0.5,
+      chosen_label: "capture",
+      cancelled: false,
+    });
+
+    writer.clear();
+    expect(writer.decisions).toHaveLength(0);
+    expect(writer.disambiguations).toHaveLength(0);
+  });
+});
+
+// ─── Row helpers ───────────────────────────────────────────────────────
+
+describe("toDecisionRow", () => {
+  it("flattens a ClassifierDecision into a row with JSON-serialised fields", () => {
+    const row = toDecisionRow("turn-1", {
+      source: "llm",
+      skipReason: null,
+      promptVersion: "0.1.0",
+      latencyMs: 55,
+      input: { messageText: "hello", truncated: false, attachments: [], activeFile: null, recentTurns: [] },
+      output: { label: "ask", confidence: 0.92, rationale: "question" },
+      confidence: 0.92,
+      label: "ask",
+    });
+
+    expect(row.turn_id).toBe("turn-1");
+    expect(typeof row.ts).toBe("number");
+    expect(row.source).toBe("llm");
+    expect(row.skip_reason).toBeNull();
+    expect(row.prompt_version).toBe("0.1.0");
+    expect(row.latency_ms).toBe(55);
+    expect(row.confidence).toBe(0.92);
+    expect(row.label).toBe("ask");
+
+    const parsedInput = JSON.parse(row.input_json);
+    expect(parsedInput.messageText).toBe("hello");
+
+    const parsedOutput = JSON.parse(row.output_json!);
+    expect(parsedOutput.label).toBe("ask");
+  });
+
+  it("handles skip-path decisions with null output", () => {
+    const row = toDecisionRow("turn-2", {
+      source: "skip",
+      skipReason: "command-capture",
+      promptVersion: "0.1.0",
+      latencyMs: 0,
+      input: { messageText: "", truncated: false, attachments: [], activeFile: null, recentTurns: [] },
+      output: null,
+      confidence: null,
+      label: "capture",
+    });
+
+    expect(row.source).toBe("skip");
+    expect(row.skip_reason).toBe("command-capture");
+    expect(row.output_json).toBeNull();
+    expect(row.confidence).toBeNull();
+    expect(row.label).toBe("capture");
+  });
+});
+
+describe("toDisambiguationRow", () => {
+  it("builds a row from a disambiguation event", () => {
+    const row = toDisambiguationRow("turn-1", {
+      originalLabel: "ask",
+      originalConfidence: 0.52,
+      chosenLabel: "capture",
+      cancelled: false,
+    });
+
+    expect(row.turn_id).toBe("turn-1");
+    expect(typeof row.ts).toBe("number");
+    expect(row.original_label).toBe("ask");
+    expect(row.original_confidence).toBe(0.52);
+    expect(row.chosen_label).toBe("capture");
+    expect(row.cancelled).toBe(false);
+  });
+});
+
+// ─── helpers ───────────────────────────────────────────────────────────
+
+function makeDecision(turnId: string) {
+  return {
+    turn_id: turnId,
+    ts: Date.now(),
+    source: "llm" as const,
+    skip_reason: null,
+    prompt_version: "0.1.0",
+    input_json: "{}",
+    output_json: null,
+    latency_ms: 10,
+    confidence: null,
+    label: null,
+  };
+}

--- a/src/services/classifier-events.ts
+++ b/src/services/classifier-events.ts
@@ -2,6 +2,10 @@ import {
   ClassifierDecisionRow,
   ClassifierDisambiguationRow,
   ClassifierEventWriter,
+  ClassifierInput,
+  ClassifierOutput,
+  ClassifierSource,
+  IntentLabel,
 } from "../contracts/classifier";
 
 // ─── DuckDB DDL ───────────────────────────────────────────────────────
@@ -11,7 +15,7 @@ import {
 export const CLASSIFIER_DECISION_DDL = [
   "CREATE TABLE IF NOT EXISTS classifier_decision (",
   "  turn_id      TEXT NOT NULL,",
-  "  ts           INTEGER NOT NULL,",
+  "  ts           BIGINT NOT NULL,",
   "  source       TEXT NOT NULL,",
   "  skip_reason  TEXT,",
   "  prompt_version TEXT NOT NULL,",
@@ -27,11 +31,11 @@ export const CLASSIFIER_DECISION_DDL = [
 export const CLASSIFIER_DISAMBIGUATION_DDL = [
   "CREATE TABLE IF NOT EXISTS classifier_disambiguation (",
   "  turn_id            TEXT NOT NULL,",
-  "  ts                 INTEGER NOT NULL,",
+  "  ts                 BIGINT NOT NULL,",
   "  original_label     TEXT NOT NULL,",
   "  original_confidence REAL NOT NULL,",
   "  chosen_label       TEXT,",
-  "  cancelled          INTEGER NOT NULL DEFAULT 0",
+  "  cancelled          BOOLEAN NOT NULL DEFAULT FALSE",
   ");",
 ].join("\n");
 
@@ -77,27 +81,27 @@ export class InMemoryClassifierEventWriter implements ClassifierEventWriter {
 export function toDecisionRow(
   turnId: string,
   decision: {
-    source: string;
+    source: ClassifierSource;
     skipReason: string | null;
     promptVersion: string;
     latencyMs: number;
-    input: object;
-    output: object | null;
+    input: ClassifierInput;
+    output: ClassifierOutput | null;
     confidence: number | null;
-    label: string | null;
+    label: IntentLabel | null;
   },
 ): ClassifierDecisionRow {
   return {
     turn_id: turnId,
     ts: Date.now(),
-    source: decision.source as ClassifierDecisionRow["source"],
+    source: decision.source,
     skip_reason: decision.skipReason,
     prompt_version: decision.promptVersion,
     input_json: JSON.stringify(decision.input),
     output_json: decision.output ? JSON.stringify(decision.output) : null,
     latency_ms: decision.latencyMs,
     confidence: decision.confidence,
-    label: decision.label as ClassifierDecisionRow["label"],
+    label: decision.label,
   };
 }
 
@@ -107,18 +111,18 @@ export function toDecisionRow(
 export function toDisambiguationRow(
   turnId: string,
   event: {
-    originalLabel: string;
+    originalLabel: IntentLabel;
     originalConfidence: number;
-    chosenLabel: string | null;
+    chosenLabel: IntentLabel | null;
     cancelled: boolean;
   },
 ): ClassifierDisambiguationRow {
   return {
     turn_id: turnId,
     ts: Date.now(),
-    original_label: event.originalLabel as ClassifierDisambiguationRow["original_label"],
+    original_label: event.originalLabel,
     original_confidence: event.originalConfidence,
-    chosen_label: event.chosenLabel as ClassifierDisambiguationRow["chosen_label"],
+    chosen_label: event.chosenLabel,
     cancelled: event.cancelled,
   };
 }

--- a/src/services/classifier-events.ts
+++ b/src/services/classifier-events.ts
@@ -1,0 +1,124 @@
+import {
+  ClassifierDecisionRow,
+  ClassifierDisambiguationRow,
+  ClassifierEventWriter,
+} from "../contracts/classifier";
+
+// ─── DuckDB DDL ───────────────────────────────────────────────────────
+
+/** SQL to create the `classifier_decision` table. Idempotent via
+ *  `CREATE TABLE IF NOT EXISTS`. Columns match `ClassifierDecisionRow`. */
+export const CLASSIFIER_DECISION_DDL = [
+  "CREATE TABLE IF NOT EXISTS classifier_decision (",
+  "  turn_id      TEXT NOT NULL,",
+  "  ts           INTEGER NOT NULL,",
+  "  source       TEXT NOT NULL,",
+  "  skip_reason  TEXT,",
+  "  prompt_version TEXT NOT NULL,",
+  "  input_json   TEXT NOT NULL,",
+  "  output_json  TEXT,",
+  "  latency_ms   INTEGER NOT NULL,",
+  "  confidence   REAL,",
+  "  label        TEXT",
+  ");",
+].join("\n");
+
+/** SQL to create the `classifier_disambiguation` table. Idempotent. */
+export const CLASSIFIER_DISAMBIGUATION_DDL = [
+  "CREATE TABLE IF NOT EXISTS classifier_disambiguation (",
+  "  turn_id            TEXT NOT NULL,",
+  "  ts                 INTEGER NOT NULL,",
+  "  original_label     TEXT NOT NULL,",
+  "  original_confidence REAL NOT NULL,",
+  "  chosen_label       TEXT,",
+  "  cancelled          INTEGER NOT NULL DEFAULT 0",
+  ");",
+].join("\n");
+
+/** Ordered set of classifier-related DDL statements for migration runs. */
+export const CLASSIFIER_DDL = [
+  CLASSIFIER_DECISION_DDL,
+  CLASSIFIER_DISAMBIGUATION_DDL,
+];
+
+// ─── In-memory writer ──────────────────────────────────────────────────
+
+/**
+ * In-memory implementation of `ClassifierEventWriter`. Stores rows in
+ * insertion order for testing and replay. Not for production — rows are
+ * lost on process exit.
+ */
+export class InMemoryClassifierEventWriter implements ClassifierEventWriter {
+  decisions: ClassifierDecisionRow[] = [];
+  disambiguations: ClassifierDisambiguationRow[] = [];
+
+  async writeDecision(row: ClassifierDecisionRow): Promise<void> {
+    this.decisions.push({ ...row });
+  }
+
+  async writeDisambiguation(row: ClassifierDisambiguationRow): Promise<void> {
+    this.disambiguations.push({ ...row });
+  }
+
+  /** Drop all stored rows. */
+  clear(): void {
+    this.decisions = [];
+    this.disambiguations = [];
+  }
+}
+
+// ─── Row helpers ───────────────────────────────────────────────────────
+
+/**
+ * Build a `ClassifierDecisionRow` from an in-memory `ClassifierDecision`
+ * plus the owning `turnId`. Serialises `input` and `output` to JSON so
+ * the row is ready to write.
+ */
+export function toDecisionRow(
+  turnId: string,
+  decision: {
+    source: string;
+    skipReason: string | null;
+    promptVersion: string;
+    latencyMs: number;
+    input: object;
+    output: object | null;
+    confidence: number | null;
+    label: string | null;
+  },
+): ClassifierDecisionRow {
+  return {
+    turn_id: turnId,
+    ts: Date.now(),
+    source: decision.source as ClassifierDecisionRow["source"],
+    skip_reason: decision.skipReason,
+    prompt_version: decision.promptVersion,
+    input_json: JSON.stringify(decision.input),
+    output_json: decision.output ? JSON.stringify(decision.output) : null,
+    latency_ms: decision.latencyMs,
+    confidence: decision.confidence,
+    label: decision.label as ClassifierDecisionRow["label"],
+  };
+}
+
+/**
+ * Build a `ClassifierDisambiguationRow`.
+ */
+export function toDisambiguationRow(
+  turnId: string,
+  event: {
+    originalLabel: string;
+    originalConfidence: number;
+    chosenLabel: string | null;
+    cancelled: boolean;
+  },
+): ClassifierDisambiguationRow {
+  return {
+    turn_id: turnId,
+    ts: Date.now(),
+    original_label: event.originalLabel as ClassifierDisambiguationRow["original_label"],
+    original_confidence: event.originalConfidence,
+    chosen_label: event.chosenLabel as ClassifierDisambiguationRow["chosen_label"],
+    cancelled: event.cancelled,
+  };
+}

--- a/src/services/classifier-prompt.test.ts
+++ b/src/services/classifier-prompt.test.ts
@@ -1,10 +1,10 @@
+import { join } from "path";
 import { describe, expect, it } from "vitest";
 import { ClassifierInput } from "../contracts/classifier";
-import {
-  assembleClassifierPrompt,
-  INTENT_CLASSIFIER_PROMPT_VERSION,
-  loadClassifierPromptBody,
-} from "./classifier-prompt";
+import { FilePromptLoader } from "./file-prompt-loader";
+import { assembleClassifierPrompt } from "./classifier-prompt";
+
+const promptsDir = join(process.cwd(), "prompts");
 
 const fixedInput: ClassifierInput = {
   messageText: "Save this as meeting notes and what did we discuss last week about API design?",
@@ -21,18 +21,9 @@ const fixedInput: ClassifierInput = {
   ],
 };
 
-describe("INTENT_CLASSIFIER_PROMPT_VERSION", () => {
-  it("matches the version header in the prompt file", async () => {
-    const body = await loadClassifierPromptBody();
-    expect(body).toContain(`version: ${INTENT_CLASSIFIER_PROMPT_VERSION}`);
-  });
-});
-
 describe("assembleClassifierPrompt", () => {
   it("renders all sections when the input is fully populated", () => {
     const body = [
-      "version: 0.1.0",
-      "",
       "System preamble",
       "",
       "## Current input",
@@ -100,9 +91,28 @@ describe("assembleClassifierPrompt", () => {
     expect(result.match(/→/g)).toHaveLength(4);
   });
 
-  it("snapshot: full prompt rendered from the on-disk file against a fixed input", async () => {
-    const body = await loadClassifierPromptBody();
-    const result = assembleClassifierPrompt(fixedInput, body);
+  it("does not interpret regex replacement patterns in user input", () => {
+    // String.prototype.replace with a string second argument expands $&, $1
+    // etc. into match references. The function-form replace must guard
+    // against this so user input is rendered verbatim.
+    const adversarial = '$& and $1 and $`';
+    const result = assembleClassifierPrompt(
+      { ...fixedInput, messageText: adversarial },
+      "Message: {{messageText}}",
+    );
+    expect(result).toBe(`Message: ${adversarial}`);
+  });
+
+  it("snapshot: full prompt rendered from FilePromptLoader against a fixed input", async () => {
+    const loader = new FilePromptLoader(promptsDir);
+    const loaded = await loader.load("intent-classifier");
+    const result = assembleClassifierPrompt(fixedInput, loaded.body);
     expect(result).toMatchSnapshot();
+  });
+
+  it("the loaded prompt's version is the source of truth for stamping", async () => {
+    const loader = new FilePromptLoader(promptsDir);
+    const loaded = await loader.load("intent-classifier");
+    expect(loaded.version).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });

--- a/src/services/classifier-prompt.test.ts
+++ b/src/services/classifier-prompt.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { ClassifierInput } from "../contracts/classifier";
+import {
+  assembleClassifierPrompt,
+  INTENT_CLASSIFIER_PROMPT_VERSION,
+  loadClassifierPromptBody,
+} from "./classifier-prompt";
+
+const fixedInput: ClassifierInput = {
+  messageText: "Save this as meeting notes and what did we discuss last week about API design?",
+  truncated: false,
+  attachments: [
+    { kind: "pdf", filename: "roadmap.pdf" },
+    { kind: "image", filename: "whiteboard.jpg" },
+  ],
+  activeFile: { filename: "projects/gemmera.md", title: "Gemmera" },
+  recentTurns: [
+    { text: "start a new note about the API", intent: "capture" },
+    { text: "what endpoints do we have?", intent: "ask" },
+    { text: "save that", intent: "capture" },
+  ],
+};
+
+describe("INTENT_CLASSIFIER_PROMPT_VERSION", () => {
+  it("matches the version header in the prompt file", async () => {
+    const body = await loadClassifierPromptBody();
+    expect(body).toContain(`version: ${INTENT_CLASSIFIER_PROMPT_VERSION}`);
+  });
+});
+
+describe("assembleClassifierPrompt", () => {
+  it("renders all sections when the input is fully populated", () => {
+    const body = [
+      "version: 0.1.0",
+      "",
+      "System preamble",
+      "",
+      "## Current input",
+      "",
+      "Message: {{messageText}}",
+      "{{attachmentList}}",
+      "{{activeFileLine}}",
+      "{{recentTurnList}}",
+    ].join("\n");
+
+    const result = assembleClassifierPrompt(fixedInput, body);
+
+    expect(result).toContain("Message: Save this as meeting notes");
+    expect(result).toContain("- pdf: roadmap.pdf");
+    expect(result).toContain("- image: whiteboard.jpg");
+    expect(result).toContain("Active file: Gemmera (projects/gemmera.md)");
+    expect(result).toContain('User: "start a new note about the API" → capture');
+    expect(result).toContain('User: "what endpoints do we have?" → ask');
+    expect(result).toContain('User: "save that" → capture');
+    expect(result).not.toContain("{{messageText}}");
+    expect(result).not.toContain("{{attachmentList}}");
+    expect(result).not.toContain("{{activeFileLine}}");
+    expect(result).not.toContain("{{recentTurnList}}");
+  });
+
+  it("omits attachment section when there are no attachments", () => {
+    const result = assembleClassifierPrompt(
+      { ...fixedInput, attachments: [] },
+      "{{attachmentList}}",
+    );
+    expect(result).toBe("");
+  });
+
+  it("omits active-file line when there is no active file", () => {
+    const result = assembleClassifierPrompt(
+      { ...fixedInput, activeFile: null },
+      "{{activeFileLine}}",
+    );
+    expect(result).toBe("");
+  });
+
+  it("omits recent-turns section when there are no recent turns", () => {
+    const result = assembleClassifierPrompt(
+      { ...fixedInput, recentTurns: [] },
+      "{{recentTurnList}}",
+    );
+    expect(result).toBe("");
+  });
+
+  it("renders exactly 3 recent turns even when more are provided", () => {
+    // prepareClassifierInput already slices to 3; this test verifies the
+    // assembler renders whatever is given (caller owns the slice).
+    const many = [
+      { text: "t1", intent: "ask" as const },
+      { text: "t2", intent: "capture" as const },
+      { text: "t3", intent: "meta" as const },
+      { text: "t4", intent: "ask" as const },
+    ];
+    const result = assembleClassifierPrompt(
+      { ...fixedInput, recentTurns: many },
+      "{{recentTurnList}}",
+    );
+    expect(result).toContain("t1");
+    expect(result).toContain("t4");
+    expect(result.match(/→/g)).toHaveLength(4);
+  });
+
+  it("snapshot: full prompt rendered from the on-disk file against a fixed input", async () => {
+    const body = await loadClassifierPromptBody();
+    const result = assembleClassifierPrompt(fixedInput, body);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/services/classifier-prompt.ts
+++ b/src/services/classifier-prompt.ts
@@ -1,43 +1,35 @@
-import { promises as fs } from "fs";
-import { join } from "path";
 import { ClassifierInput } from "../contracts/classifier";
-
-/** Canonical version ID for intent-classifier prompt. Stamped into every
- *  `classifier_decision` event row so eval regressions trace to the
- *  exact prompt revision. Must match the `version:` header in
- *  `prompts/intent-classifier.md`. */
-export const INTENT_CLASSIFIER_PROMPT_VERSION = "0.1.0";
 
 /**
  * Assemble the full classifier prompt by rendering a template body with
- * values from `input`. The `body` parameter is the raw prompt file
- * content (system instructions + few-shot examples + placeholders) as
- * loaded by the FilePromptLoader or from disk.
+ * values from `input`. The `body` parameter is the prompt body returned
+ * by `FilePromptLoader.load("intent-classifier")` (header stripped, body
+ * trimmed). The resolved `version` from the same `LoadedPrompt` is what
+ * gets stamped into `classifier_decision` rows.
  *
  * Placeholders:
  *   {{messageText}}     — the (possibly truncated) user message
  *   {{attachmentList}}  — bullet list of attachments, or empty line
  *   {{activeFileLine}}  — "Active file: title (filename)", or empty line
  *   {{recentTurnList}}  — numbered recent turns, or empty line
+ *
+ * Substitution uses a function-form replace so user input containing
+ * `$&`, `$1`, etc. is not interpreted as a regex backreference.
  */
 export function assembleClassifierPrompt(
   input: ClassifierInput,
   body: string,
 ): string {
-  return body
-    .replace("{{messageText}}", input.messageText)
-    .replace("{{attachmentList}}", renderAttachmentList(input))
-    .replace("{{activeFileLine}}", renderActiveFile(input))
-    .replace("{{recentTurnList}}", renderRecentTurns(input));
-}
-
-/** Load the prompt file from the `prompts/` directory next to the
- *  project root. Returns the raw file content including the version
- *  header line. */
-export async function loadClassifierPromptBody(): Promise<string> {
-  return fs.readFile(
-    join(process.cwd(), "prompts", "intent-classifier.md"),
-    "utf-8",
+  const substitutions: Record<string, string> = {
+    messageText: input.messageText,
+    attachmentList: renderAttachmentList(input),
+    activeFileLine: renderActiveFile(input),
+    recentTurnList: renderRecentTurns(input),
+  };
+  return body.replace(/\{\{(\w+)\}\}/g, (match, key: string) =>
+    Object.prototype.hasOwnProperty.call(substitutions, key)
+      ? substitutions[key]
+      : match,
   );
 }
 

--- a/src/services/classifier-prompt.ts
+++ b/src/services/classifier-prompt.ts
@@ -1,0 +1,67 @@
+import { promises as fs } from "fs";
+import { join } from "path";
+import { ClassifierInput } from "../contracts/classifier";
+
+/** Canonical version ID for intent-classifier prompt. Stamped into every
+ *  `classifier_decision` event row so eval regressions trace to the
+ *  exact prompt revision. Must match the `version:` header in
+ *  `prompts/intent-classifier.md`. */
+export const INTENT_CLASSIFIER_PROMPT_VERSION = "0.1.0";
+
+/**
+ * Assemble the full classifier prompt by rendering a template body with
+ * values from `input`. The `body` parameter is the raw prompt file
+ * content (system instructions + few-shot examples + placeholders) as
+ * loaded by the FilePromptLoader or from disk.
+ *
+ * Placeholders:
+ *   {{messageText}}     — the (possibly truncated) user message
+ *   {{attachmentList}}  — bullet list of attachments, or empty line
+ *   {{activeFileLine}}  — "Active file: title (filename)", or empty line
+ *   {{recentTurnList}}  — numbered recent turns, or empty line
+ */
+export function assembleClassifierPrompt(
+  input: ClassifierInput,
+  body: string,
+): string {
+  return body
+    .replace("{{messageText}}", input.messageText)
+    .replace("{{attachmentList}}", renderAttachmentList(input))
+    .replace("{{activeFileLine}}", renderActiveFile(input))
+    .replace("{{recentTurnList}}", renderRecentTurns(input));
+}
+
+/** Load the prompt file from the `prompts/` directory next to the
+ *  project root. Returns the raw file content including the version
+ *  header line. */
+export async function loadClassifierPromptBody(): Promise<string> {
+  return fs.readFile(
+    join(process.cwd(), "prompts", "intent-classifier.md"),
+    "utf-8",
+  );
+}
+
+// ─── section renderers ────────────────────────────────────────────────
+
+function renderAttachmentList(input: ClassifierInput): string {
+  if (input.attachments.length === 0) return "";
+  return (
+    "Attachments:\n" +
+    input.attachments.map((a) => `- ${a.kind}: ${a.filename}`).join("\n")
+  );
+}
+
+function renderActiveFile(input: ClassifierInput): string {
+  if (!input.activeFile) return "";
+  return `Active file: ${input.activeFile.title} (${input.activeFile.filename})`;
+}
+
+function renderRecentTurns(input: ClassifierInput): string {
+  if (input.recentTurns.length === 0) return "";
+  return (
+    "Recent conversation:\n" +
+    input.recentTurns
+      .map((t) => `- User: "${t.text}" → ${t.intent}`)
+      .join("\n")
+  );
+}

--- a/src/services/classifier-utils.test.ts
+++ b/src/services/classifier-utils.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  lastRecentTurns,
+  prepareClassifierInput,
+  truncateMessage,
+} from "./classifier-utils";
+
+// ─── truncateMessage ──────────────────────────────────────────────────
+
+describe("truncateMessage", () => {
+  it("returns the original text and truncated=false when under the limit", () => {
+    const result = truncateMessage("hello", 8192);
+    expect(result.text).toBe("hello");
+    expect(result.truncated).toBe(false);
+  });
+
+  it("truncates at the exact byte limit and appends the marker", () => {
+    const text = "a".repeat(9000);
+    const result = truncateMessage(text, 8192);
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBeLessThan(text.length);
+    expect(result.text).toContain("[message truncated]");
+  });
+
+  it("respects UTF-8 multibyte character boundaries", () => {
+    // "é" is 2 bytes in UTF-8. Place one right at the boundary.
+    const prefix = "a".repeat(8190); // 8190 bytes
+    const text = prefix + "é" + "bbbb"; // 8190 + 2 + 4 = 8196 bytes
+    const result = truncateMessage(text, 8192);
+
+    expect(result.truncated).toBe(true);
+    const encoded = new TextEncoder().encode(result.text);
+    // The "é" at position 8190-8191 would push 8193, so it should be cut
+    // and the truncation marker should fit within 8192.
+    expect(encoded.byteLength).toBeLessThanOrEqual(8192);
+  });
+
+  it("delivers only the marker when the limit is smaller than the marker itself", () => {
+    // Text (30 chars) exceeds limit (10 bytes), and the marker (~23 bytes)
+    // leaves no room for content — contentLimit becomes negative.
+    const result = truncateMessage("this text is way too long for 10 bytes", 10);
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.text).toContain("message truncated");
+  });
+
+  it("handles exactly-at-limit text as no-op", () => {
+    const text = "a".repeat(8192);
+    const result = truncateMessage(text, 8192);
+    expect(result.truncated).toBe(false);
+    expect(result.text).toBe(text);
+  });
+
+  it("handles one byte over the limit", () => {
+    const text = "a".repeat(8193);
+    const result = truncateMessage(text, 8192);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("truncates empty string correctly", () => {
+    const result = truncateMessage("", 8192);
+    expect(result.truncated).toBe(false);
+    expect(result.text).toBe("");
+  });
+
+  it("preserves leading/trailing content before the marker", () => {
+    const text = "start " + "x".repeat(9000) + " end";
+    const result = truncateMessage(text, 8192);
+    expect(result.text.startsWith("start ")).toBe(true);
+    expect(result.text).toContain("[message truncated]");
+  });
+});
+
+// ─── lastRecentTurns ──────────────────────────────────────────────────
+
+describe("lastRecentTurns", () => {
+  const turn = (text: string) => ({ text, intent: "ask" as const });
+
+  it("returns all turns when fewer than 3", () => {
+    const turns = [turn("a"), turn("b")];
+    expect(lastRecentTurns(turns)).toHaveLength(2);
+    expect(lastRecentTurns(turns)[0].text).toBe("a");
+  });
+
+  it("returns the last 3 when more than 3", () => {
+    const turns = [turn("1"), turn("2"), turn("3"), turn("4"), turn("5")];
+    const result = lastRecentTurns(turns);
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.text)).toEqual(["3", "4", "5"]);
+  });
+
+  it("returns all 3 exactly when precisely 3", () => {
+    const turns = [turn("x"), turn("y"), turn("z")];
+    expect(lastRecentTurns(turns)).toHaveLength(3);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(lastRecentTurns([])).toEqual([]);
+  });
+
+  it("does not mutate the original array", () => {
+    const turns = [turn("1"), turn("2"), turn("3"), turn("4")];
+    const copy = [...turns];
+    lastRecentTurns(turns);
+    expect(turns).toEqual(copy);
+  });
+});
+
+// ─── prepareClassifierInput ───────────────────────────────────────────
+
+describe("prepareClassifierInput", () => {
+  it("composes truncation + recent-turns slice into a ClassifierInput", () => {
+    const input = prepareClassifierInput({
+      messageText: "hello world",
+      attachments: [{ kind: "pdf", filename: "doc.pdf" }],
+      activeFile: { filename: "note.md", title: "my note" },
+      recentTurns: [
+        { text: "t1", intent: "ask" },
+        { text: "t2", intent: "capture" },
+        { text: "t3", intent: "ask" },
+        { text: "t4", intent: "meta" },
+      ],
+    });
+
+    expect(input.messageText).toBe("hello world");
+    expect(input.truncated).toBe(false);
+    expect(input.attachments).toHaveLength(1);
+    expect(input.activeFile?.title).toBe("my note");
+    expect(input.recentTurns).toHaveLength(3);
+    expect(input.recentTurns[0].text).toBe("t2");
+  });
+
+  it("flags truncated when the message exceeds 8 KB", () => {
+    const longText = "x".repeat(9000);
+    const input = prepareClassifierInput({
+      messageText: longText,
+      attachments: [],
+      activeFile: null,
+      recentTurns: [],
+    });
+
+    expect(input.truncated).toBe(true);
+    expect(input.messageText).toContain("[message truncated]");
+  });
+});

--- a/src/services/classifier-utils.ts
+++ b/src/services/classifier-utils.ts
@@ -1,0 +1,86 @@
+import { ClassifierInput, RecentTurn } from "../contracts/classifier";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** Planning/classifier.md §"Input contract": 8 KB message cap. */
+const MESSAGE_BYTE_LIMIT = 8192;
+
+/** Marker appended when the message is truncated, so the user can see it
+ *  wasn't fully processed. Kept short to minimise prompt tokens. */
+const TRUNCATION_MARKER = "\n… [message truncated]";
+
+/**
+ * Pre-process raw user input into a `ClassifierInput` suitable for
+ * prompt assembly. Handles truncation and the recent-turns slice in one
+ * call-site convenience function.
+ */
+export function prepareClassifierInput(raw: {
+  messageText: string;
+  attachments: ClassifierInput["attachments"];
+  activeFile: ClassifierInput["activeFile"];
+  recentTurns: RecentTurn[];
+}): ClassifierInput {
+  const { text, truncated } = truncateMessage(raw.messageText);
+  return {
+    messageText: text,
+    truncated,
+    attachments: raw.attachments,
+    activeFile: raw.activeFile,
+    recentTurns: lastRecentTurns(raw.recentTurns),
+  };
+}
+
+/**
+ * Truncate `text` so its UTF-8 byte length does not exceed `limit`
+ * (default 8 KB). The last code-point boundary before the limit is
+ * preserved — multibyte characters are never split. Returns the
+ * truncated string with a visible marker and a `truncated` flag.
+ *
+ * No-op when the text is already under the limit.
+ */
+export function truncateMessage(
+  text: string,
+  limit: number = MESSAGE_BYTE_LIMIT,
+): { text: string; truncated: boolean } {
+  const encoded = encoder.encode(text);
+  if (encoded.byteLength <= limit) {
+    return { text, truncated: false };
+  }
+
+  const tail = encoder.encode(TRUNCATION_MARKER);
+  const contentLimit = limit - tail.byteLength;
+
+  if (contentLimit <= 0) {
+    // Edge case: limit is smaller than the marker itself.
+    // Deliver just the marker so the user at least knows truncation happened.
+    return { text: TRUNCATION_MARKER.trimStart(), truncated: true };
+  }
+
+  const trimmed = trimUtf8(encoded, contentLimit);
+  const truncatedText = decoder.decode(trimmed);
+
+  return { text: truncatedText + TRUNCATION_MARKER, truncated: true };
+}
+
+/**
+ * Return at most the last 3 recent turns. The classifier prompt uses
+ * this slice for referent resolution ("save that", "tell me more").
+ */
+export function lastRecentTurns(turns: readonly RecentTurn[]): RecentTurn[] {
+  if (turns.length <= 3) return [...turns];
+  return turns.slice(-3);
+}
+
+// ─── internals ────────────────────────────────────────────────────────
+
+function trimUtf8(bytes: Uint8Array, byteLimit: number): Uint8Array {
+  let end = byteLimit;
+  // Walk backwards to the nearest code-point boundary. Multi-byte
+  // sequences in UTF-8 never contain 0xxxxxxx or 11xxxxxx as a
+  // continuation byte — continuation bytes are always 10xxxxxx.
+  while (end > 0 && (bytes[end] & 0xc0) === 0x80) {
+    end--;
+  }
+  return bytes.slice(0, end);
+}


### PR DESCRIPTION
## What

Classifier v1 Phase 1 — input/output contracts, versioned few-shot prompt, and event-log schema. Three tightly-coupled issues that define the classifier's type surface and observability footprint before routing logic begins.

| Issue | Summary |
|---|---|
| #17 | `ClassifierInput`, `ClassifierOutput`, `IntentLabel` taxonomy, `truncateMessage` (UTF-8-safe, 8 KB cap), `lastRecentTurns` (last 3), `prepareClassifierInput` composer |
| #18 | `prompts/intent-classifier.md` — ~150-token system prompt + 6 few-shot examples (4 labels + 2 edge cases). `assembleClassifierPrompt()` renderer with placeholder substitution. `INTENT_CLASSIFIER_PROMPT_VERSION` constant. Snapshot test pins the rendered prompt. |
| #19 | `ClassifierDecisionRow` + `ClassifierDisambiguationRow` DB types. DuckDB DDL strings. `ClassifierEventWriter` contract. `InMemoryClassifierEventWriter` + `toDecisionRow`/`toDisambiguationRow` helpers. |

## How to test

```
npm test       # 249 tests pass (was 216 before this branch)
npx tsc --noEmit  # clean
```

## What is not in this PR

Phase 2 work (skip-condition pre-router, Ollama `format:json` call, retry budget, asymmetric thresholds) stays in follow-up PRs.

Closes #17, closes #18, closes #19