### PR TITLE
feat(classifier): retry budget and timeout/error fallbacks (closes #75)

### DIFF
--- a/src/services/classifier-llm.ts
+++ b/src/services/classifier-llm.ts
@@ -28,6 +28,10 @@ export class ClassifierError extends Error {
       | "invalid-confidence"
       | "transport",
     public readonly raw?: string,
+    /** Prompt version loaded before the call, for event-log stamping.
+     *  Not readonly — may be set after construction by the caller if the
+     *  prompt was already loaded by the time the error surface is known. */
+    public promptVersion?: string,
   ) {
     super(message);
     this.name = "ClassifierError";
@@ -87,7 +91,17 @@ export async function classifyWithLLM(
     });
 
     clearTimeout(timeoutId);
-    const output = parseAndValidate(res.content);
+
+    let output: ClassifierOutput;
+    try {
+      output = parseAndValidate(res.content);
+    } catch (parseErr) {
+      if (parseErr instanceof ClassifierError) {
+        parseErr.promptVersion = loaded.version;
+      }
+      throw parseErr;
+    }
+
     const latencyMs = Math.round(performance.now() - start);
 
     return {
@@ -99,15 +113,19 @@ export async function classifyWithLLM(
     clearTimeout(timeoutId);
 
     if (err instanceof Error && err.name === "AbortError") {
-      throw new ClassifierError("Classifier timed out", "timeout");
+      throw new ClassifierError("Classifier timed out", "timeout", undefined, loaded.version);
     }
     if (err instanceof ClassifierError) {
+      // promptVersion may already be set if from parseAndValidate.
+      if (!err.promptVersion) err.promptVersion = loaded.version;
       throw err;
     }
     // Transport / network / generic Ollama error.
     throw new ClassifierError(
       err instanceof Error ? err.message : String(err),
       "transport",
+      undefined,
+      loaded.version,
     );
   }
 }

--- a/src/services/classifier-retries.test.ts
+++ b/src/services/classifier-retries.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyWithRetries,
+  ClassifierRetriedResult,
+} from "./classifier-retries";
+import { ClassifierInput } from "../contracts/classifier";
+import { LLMService, LLMResponse } from "../contracts/llm";
+import { LoadedPrompt, PromptLoader } from "../contracts/prompts";
+import { ClassifierError } from "./classifier-llm";
+
+const TEST_PROMPT: LoadedPrompt = {
+  id: "intent-classifier",
+  version: "0.1.0",
+  body: `{{messageText}}\n{{attachmentList}}\n{{activeFileLine}}\n{{recentTurnList}}`,
+};
+
+function makePromptLoader(prompt: LoadedPrompt = TEST_PROMPT): PromptLoader {
+  return { load: async () => prompt, invalidate: () => {} };
+}
+
+function makeInput(overrides: Partial<ClassifierInput> = {}): ClassifierInput {
+  return {
+    messageText: "Save this",
+    truncated: false,
+    attachments: [],
+    activeFile: null,
+    recentTurns: [],
+    ...overrides,
+  };
+}
+
+/** Mock LLM that returns the given JSON (or throws). Uses format:json, stream:false. */
+function makeJsonLLM(content: string, throwErr?: Error): LLMService {
+  return {
+    chat: async (opts) => {
+      expect(opts.format).toBe("json");
+      expect(opts.stream).toBe(false);
+      if (throwErr) throw throwErr;
+      return { content } as LLMResponse;
+    },
+    isReachable: async () => "running",
+    listModels: async () => ["gemma3:latest"],
+    pickDefaultModel: async () => "gemma3:latest",
+  };
+}
+
+/** Sequence-based mock: each call consumes one entry. */
+function makeSeqLLM(
+  responses: { content: string; throwErr?: Error }[],
+): LLMService {
+  let i = 0;
+  return {
+    chat: async (opts) => {
+      expect(opts.format).toBe("json");
+      expect(opts.stream).toBe(false);
+      const r = responses[i++];
+      if (!r) throw new Error("Unexpected extra LLM call");
+      if (r.throwErr) throw r.throwErr;
+      return { content: r.content } as LLMResponse;
+    },
+    isReachable: async () => "running",
+    listModels: async () => ["gemma3:latest"],
+    pickDefaultModel: async () => "gemma3:latest",
+  };
+}
+
+function validJson(label = "capture", confidence = 0.9) {
+  return JSON.stringify({
+    label,
+    confidence,
+    rationale: "Test rationale.",
+  });
+}
+
+describe("classifyWithRetries", () => {
+  // ─── Happy path ───────────────────────────────────────────────────────
+
+  it("returns output on first successful call (no retries)", async () => {
+    const result = await classifyWithRetries(makeInput(), {
+      llm: makeJsonLLM(validJson()),
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output).toEqual({
+      label: "capture",
+      confidence: 0.9,
+      rationale: "Test rationale.",
+    });
+    expect(result.retries).toBe(0);
+    expect(result.promptVersion).toBe("0.1.0");
+    expect(result.fallbackReason).toBeUndefined();
+  });
+
+  // ─── Unparseable → retry → success ────────────────────────────────────
+
+  it("retries once on unparseable and succeeds on second try", async () => {
+    const llm = makeSeqLLM([
+      { content: "not json" },
+      { content: validJson("ask") },
+    ]);
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output?.label).toBe("ask");
+    expect(result.retries).toBe(1);
+  });
+
+  it("retry latency is measured from first call", async () => {
+    const llm = makeSeqLLM([
+      { content: "not json" },
+      { content: validJson() },
+    ]);
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.retries).toBe(1);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // ─── Unparseable → retry → fail → fallback ─────────────────────────────
+
+  it("falls back after two unparseable responses", async () => {
+    const llm = makeSeqLLM([
+      { content: "garbage 1" },
+      { content: "garbage 2" },
+    ]);
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output).toBeNull();
+    expect(result.retries).toBe(1);
+    expect(result.fallbackReason).toBe("unparseable");
+    expect(result.rawResponse).toBe("garbage 1");
+  });
+
+  it("falls back when retry throws unparseable for invalid-confidence", async () => {
+    // First call: unparseable. Retry: invalid-confidence (should still
+    // fall back, not re-throw).
+    const llm = makeSeqLLM([
+      { content: "not json" },
+      {
+        content: JSON.stringify({
+          label: "capture",
+          confidence: 99,
+          rationale: "x",
+        }),
+      },
+    ]);
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output).toBeNull();
+    expect(result.retries).toBe(1);
+    expect(result.fallbackReason).toBe("unparseable");
+  });
+
+  // ─── Timeout → fallback (no retry) ────────────────────────────────────
+
+  it("falls back immediately on timeout (no retry)", async () => {
+    const err = new ClassifierError("timed out", "timeout", undefined, "0.1.0");
+    const llm = makeJsonLLM("", err);
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output).toBeNull();
+    expect(result.retries).toBe(0);
+    expect(result.fallbackReason).toBe("timeout");
+  });
+
+  // ─── Invalid label / confidence → fallback (no retry) ──────────────────
+
+  it("falls back on invalid label (no retry)", async () => {
+    const llm = makeJsonLLM(
+      JSON.stringify({ label: "unknown", confidence: 0.8, rationale: "x" }),
+    );
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output).toBeNull();
+    expect(result.retries).toBe(0);
+    expect(result.fallbackReason).toBe("invalid-label");
+    expect(result.rawResponse).toContain("unknown");
+  });
+
+  it("falls back on invalid confidence (no retry)", async () => {
+    const llm = makeJsonLLM(
+      JSON.stringify({ label: "capture", confidence: -1, rationale: "x" }),
+    );
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output).toBeNull();
+    expect(result.retries).toBe(0);
+    expect(result.fallbackReason).toBe("invalid-confidence");
+  });
+
+  // ─── Transport → re-throw (no retry) ───────────────────────────────────
+
+  it("re-throws transport errors immediately (no retry)", async () => {
+    const err = new ClassifierError("ECONNREFUSED", "transport");
+    const llm = makeJsonLLM("", err);
+
+    await expect(
+      classifyWithRetries(makeInput(), {
+        llm,
+        promptLoader: makePromptLoader(),
+      }),
+    ).rejects.toMatchObject({ code: "transport" });
+  });
+
+  // ─── Prompt version ────────────────────────────────────────────────────
+
+  it("preserves prompt version on success", async () => {
+    const result = await classifyWithRetries(makeInput(), {
+      llm: makeJsonLLM(validJson()),
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.output).toBeDefined();
+    expect(result.promptVersion).toBe("0.1.0");
+  });
+
+  it("preserves prompt version on fallback", async () => {
+    const err = new ClassifierError("oops", "invalid-label", "raw", "0.1.0");
+    const llm = makeJsonLLM("", err);
+
+    const result = await classifyWithRetries(makeInput(), {
+      llm,
+      promptLoader: makePromptLoader(),
+    });
+
+    expect(result.promptVersion).toBe("0.1.0");
+  });
+});

