### PR TITLE
feat(classifier): Ollama call with format=json constrained decoding (closes #23)

### DIFF
--- a/src/contracts/llm.ts
+++ b/src/contracts/llm.ts
@@ -30,6 +30,11 @@ export interface ChatOptions {
   tools?: Tool[];
   onToken?: (token: string) => void;
   signal?: AbortSignal;
+  /** Constrain output to valid JSON when set. */
+  format?: "json";
+  /** Stream tokens via onToken. Defaults to true for chat; classifier
+   *  calls typically set stream=false for a single JSON blob. */
+  stream?: boolean;
 }
 
 export type LLMReachability = "running" | "missing";

--- a/src/services/classifier-events.ts
+++ b/src/services/classifier-events.ts
@@ -94,9 +94,8 @@ export function toDecisionRow(
   return {
     turn_id: turnId,
     ts: Date.now(),
-<<<<<<< HEAD
     source: decision.source,
-    skip_reason: decision.skipReason,
+    skip_reason: decision.skipReason as ClassifierDecisionRow["skip_reason"],
     prompt_version: decision.promptVersion,
     input_json: JSON.stringify(decision.input),
     output_json: decision.output ? JSON.stringify(decision.output) : null,

--- a/src/services/classifier-llm.test.ts
+++ b/src/services/classifier-llm.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyWithLLM,
+  ClassifierCallDeps,
+  ClassifierError,
+} from "./classifier-llm";
+import { ClassifierInput } from "../contracts/classifier";
+import { LLMService } from "../contracts/llm";
+import { LoadedPrompt, PromptLoader } from "../contracts/prompts";
+
+const TEST_PROMPT: LoadedPrompt = {
+  id: "intent-classifier",
+  version: "0.1.0",
+  body: `
+# Intent Classifier v0.1.0
+Classify the user message.
+
+{{messageText}}
+{{attachmentList}}
+{{activeFileLine}}
+{{recentTurnList}}
+`,
+};
+
+function makeMockPromptLoader(prompt: LoadedPrompt = TEST_PROMPT): PromptLoader {
+  return {
+    load: async () => prompt,
+    invalidate: () => {},
+  };
+}
+
+function makeInput(overrides: Partial<ClassifierInput> = {}): ClassifierInput {
+  return {
+    messageText: "Save this as meeting notes",
+    truncated: false,
+    attachments: [],
+    activeFile: null,
+    recentTurns: [],
+    ...overrides,
+  };
+}
+
+interface MockResponse {
+  content?: string;
+  delayMs?: number;
+  throwError?: Error;
+}
+
+function makeMockLLM(responses: MockResponse[]): LLMService {
+  let callCount = 0;
+  return {
+    chat: async (opts) => {
+      const resp = responses[callCount++];
+      if (!resp) throw new Error("Unexpected extra LLM call");
+      if (resp.throwError) throw resp.throwError;
+
+      // Respect abort signal for timeout tests.
+      function abortError(): Error {
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        return err;
+      }
+
+      if (opts.signal?.aborted) {
+        throw abortError();
+      }
+
+      if (resp.delayMs) {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, resp.delayMs);
+          opts.signal?.addEventListener("abort", () => {
+            clearTimeout(timer);
+            reject(abortError());
+          });
+        });
+      }
+
+      // Verify classifier-specific options are passed.
+      expect(opts.format).toBe("json");
+      expect(opts.stream).toBe(false);
+      expect(opts.model).toBe("gemma3:latest");
+
+      return { content: resp.content ?? "" };
+    },
+    isReachable: async () => "running",
+    listModels: async () => ["gemma3:latest"],
+    pickDefaultModel: async () => "gemma3:latest",
+  };
+}
+
+describe("classifyWithLLM", () => {
+  // ─── Happy path ───────────────────────────────────────────────────────
+
+  it("returns parsed output on valid JSON response", async () => {
+    const llm = makeMockLLM([
+      {
+        content: JSON.stringify({
+          label: "capture",
+          confidence: 0.92,
+          rationale: "User wants to save content.",
+        }),
+      },
+    ]);
+
+    const result = await classifyWithLLM(makeInput(), {
+      llm,
+      promptLoader: makeMockPromptLoader(),
+    });
+
+    expect(result.output).toEqual({
+      label: "capture",
+      confidence: 0.92,
+      rationale: "User wants to save content.",
+    });
+    expect(result.promptVersion).toBe("0.1.0");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("works for each valid label", async () => {
+    const labels = ["capture", "ask", "mixed", "meta"] as const;
+    for (const label of labels) {
+      const llm = makeMockLLM([
+        {
+          content: JSON.stringify({
+            label,
+            confidence: 0.8,
+            rationale: "Test rationale.",
+          }),
+        },
+      ]);
+
+      const result = await classifyWithLLM(makeInput(), {
+        llm,
+        promptLoader: makeMockPromptLoader(),
+      });
+
+      expect(result.output.label).toBe(label);
+    }
+  });
+
+  // ─── Parse / validation errors ────────────────────────────────────────
+
+  it("throws unparseable on invalid JSON", async () => {
+    const llm = makeMockLLM([{ content: "not json" }]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "unparseable" });
+  });
+
+  it("throws invalid-label when label is not in taxonomy", async () => {
+    const llm = makeMockLLM([
+      {
+        content: JSON.stringify({
+          label: "unknown",
+          confidence: 0.9,
+          rationale: "Test.",
+        }),
+      },
+    ]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "invalid-label" });
+  });
+
+  it("throws invalid-confidence when confidence is negative", async () => {
+    const llm = makeMockLLM([
+      {
+        content: JSON.stringify({
+          label: "capture",
+          confidence: -0.1,
+          rationale: "Test.",
+        }),
+      },
+    ]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "invalid-confidence" });
+  });
+
+  it("throws invalid-confidence when confidence is above 1", async () => {
+    const llm = makeMockLLM([
+      {
+        content: JSON.stringify({
+          label: "capture",
+          confidence: 1.5,
+          rationale: "Test.",
+        }),
+      },
+    ]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "invalid-confidence" });
+  });
+
+  it("throws invalid-confidence when confidence is not a number", async () => {
+    const llm = makeMockLLM([
+      {
+        content: JSON.stringify({
+          label: "capture",
+          confidence: "high",
+          rationale: "Test.",
+        }),
+      },
+    ]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "invalid-confidence" });
+  });
+
+  it("throws unparseable when rationale is missing", async () => {
+    const llm = makeMockLLM([
+      {
+        content: JSON.stringify({
+          label: "capture",
+          confidence: 0.9,
+        }),
+      },
+    ]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "unparseable" });
+  });
+
+  it("throws unparseable when output is not an object", async () => {
+    const llm = makeMockLLM([{ content: JSON.stringify(["capture", 0.9]) }]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "unparseable" });
+  });
+
+  // ─── Transport / timeout errors ───────────────────────────────────────
+
+  it("throws transport error when LLM throws a network error", async () => {
+    const llm = makeMockLLM([{ throwError: new Error("ECONNREFUSED") }]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "transport" });
+  });
+
+  it("throws timeout error when LLM call exceeds 500ms", async () => {
+    const llm = makeMockLLM([{ content: "irrelevant", delayMs: 600 }]);
+
+    await expect(
+      classifyWithLLM(makeInput(), { llm, promptLoader: makeMockPromptLoader() }),
+    ).rejects.toMatchObject({ code: "timeout" });
+  });
+});

