### PR TITLE
docs: drop required --base dev flag now that dev is the default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,10 @@ This catches conflicts on your branch instead of mixing them into the PR.
 ### 4. Open the PR
 
 ```bash
-gh pr create --base dev --title "feat(area): short title" --body "..."
+gh pr create --title "feat(area): short title" --body "..."
 ```
 
-**Note:** `--base dev` is critical. GitHub's default is `main`, so don't forget this flag.
+The repo's default branch is `dev`, so PRs target `dev` automatically. Pass `--base dev` explicitly if you want to be defensive, or `--base main` only when preparing a release PR from `dev` to `main`.
 
 ## Commit messages — Conventional Commits
 


### PR DESCRIPTION
## What
Updates the "Open the PR" section of CONTRIBUTING.md to reflect that `dev` is now the repo's default branch.

## Why
We changed the default branch from `main` to `dev`, so:
- `gh pr create` (and the GitHub web UI) target `dev` automatically
- The previous "`--base dev` is critical" warning is no longer accurate

## Change
- Drop `--base dev` from the example command
- Replace the "GitHub's default is main" warning with a note about how to override the default if needed (e.g. when opening a release PR from `dev` to `main`)

## How to test
Read the diff. Two-line change.