### PR TITLE
feat(classifier): asymmetric confidence threshold gating (closes #77)

### DIFF
--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -77,6 +77,26 @@ export type PresetCommand =
   | "cowork.capture-active-note"
   | "cowork.ask-about-active-note";
 
+// ─── Confidence thresholds ────────────────────────────────────────────
+
+/** Per-label confidence thresholds. When confidence falls below the
+ *  label's threshold, the disambiguation chip is shown. */
+export interface ClassifierThresholds {
+  capture: number;
+  ask: number;
+  mixed: number;
+  meta: number;
+}
+
+/** Anchor values from planning/classifier.md §"Confidence thresholds".
+ *  Committed values land after the first golden-set run during M1. */
+export const DEFAULT_CLASSIFIER_THRESHOLDS: ClassifierThresholds = {
+  capture: 0.85,
+  ask: 0.70,
+  mixed: 0.75,
+  meta: 0.70,
+};
+
 // ─── Decision log entry (upstream of #19 event-log schema) ────────────
 
 /** Source of a classifier decision. "skip" means a hard signal pre-empted
@@ -97,6 +117,18 @@ export interface ClassifierDecision {
    * "ctrl-enter", "leading-question-mark".
    */
   skipReason: SkipReason | null;
+  /**
+   * True when the confidence is below the active threshold and the
+   * disambiguation chip should be shown.  Always false for skip-path
+   * decisions and true for LLM fallbacks (null output).
+   */
+  needsDisambiguation: boolean;
+  /**
+   * Reason for LLM fallback — set when output is null and the LLM call
+   * failed (timeout, unparseable, invalid-label, invalid-confidence).
+   * Null for skip-path decisions and successful LLM calls.
+   */
+  fallbackReason: "timeout" | "unparseable" | "invalid-label" | "invalid-confidence" | null;
 }
 
 // ─── Event-log rows (#19) ─────────────────────────────────────────────

--- a/src/services/classifier-thresholds.test.ts
+++ b/src/services/classifier-thresholds.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { isConfident } from "./classifier-thresholds";
+import {
+  ClassifierThresholds,
+  DEFAULT_CLASSIFIER_THRESHOLDS,
+} from "../contracts/classifier";
+
+describe("isConfident", () => {
+  // ─── Default thresholds ───────────────────────────────────────────────
+
+  it("capture threshold 0.85: confident at exactly 0.85", () => {
+    expect(isConfident("capture", 0.85)).toBe(true);
+  });
+
+  it("capture threshold 0.85: not confident below", () => {
+    expect(isConfident("capture", 0.849)).toBe(false);
+  });
+
+  it("capture threshold 0.85: confident above", () => {
+    expect(isConfident("capture", 0.86)).toBe(true);
+  });
+
+  it("ask threshold 0.70: confident at exactly 0.70", () => {
+    expect(isConfident("ask", 0.70)).toBe(true);
+  });
+
+  it("ask threshold 0.70: not confident below", () => {
+    expect(isConfident("ask", 0.699)).toBe(false);
+  });
+
+  it("mixed threshold 0.75: confident at exactly 0.75", () => {
+    expect(isConfident("mixed", 0.75)).toBe(true);
+  });
+
+  it("mixed threshold 0.75: not confident below", () => {
+    expect(isConfident("mixed", 0.749)).toBe(false);
+  });
+
+  it("meta threshold 0.70: confident at exactly 0.70", () => {
+    expect(isConfident("meta", 0.70)).toBe(true);
+  });
+
+  it("meta threshold 0.70: not confident below", () => {
+    expect(isConfident("meta", 0.699)).toBe(false);
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────
+
+  it("returns false for confidence 0", () => {
+    expect(isConfident("ask", 0)).toBe(false);
+  });
+
+  it("returns true for confidence 1.0 on any label", () => {
+    expect(isConfident("capture", 1.0)).toBe(true);
+    expect(isConfident("ask", 1.0)).toBe(true);
+    expect(isConfident("mixed", 1.0)).toBe(true);
+    expect(isConfident("meta", 1.0)).toBe(true);
+  });
+
+  // ─── Asymmetric thresholds: capture requires higher confidence ─────────
+
+  it("capture is stricter than ask (0.85 > 0.70)", () => {
+    // 0.72: passes ask threshold but fails capture
+    expect(isConfident("ask", 0.72)).toBe(true);
+    expect(isConfident("capture", 0.72)).toBe(false);
+  });
+
+  // ─── Custom thresholds ────────────────────────────────────────────────
+
+  it("accepts custom thresholds", () => {
+    const custom: ClassifierThresholds = {
+      capture: 0.5,
+      ask: 0.5,
+      mixed: 0.5,
+      meta: 0.5,
+    };
+    expect(isConfident("capture", 0.5, custom)).toBe(true);
+    expect(isConfident("capture", 0.49, custom)).toBe(false);
+  });
+
+  // ─── Unknown label ────────────────────────────────────────────────────
+
+  it("returns false for an unknown label", () => {
+    expect(isConfident("unknown" as any, 0.9)).toBe(false);
+  });
+
+  // ─── Default thresholds are the documented anchor values ──────────────
+
+  it("DEFAULT_CLASSIFIER_THRESHOLDS match the documented anchors", () => {
+    expect(DEFAULT_CLASSIFIER_THRESHOLDS).toEqual({
+      capture: 0.85,
+      ask: 0.70,
+      mixed: 0.75,
+      meta: 0.70,
+    });
+  });
+});

--- a/src/services/classifier-thresholds.ts
+++ b/src/services/classifier-thresholds.ts
@@ -1,0 +1,33 @@
+/**
+ * Confidence threshold gating — issue #77.
+ *
+ * Pure-function check against the asymmetric per-label thresholds
+ * documented in planning/classifier.md §"Confidence thresholds".
+ *
+ * #77
+ */
+
+import {
+  ClassifierThresholds,
+  DEFAULT_CLASSIFIER_THRESHOLDS,
+  IntentLabel,
+} from "../contracts/classifier";
+
+/**
+ * Check whether a classifier output's confidence meets the threshold
+ * for the given label.
+ *
+ * Returns `true` when confidence >= threshold.  Returns `false` for
+ * unknown labels and for any confidence below the label's threshold.
+ *
+ * The caller uses `false` to trigger the disambiguation chip.
+ */
+export function isConfident(
+  label: IntentLabel,
+  confidence: number,
+  thresholds: ClassifierThresholds = DEFAULT_CLASSIFIER_THRESHOLDS,
+): boolean {
+  const t = thresholds[label];
+  if (t === undefined) return false;
+  return confidence >= t;
+}


### PR DESCRIPTION
Closes #77

- Add ClassifierThresholds interface + DEFAULT_CLASSIFIER_THRESHOLDS anchor values (capture 0.85, ask 0.70, mixed 0.75, meta 0.70)
- Add needsDisambiguation + fallbackReason fields to ClassifierDecision
- isConfident() pure function with per-label threshold check
- 15 tests: all 4 label boundaries, asymmetry validation, custom thresholds, edge cases
- 356 tests pass, tsc clean