--- a/src/services/classifier-llm.ts
+++ b/src/services/classifier-llm.ts
@@ -1,0 +1,164 @@
+/**
+ * Classifier LLM call — issue #05.
+ *
+ * Renders the intent-classifier prompt, issues an Ollama call with
+ * `format: "json"` constrained decoding, parses + validates the output.
+ *
+ * Retry budget and timeout fallbacks are handled by the caller (issue #06).
+ *
+ * #05
+ */
+
+import { ClassifierInput, ClassifierOutput } from "../contracts/classifier";
+import { ChatMessage, LLMService } from "../contracts/llm";
+import { PromptLoader } from "../contracts/prompts";
+import { assembleClassifierPrompt } from "./classifier-prompt";
+
+const CLASSIFIER_MODEL = "gemma3:latest";
+const CLASSIFIER_TIMEOUT_MS = 500;
+
+/** Errors the classifier call surface can throw. */
+export class ClassifierError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "timeout"
+      | "unparseable"
+      | "invalid-label"
+      | "invalid-confidence"
+      | "transport",
+    public readonly raw?: string,
+  ) {
+    super(message);
+    this.name = "ClassifierError";
+  }
+}
+
+/** Result of a classifier LLM call. */
+export interface ClassifierCallResult {
+  output: ClassifierOutput;
+  latencyMs: number;
+  promptVersion: string;
+}
+
+/** Dependencies needed by the classifier call site. */
+export interface ClassifierCallDeps {
+  llm: LLMService;
+  /** Prompt loader — tests can inject a mock. */
+  promptLoader: PromptLoader;
+}
+
+/**
+ * Run the LLM classifier against the given input.
+ *
+ * Behaviour:
+ *   1. Load the intent-classifier prompt via `promptLoader`.
+ *   2. Render the prompt body with the input.
+ *   3. Call Ollama with `format: "json"`, `stream: false`, and a 500 ms
+ *      AbortSignal timeout.
+ *   4. Parse the JSON response.
+ *   5. Validate `label` is in the taxonomy and `confidence` is in [0,1].
+ *   6. On transport/timeout error → throw ClassifierError (caller falls
+ *      back to main-loop Ollama-error handling or timeout behaviour).
+ */
+export async function classifyWithLLM(
+  input: ClassifierInput,
+  deps: ClassifierCallDeps,
+): Promise<ClassifierCallResult> {
+  const loaded = await deps.promptLoader.load("intent-classifier");
+  const prompt = assembleClassifierPrompt(input, loaded.body);
+  const messages: ChatMessage[] = [
+    { role: "system", content: "You are an intent classifier." },
+    { role: "user", content: prompt },
+  ];
+
+  const start = performance.now();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), CLASSIFIER_TIMEOUT_MS);
+
+  try {
+    const res = await deps.llm.chat({
+      messages,
+      model: CLASSIFIER_MODEL,
+      format: "json",
+      stream: false,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+    const output = parseAndValidate(res.content);
+    const latencyMs = Math.round(performance.now() - start);
+
+    return {
+      output,
+      latencyMs,
+      promptVersion: loaded.version,
+    };
+  } catch (err) {
+    clearTimeout(timeoutId);
+
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new ClassifierError("Classifier timed out", "timeout");
+    }
+    if (err instanceof ClassifierError) {
+      throw err;
+    }
+    // Transport / network / generic Ollama error.
+    throw new ClassifierError(
+      err instanceof Error ? err.message : String(err),
+      "transport",
+    );
+  }
+}
+
+function parseAndValidate(raw: string): ClassifierOutput {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ClassifierError("Invalid JSON from classifier", "unparseable", raw);
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new ClassifierError("Classifier output is not an object", "unparseable", raw);
+  }
+
+  const label = parsed.label;
+  const confidence = parsed.confidence;
+  const rationale = parsed.rationale;
+
+  if (!isValidLabel(label)) {
+    throw new ClassifierError(
+      `Invalid label: ${String(label)}`,
+      "invalid-label",
+      raw,
+    );
+  }
+
+  if (typeof confidence !== "number" || confidence < 0 || confidence > 1) {
+    throw new ClassifierError(
+      `Confidence out of range: ${String(confidence)}`,
+      "invalid-confidence",
+      raw,
+    );
+  }
+
+  if (typeof rationale !== "string") {
+    throw new ClassifierError(
+      `Rationale missing or not a string`,
+      "unparseable",
+      raw,
+    );
+  }
+
+  return { label, confidence, rationale };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isValidLabel(v: unknown): v is "capture" | "ask" | "mixed" | "meta" {
+  return v === "capture" || v === "ask" || v === "mixed" || v === "meta";
+}