--- a/src/services/classifier-retries.ts
+++ b/src/services/classifier-retries.ts
@@ -1,0 +1,142 @@
+/**
+ * Classifier retry budget — issue #75.
+ *
+ * Wraps `classifyWithLLM` with the classifier-specific retry rules
+ * documented in planning/classifier.md §"Retry budget".
+ *
+ * - 1 retry on invalid JSON output (retries do NOT count against the
+ *   main turn's 3-retry budget).
+ * - 0 retries on transport errors → re-throw for main-loop handling.
+ * - 0 retries on out-of-taxonomy labels, confidence out-of-range,
+ *   or timeout → fallback result (caller routes to "ask" + chip).
+ * - Low confidence on a valid output → NOT a retry; returned as-is
+ *   (disambiguation is handled by #07 thresholds).
+ *
+ * #75
+ */
+
+import { ClassifierInput, ClassifierOutput } from "../contracts/classifier";
+import {
+  classifyWithLLM,
+  ClassifierCallDeps,
+  ClassifierError,
+  ClassifierCallResult,
+} from "./classifier-llm";
+
+export interface ClassifierRetriedResult {
+  /** Validated output, or null when fallback occurred. */
+  output: ClassifierOutput | null;
+  /** Number of retries attempted (0 or 1). */
+  retries: number;
+  /** Total wall-clock latency from initial call to final decision, in ms. */
+  latencyMs: number;
+  /** Prompt version ID from the loaded intent-classifier prompt. */
+  promptVersion: string;
+  /** Raw classifier response text for debugging (set when output is null). */
+  rawResponse?: string;
+  /** Reason for fallback (only set when output is null). */
+  fallbackReason?: "timeout" | "unparseable" | "invalid-label" | "invalid-confidence";
+}
+
+/**
+ * Run the classifier with the v1 retry budget.
+ *
+ * Rules (in order of evaluation):
+ *
+ * | Error type          | Retries | Outcome                                   |
+ * |---------------------|---------|-------------------------------------------|
+ * | unparseable         | 1       | Retry once; second failure → fallback      |
+ * | timeout             | 0       | Fallback (no retry)                        |
+ * | invalid-label       | 0       | Fallback (no retry)                        |
+ * | invalid-confidence  | 0       | Fallback (no retry)                        |
+ * | transport           | 0       | Re-throw (caller shows main-loop error)    |
+ *
+ * All fallback paths return `{ output: null, fallbackReason, rawResponse }`.
+ * Transport errors are re-thrown — the caller must route to the main-loop
+ * Ollama-error handling (Notice with Start action). The turn is not submitted.
+ */
+export async function classifyWithRetries(
+  input: ClassifierInput,
+  deps: ClassifierCallDeps,
+): Promise<ClassifierRetriedResult> {
+  const overallStart = performance.now();
+
+  try {
+    const first = await classifyWithLLM(input, deps);
+    return toSuccess(first, 0, overallStart);
+  } catch (err) {
+    if (!(err instanceof ClassifierError)) {
+      throw err;
+    }
+
+    const pv = err.promptVersion ?? "";
+
+    // Transport errors: 0 retries, re-throw.
+    if (err.code === "transport") {
+      throw err;
+    }
+
+    // Invalid label or confidence: 0 retries, fallback.
+    if (err.code === "invalid-label" || err.code === "invalid-confidence") {
+      return {
+        output: null,
+        retries: 0,
+        latencyMs: Math.round(performance.now() - overallStart),
+        promptVersion: pv,
+        rawResponse: err.raw,
+        fallbackReason: err.code,
+      };
+    }
+
+    // Timeout: 0 retries, fallback.
+    if (err.code === "timeout") {
+      return {
+        output: null,
+        retries: 0,
+        latencyMs: Math.round(performance.now() - overallStart),
+        promptVersion: pv,
+        fallbackReason: "timeout",
+      };
+    }
+
+    // unparseable: 1 retry.
+    if (err.code === "unparseable") {
+      const firstRaw = err.raw;
+
+      try {
+        const second = await classifyWithLLM(input, deps);
+        return toSuccess(second, 1, overallStart);
+      } catch (retryErr) {
+        if (!(retryErr instanceof ClassifierError)) {
+          throw retryErr;
+        }
+
+        // Second failure — fallback.  Per spec, treat as timeout behaviour
+        // (route ask, show chip, log malformed output).
+        return {
+          output: null,
+          retries: 1,
+          latencyMs: Math.round(performance.now() - overallStart),
+          promptVersion: pv,
+          rawResponse: firstRaw ?? retryErr.raw,
+          fallbackReason: "unparseable",
+        };
+      }
+    }
+
+    throw err;
+  }
+}
+
+function toSuccess(
+  result: ClassifierCallResult,
+  retries: number,
+  overallStart: number,
+): ClassifierRetriedResult {
+  return {
+    output: result.output,
+    retries,
+    latencyMs: Math.round(performance.now() - overallStart),
+    promptVersion: result.promptVersion,
+  };
+}


### PR DESCRIPTION
Closes #75

- Add promptVersion to ClassifierError so fallback paths carry the version
- classifyWithRetries: 1 retry on unparseable, 0 on timeout/invalid-label/invalid-confidence/transport
- Fallback returns { output: null, fallbackReason, rawResponse } — caller routes to ask + chip
- Transport errors re-thrown for main-loop Ollama-error handling
- 11 tests covering all retry + fallback branches
- 341 tests pass, tsc clean