--- a/src/services/ollama-llm.ts
+++ b/src/services/ollama-llm.ts
@@ -45,20 +45,33 @@ export class OllamaLLMService implements LLMService {
   }
 
   async chat(opts: ChatOptions): Promise<LLMResponse> {
-    const { messages, model = DEFAULT_MODEL, onToken, signal } = opts;
+    const {
+      messages,
+      model = DEFAULT_MODEL,
+      onToken,
+      signal,
+      format,
+      stream = true,
+    } = opts;
     const res = await fetch(`${this.baseUrl}/api/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         model,
         messages: messages.map(toOllamaMessage),
-        stream: true,
+        stream,
+        ...(format ? { format } : {}),
       }),
       signal,
     });
     if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
-    if (!res.body) throw new Error("No response body");
 
+    if (!stream) {
+      const data = (await res.json()) as { message?: { content: string } };
+      return { content: data.message?.content ?? "" };
+    }
+
+    if (!res.body) throw new Error("No response body");
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";


### PR DESCRIPTION
Closes #23

- Add `format?: "json"` and `stream?: boolean` to `ChatOptions` contract
- Update `OllamaLLMService` to pass `format` through and handle non-streaming responses
- `classifyWithLLM()` — render prompt, call Ollama with `format: "json"` `stream: false`, parse + validate output, 500ms AbortSignal timeout
- `ClassifierError` with granular codes: `timeout`, `unparseable`, `invalid-label`, `invalid-confidence`, `transport`
- 11 tests: happy path (all 4 labels), parse errors, validation errors, transport error, timeout
- 330 tests pass