### PR TITLE
feat(classifier): confidence thresholds + route decisions (#77, #79)

### DIFF
--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -172,3 +172,50 @@ export interface ClassifierEventWriter {
   writeDecision(row: ClassifierDecisionRow): Promise<void>;
   writeDisambiguation(row: ClassifierDisambiguationRow): Promise<void>;
 }
+
+// ─── Route decision (#79) ──────────────────────────────────────────────
+
+/**
+ * Result of running the full classifier pipeline (skip router → LLM →
+ * confidence check) against a single turn.  Returned by the classifier
+ * orchestrator and consumed by the turn router to dispatch into the
+ * ingest / query / meta state machines.
+ */
+export interface RouteDecision {
+  /** Owning turn id so the caller does not need to thread it separately. */
+  turnId: string;
+
+  /**
+   * Final intent label after all processing.
+   * - `null` when the skip router returned an error (empty message).
+   * - `"meta"` when the orchestrator short-circuits to help.
+   * - Otherwise the validated or fallback label.
+   */
+  label: IntentLabel | null;
+
+  /**
+   * Full classifier decision for the turn inspector and the event log.
+   * Always populated — even for empty-message errors, so the inspector
+   * can show the attempted classification.
+   */
+  decision: ClassifierDecision;
+
+  /**
+   * True when the confidence is below the active threshold and the
+   * disambiguation chip should be shown to the user.  Always false for
+   * skip-path decisions and true for LLM fallbacks (null output).
+   */
+  needsDisambiguation: boolean;
+
+  /**
+   * True when the orchestrator should short-circuit the main tool loop
+   * and render a response directly (currently only `"meta"`).
+   */
+  shortCircuit: boolean;
+
+  /**
+   * Static help text rendered when `shortCircuit` is true.  Undefined
+   * for non-meta routes.
+   */
+  helpResponse?: string;
+}

--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -77,6 +77,26 @@ export type PresetCommand =
   | "cowork.capture-active-note"
   | "cowork.ask-about-active-note";
 
+// ─── Confidence thresholds ────────────────────────────────────────────
+
+/** Per-label confidence thresholds. When confidence falls below the
+ *  label's threshold, the disambiguation chip is shown. */
+export interface ClassifierThresholds {
+  capture: number;
+  ask: number;
+  mixed: number;
+  meta: number;
+}
+
+/** Anchor values from planning/classifier.md §"Confidence thresholds".
+ *  Committed values land after the first golden-set run during M1. */
+export const DEFAULT_CLASSIFIER_THRESHOLDS: ClassifierThresholds = {
+  capture: 0.85,
+  ask: 0.70,
+  mixed: 0.75,
+  meta: 0.70,
+};
+
 // ─── Decision log entry (upstream of #19 event-log schema) ────────────
 
 /** Source of a classifier decision. "skip" means a hard signal pre-empted
@@ -97,6 +117,18 @@ export interface ClassifierDecision {
    * "ctrl-enter", "leading-question-mark".
    */
   skipReason: SkipReason | null;
+  /**
+   * True when the confidence is below the active threshold and the
+   * disambiguation chip should be shown.  Always false for skip-path
+   * decisions and true for LLM fallbacks (null output).
+   */
+  needsDisambiguation: boolean;
+  /**
+   * Reason for LLM fallback — set when output is null and the LLM call
+   * failed (timeout, unparseable, invalid-label, invalid-confidence).
+   * Null for skip-path decisions and successful LLM calls.
+   */
+  fallbackReason: "timeout" | "unparseable" | "invalid-label" | "invalid-confidence" | null;
 }
 
 // ─── Event-log rows (#19) ─────────────────────────────────────────────

--- a/src/services/classifier-orchestrator.test.ts
+++ b/src/services/classifier-orchestrator.test.ts
@@ -1,0 +1,488 @@
+import { describe, expect, it } from "vitest";
+import { classifyTurn, ClassifyTurnInput, ClassifyTurnDeps } from "./classifier-orchestrator";
+import { ClassifierInput, ClassifierThresholds, DEFAULT_CLASSIFIER_THRESHOLDS, RouteDecision, IntentLabel } from "../contracts/classifier";
+import { LLMService, LLMResponse } from "../contracts/llm";
+import { LoadedPrompt, PromptLoader } from "../contracts/prompts";
+import { InMemoryClassifierEventWriter } from "./classifier-events";
+import { ClassifierError } from "./classifier-llm";
+import { META_HELP_RESPONSE } from "./help-content";
+
+// ─── Test helpers ──────────────────────────────────────────────────────
+
+const TEST_PROMPT: LoadedPrompt = {
+  id: "intent-classifier",
+  version: "0.1.0",
+  body: `{{messageText}}\n{{attachmentList}}\n{{activeFileLine}}\n{{recentTurnList}}`,
+};
+
+function makePromptLoader(prompt: LoadedPrompt = TEST_PROMPT): PromptLoader {
+  return { load: async () => prompt, invalidate: () => {} };
+}
+
+function makeInput(overrides: Partial<ClassifyTurnInput> = {}): ClassifyTurnInput {
+  return {
+    messageText: "Save this note about project alpha",
+    attachments: [],
+    activeFile: null,
+    recentTurns: [],
+    ...overrides,
+  };
+}
+
+function validJson(label = "capture", confidence = 0.9, rationale = "Test rationale.") {
+  return JSON.stringify({ label, confidence, rationale });
+}
+
+function makeJsonLLM(content: string, throwErr?: Error): LLMService {
+  return {
+    chat: async (opts) => {
+      expect(opts.format).toBe("json");
+      expect(opts.stream).toBe(false);
+      if (throwErr) throw throwErr;
+      return { content } as LLMResponse;
+    },
+    isReachable: async () => "running",
+    listModels: async () => ["gemma3:latest"],
+    pickDefaultModel: async () => "gemma3:latest",
+  };
+}
+
+function makeDeps(
+  overrides: Partial<ClassifyTurnDeps> = {},
+): ClassifyTurnDeps {
+  return {
+    llm: makeJsonLLM(validJson()),
+    promptLoader: makePromptLoader(),
+    eventWriter: new InMemoryClassifierEventWriter(),
+    ...overrides,
+  };
+}
+
+// ─── Skip router path ──────────────────────────────────────────────────
+
+describe("classifyTurn — skip router", () => {
+  it("returns error for empty message with no attachments", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(
+      { messageText: "", attachments: [], activeFile: null, recentTurns: [] },
+      deps,
+      "turn-1",
+    );
+    expect(result.label).toBeNull();
+    expect(result.decision.source).toBe("skip");
+    expect(result.needsDisambiguation).toBe(false);
+    expect(result.shortCircuit).toBe(false);
+  });
+
+  it("skips to capture for attachment-only messages", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(
+      { messageText: "", attachments: [{ kind: "image", filename: "photo.png" }], activeFile: null, recentTurns: [] },
+      deps,
+      "turn-2",
+    );
+    expect(result.label).toBe("capture");
+    expect(result.decision.source).toBe("skip");
+    expect(result.decision.skipReason).toBe("attachment-only");
+    expect(result.decision.output?.confidence).toBe(1.0);
+    expect(result.needsDisambiguation).toBe(false);
+    expect(result.shortCircuit).toBe(false);
+  });
+
+  it("skips to capture for capture-selection command", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(
+      { messageText: "selected text", attachments: [], activeFile: null, recentTurns: [], presetCommand: "cowork.capture-selection" },
+      deps,
+      "turn-3",
+    );
+    expect(result.label).toBe("capture");
+    expect(result.decision.source).toBe("skip");
+    expect(result.decision.skipReason).toBe("command-capture");
+  });
+
+  it("skips to capture for capture-active-note command", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(
+      { messageText: "active note", attachments: [], activeFile: null, recentTurns: [], presetCommand: "cowork.capture-active-note" },
+      deps,
+      "turn-4",
+    );
+    expect(result.label).toBe("capture");
+    expect(result.decision.skipReason).toBe("command-capture");
+  });
+
+  it("skips to ask for ask-about-active-note command", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(
+      { messageText: "summarize this", attachments: [], activeFile: null, recentTurns: [], presetCommand: "cowork.ask-about-active-note" },
+      deps,
+      "turn-5",
+    );
+    expect(result.label).toBe("ask");
+    expect(result.decision.source).toBe("skip");
+    expect(result.decision.skipReason).toBe("command-ask");
+  });
+
+  it("skips to capture for Ctrl+Enter", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(
+      { messageText: "some content", attachments: [], activeFile: null, recentTurns: [], ctrlEnter: true },
+      deps,
+      "turn-6",
+    );
+    expect(result.label).toBe("capture");
+    expect(result.decision.skipReason).toBe("ctrl-enter");
+  });
+
+  it("skips to ask for leading ? and strips the marker", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(
+      { messageText: "?what is the project status", attachments: [], activeFile: null, recentTurns: [] },
+      deps,
+      "turn-7",
+    );
+    expect(result.label).toBe("ask");
+    expect(result.decision.skipReason).toBe("leading-question-mark");
+    // Input should have the stripped text (no leading ?)
+    expect(result.decision.input.messageText).toBe("what is the project status");
+  });
+
+  it("writes a decision event for skip paths", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    const deps = makeDeps({ eventWriter: writer });
+    await classifyTurn(
+      { messageText: "", attachments: [{ kind: "pdf", filename: "doc.pdf" }], activeFile: null, recentTurns: [] },
+      deps,
+      "turn-write",
+    );
+    expect(writer.decisions).toHaveLength(1);
+    expect(writer.decisions[0].source).toBe("skip");
+    expect(writer.decisions[0].turn_id).toBe("turn-write");
+    expect(writer.decisions[0].skip_reason).toBe("attachment-only");
+  });
+});
+
+// ─── LLM path — happy ──────────────────────────────────────────────────
+
+describe("classifyTurn — LLM happy path", () => {
+  it("classifies capture with high confidence", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("capture", 0.9)) });
+    const result = await classifyTurn(makeInput({ messageText: "Save this note" }), deps, "turn-10");
+    expect(result.label).toBe("capture");
+    expect(result.decision.source).toBe("llm");
+    expect(result.decision.output?.label).toBe("capture");
+    expect(result.decision.output?.confidence).toBe(0.9);
+    expect(result.needsDisambiguation).toBe(false);
+    expect(result.shortCircuit).toBe(false);
+  });
+
+  it("classifies ask with high confidence", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("ask", 0.95)) });
+    const result = await classifyTurn(makeInput({ messageText: "What are the key points?" }), deps, "turn-11");
+    expect(result.label).toBe("ask");
+    expect(result.decision.source).toBe("llm");
+    expect(result.needsDisambiguation).toBe(false);
+  });
+
+  it("classifies mixed with high confidence", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("mixed", 0.88)) });
+    const result = await classifyTurn(makeInput({ messageText: "Save this and tell me about related notes" }), deps, "turn-12");
+    expect(result.label).toBe("mixed");
+    expect(result.needsDisambiguation).toBe(false);
+  });
+
+  it("classifies meta with high confidence and short-circuits with help", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("meta", 0.85)) });
+    const result = await classifyTurn(makeInput({ messageText: "help" }), deps, "turn-13");
+    expect(result.label).toBe("meta");
+    expect(result.shortCircuit).toBe(true);
+    expect(result.helpResponse).toBe(META_HELP_RESPONSE);
+    expect(result.needsDisambiguation).toBe(false);
+  });
+
+  it("sets needsDisambiguation when confidence is below threshold", async () => {
+    // capture threshold is 0.85, confidence 0.84 should trigger
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("capture", 0.84)) });
+    const result = await classifyTurn(makeInput(), deps, "turn-14");
+    expect(result.label).toBe("capture");
+    expect(result.needsDisambiguation).toBe(true);
+    expect(result.decision.needsDisambiguation).toBe(true);
+  });
+
+  it("ask threshold is lower than capture (0.70 vs 0.85)", async () => {
+    // ask threshold is 0.70, confidence 0.75 should be confident
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("ask", 0.75)) });
+    const result = await classifyTurn(makeInput(), deps, "turn-15");
+    expect(result.label).toBe("ask");
+    expect(result.needsDisambiguation).toBe(false);
+  });
+
+  it("capture at exactly threshold is confident", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("capture", 0.85)) });
+    const result = await classifyTurn(makeInput(), deps, "turn-16");
+    expect(result.needsDisambiguation).toBe(false);
+  });
+
+  it("uses custom thresholds when provided", async () => {
+    const customThresholds: ClassifierThresholds = { capture: 0.95, ask: 0.80, mixed: 0.85, meta: 0.80 };
+    const deps = makeDeps({
+      llm: makeJsonLLM(validJson("capture", 0.94)),
+      thresholds: customThresholds,
+    });
+    const result = await classifyTurn(makeInput(), deps, "turn-17");
+    expect(result.needsDisambiguation).toBe(true); // 0.94 < 0.95
+  });
+
+  it("tags the decision with the prompt version", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson()) });
+    const result = await classifyTurn(makeInput(), deps, "turn-18");
+    expect(result.decision.promptVersion).toBe("0.1.0");
+  });
+
+  it("writes a decision event for LLM paths", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("ask", 0.9)), eventWriter: writer });
+    await classifyTurn(makeInput(), deps, "turn-19");
+    expect(writer.decisions).toHaveLength(1);
+    expect(writer.decisions[0].source).toBe("llm");
+    expect(writer.decisions[0].turn_id).toBe("turn-19");
+    expect(writer.decisions[0].label).toBe("ask");
+    expect(writer.decisions[0].confidence).toBe(0.9);
+  });
+});
+
+// ─── LLM path — fallback ───────────────────────────────────────────────
+
+describe("classifyTurn — LLM fallback", () => {
+  it("routes to ask on timeout fallback", async () => {
+    const error = new ClassifierError("timed out", "timeout", undefined, "0.1.0");
+    const deps = makeDeps({ llm: makeJsonLLM("", error) });
+    const result = await classifyTurn(makeInput(), deps, "turn-20");
+    expect(result.label).toBe("ask");
+    expect(result.decision.fallbackReason).toBe("timeout");
+    expect(result.needsDisambiguation).toBe(true);
+  });
+
+  it("routes to ask on unparseable fallback", async () => {
+    const error = new ClassifierError("invalid json", "unparseable", "{bad", "0.1.0");
+    const deps = makeDeps({ llm: makeJsonLLM("", error) });
+    const result = await classifyTurn(makeInput(), deps, "turn-21");
+    expect(result.label).toBe("ask");
+    expect(result.decision.fallbackReason).toBe("unparseable");
+    expect(result.needsDisambiguation).toBe(true);
+  });
+
+  it("routes to ask on invalid-label fallback", async () => {
+    const error = new ClassifierError("bad label", "invalid-label", '{"label":"unknown"}', "0.1.0");
+    const deps = makeDeps({ llm: makeJsonLLM("", error) });
+    const result = await classifyTurn(makeInput(), deps, "turn-22");
+    expect(result.label).toBe("ask");
+    expect(result.decision.fallbackReason).toBe("invalid-label");
+  });
+
+  it("routes to ask on invalid-confidence fallback", async () => {
+    const error = new ClassifierError("bad range", "invalid-confidence", '{"label":"capture","confidence":2}', "0.1.0");
+    const deps = makeDeps({ llm: makeJsonLLM("", error) });
+    const result = await classifyTurn(makeInput(), deps, "turn-23");
+    expect(result.label).toBe("ask");
+    expect(result.decision.fallbackReason).toBe("invalid-confidence");
+  });
+
+  it("re-throws transport errors", async () => {
+    const error = new ClassifierError("connection refused", "transport", undefined, "0.1.0");
+    const deps = makeDeps({ llm: makeJsonLLM("", error) });
+    await expect(
+      classifyTurn(makeInput(), deps, "turn-24"),
+    ).rejects.toThrow("connection refused");
+  });
+
+  it("writes a decision event on fallback", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    const error = new ClassifierError("timed out", "timeout", undefined, "0.1.0");
+    const deps = makeDeps({ llm: makeJsonLLM("", error), eventWriter: writer });
+    await classifyTurn(makeInput(), deps, "turn-fallback");
+    expect(writer.decisions).toHaveLength(1);
+    expect(writer.decisions[0].source).toBe("llm");
+    expect(writer.decisions[0].label).toBeNull();
+    expect(writer.decisions[0].confidence).toBeNull();
+  });
+});
+
+// ─── Mixed intent (acceptance criterion) ───────────────────────────────
+
+describe("classifyTurn — mixed intent", () => {
+  it("returns mixed label for mixed intent (caller dispatches ingest→query)", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("mixed", 0.88)) });
+    const result = await classifyTurn(
+      makeInput({ messageText: "Log this idea and find similar notes" }),
+      deps,
+      "turn-30",
+    );
+    expect(result.label).toBe("mixed");
+    // The orchestrator returns the mixed label; the turn router / tool
+    // loop is responsible for running ingest then query in sequence.
+    expect(result.shortCircuit).toBe(false);
+    expect(result.needsDisambiguation).toBe(false);
+  });
+});
+
+// ─── Meta short-circuit (acceptance criterion) ──────────────────────────
+
+describe("classifyTurn — meta short-circuit", () => {
+  it("short-circuits with help response for meta intent", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("meta", 0.90)) });
+    const result = await classifyTurn(makeInput({ messageText: "what can you do" }), deps, "turn-40");
+    expect(result.label).toBe("meta");
+    expect(result.shortCircuit).toBe(true);
+    expect(result.helpResponse).toBeDefined();
+    expect(result.helpResponse!.length).toBeGreaterThan(0);
+  });
+
+  it("does not short-circuit for non-meta labels", async () => {
+    const labels: IntentLabel[] = ["capture", "ask", "mixed"];
+    for (const label of labels) {
+      const deps = makeDeps({ llm: makeJsonLLM(validJson(label, 0.95)) });
+      const result = await classifyTurn(makeInput(), deps, `turn-meta-${label}`);
+      expect(result.shortCircuit).toBe(false);
+      expect(result.helpResponse).toBeUndefined();
+    }
+  });
+});
+
+// ─── Turn record attachment (acceptance criterion) ─────────────────────
+
+describe("classifyTurn — turn record attachment", () => {
+  it("attaches the full decision to the route for the turn inspector", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("ask", 0.78)) });
+    const result = await classifyTurn(makeInput({ messageText: "find meeting notes" }), deps, "turn-50");
+
+    // The decision is attached to the route so the inspector can read it.
+    expect(result.decision).toBeDefined();
+    expect(result.decision.source).toBe("llm");
+    expect(result.decision.input.messageText).toBe("find meeting notes");
+    expect(result.decision.output?.label).toBe("ask");
+    expect(result.decision.output?.confidence).toBe(0.78);
+    expect(result.decision.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.decision.promptVersion).toBe("0.1.0");
+  });
+
+  it("turnId is threaded through the route decision", async () => {
+    const deps = makeDeps();
+    const result = await classifyTurn(makeInput(), deps, "my-turn-id");
+    expect(result.turnId).toBe("my-turn-id");
+  });
+
+  it("decision row written for downstream inspector consumption", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("capture", 0.91)), eventWriter: writer });
+    await classifyTurn(makeInput({ messageText: "save meeting log" }), deps, "turn-52");
+
+    expect(writer.decisions).toHaveLength(1);
+    const row = writer.decisions[0];
+    expect(row.turn_id).toBe("turn-52");
+    expect(row.source).toBe("llm");
+    expect(row.label).toBe("capture");
+    expect(row.confidence).toBe(0.91);
+    // input_json / output_json are serialised for DuckDB storage.
+    const parsedInput = JSON.parse(row.input_json);
+    expect(parsedInput.messageText).toBe("save meeting log");
+    const parsedOutput = JSON.parse(row.output_json!);
+    expect(parsedOutput.label).toBe("capture");
+  });
+});
+
+// ─── Preset command + leading-? input fidelity ─────────────────────────
+
+describe("classifyTurn — input fidelity", () => {
+  it("preserves attachments in the decision input", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson()) });
+    const result = await classifyTurn(
+      makeInput({
+        messageText: "Save these",
+        attachments: [{ kind: "pdf", filename: "report.pdf" }, { kind: "image", filename: "chart.png" }],
+      }),
+      deps,
+      "turn-60",
+    );
+    expect(result.decision.input.attachments).toHaveLength(2);
+    expect(result.decision.input.attachments[0].filename).toBe("report.pdf");
+  });
+
+  it("preserves active file in the decision input", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson()) });
+    const result = await classifyTurn(
+      makeInput({ activeFile: { filename: "projects.md", title: "Projects" } }),
+      deps,
+      "turn-61",
+    );
+    expect(result.decision.input.activeFile?.filename).toBe("projects.md");
+  });
+
+  it("slices recent turns to last 3", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson()) });
+    const recent = [
+      { text: "turn 1", intent: "capture" as const },
+      { text: "turn 2", intent: "ask" as const },
+      { text: "turn 3", intent: "ask" as const },
+      { text: "turn 4", intent: "capture" as const },
+    ];
+    const result = await classifyTurn(makeInput({ recentTurns: recent }), deps, "turn-62");
+    expect(result.decision.input.recentTurns).toHaveLength(3);
+    expect(result.decision.input.recentTurns[0].text).toBe("turn 2");
+  });
+});
+
+// ─── Event writer integration ──────────────────────────────────────────
+
+describe("classifyTurn — event writer integration", () => {
+  it("writes one decision row per classification", async () => {
+    const writer = new InMemoryClassifierEventWriter();
+    const deps = makeDeps({ eventWriter: writer, llm: makeJsonLLM(validJson()) });
+
+    await classifyTurn(makeInput({ messageText: "first" }), deps, "turn-a");
+    await classifyTurn(makeInput({ messageText: "second" }), deps, "turn-b");
+    await classifyTurn(
+      { messageText: "", attachments: [{ kind: "text", filename: "note.txt" }], activeFile: null, recentTurns: [] },
+      deps,
+      "turn-c",
+    );
+
+    expect(writer.decisions).toHaveLength(3);
+    expect(writer.decisions.map((d) => d.turn_id)).toEqual(["turn-a", "turn-b", "turn-c"]);
+    expect(writer.decisions[0].source).toBe("llm");
+    expect(writer.decisions[1].source).toBe("llm");
+    expect(writer.decisions[2].source).toBe("skip");
+  });
+});
+
+// ─── Integration: full pipeline ────────────────────────────────────────
+
+describe("classifyTurn — full pipeline integration", () => {
+  it("prefers skip router over LLM when both could match", async () => {
+    // Leading "?" takes precedence — no LLM call made.
+    let llmCalled = false;
+    const llm: LLMService = {
+      chat: async () => { llmCalled = true; return { content: validJson() } as LLMResponse; },
+      isReachable: async () => "running",
+      listModels: async () => ["gemma3:latest"],
+      pickDefaultModel: async () => "gemma3:latest",
+    };
+    const deps = makeDeps({ llm });
+    const result = await classifyTurn(
+      { messageText: "?what is this", attachments: [], activeFile: null, recentTurns: [] },
+      deps,
+      "turn-skip-first",
+    );
+    expect(result.label).toBe("ask");
+    expect(result.decision.source).toBe("skip");
+    expect(llmCalled).toBe(false);
+  });
+
+  it("falls through to LLM when skip router returns null", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("ask", 0.95)) });
+    const result = await classifyTurn(makeInput({ messageText: "no skip triggers here" }), deps, "turn-fallthrough");
+    expect(result.decision.source).toBe("llm");
+    expect(result.label).toBe("ask");
+  });
+});

--- a/src/services/classifier-orchestrator.ts
+++ b/src/services/classifier-orchestrator.ts
@@ -1,0 +1,306 @@
+/**
+ * Classifier orchestrator — issue #79.
+ *
+ * Wires the full classifier pipeline (skip router → LLM call → retries →
+ * confidence thresholds → event writing) into a single `classifyTurn`
+ * function that produces a `RouteDecision` for the turn router.
+ *
+ * This is the integration point between the classifier sub-system and the
+ * tool loop.  The caller (view.ts / main.ts) calls `classifyTurn` on every
+ * user submission, then dispatches the returned `RouteDecision` to the
+ * appropriate state machine or renders the meta help response.
+ *
+ * #79
+ */
+
+import {
+  Attachment,
+  ActiveFile,
+  RecentTurn,
+  PresetCommand,
+  ClassifierDecision,
+  ClassifierInput,
+  ClassifierSource,
+  ClassifierThresholds,
+  DEFAULT_CLASSIFIER_THRESHOLDS,
+  IntentLabel,
+  RouteDecision,
+  SkipReason,
+} from "../contracts/classifier";
+import { LLMService } from "../contracts/llm";
+import { PromptLoader } from "../contracts/prompts";
+import { ClassifierEventWriter } from "../contracts/classifier";
+import { classifySkipRouter } from "./classifier-skip-router";
+import { classifyWithRetries } from "./classifier-retries";
+import { isConfident } from "./classifier-thresholds";
+import { prepareClassifierInput } from "./classifier-utils";
+import { toDecisionRow } from "./classifier-events";
+import { META_HELP_RESPONSE } from "./help-content";
+
+// ─── Orchestrator input ────────────────────────────────────────────────
+
+/** Raw input received from the chat view / composer. */
+export interface ClassifyTurnInput {
+  messageText: string;
+  attachments: Attachment[];
+  activeFile: ActiveFile | null;
+  recentTurns: RecentTurn[];
+  ctrlEnter?: boolean;
+  presetCommand?: PresetCommand;
+}
+
+/** Dependencies required by the classifier orchestrator. */
+export interface ClassifyTurnDeps {
+  llm: LLMService;
+  promptLoader: PromptLoader;
+  eventWriter: ClassifierEventWriter;
+  thresholds?: ClassifierThresholds;
+}
+
+// ─── Orchestrator ──────────────────────────────────────────────────────
+
+/**
+ * Run the full classifier pipeline against a single turn.
+ *
+ * Pipeline:
+ *   1. Skip router — hard signals that pre-empt the LLM.
+ *   2. Input preparation — truncation + recent-turns slice.
+ *   3. LLM call (with retry budget) — Ollama classification.
+ *   4. Confidence gating — asymmetric per-label thresholds.
+ *   5. Event writing — decision row written regardless of outcome.
+ *   6. Meta short-circuit — help response returned directly.
+ *
+ * Returns `RouteDecision` with the final label, the full decision object
+ * for the turn inspector, and any disambiguation / short-circuit flags.
+ *
+ * Transport errors are re-thrown — the caller must surface an Ollama-error
+ * Notice.  All other classifier errors are encoded in the decision.
+ */
+export async function classifyTurn(
+  input: ClassifyTurnInput,
+  deps: ClassifyTurnDeps,
+  turnId: string,
+): Promise<RouteDecision> {
+  const start = performance.now();
+  const thresholds = deps.thresholds ?? DEFAULT_CLASSIFIER_THRESHOLDS;
+
+  // ── 1. Skip router ──────────────────────────────────────────────────
+
+  const skipResult = classifySkipRouter({
+    messageText: input.messageText,
+    attachments: input.attachments,
+    ctrlEnter: input.ctrlEnter,
+    presetCommand: input.presetCommand,
+  });
+
+  if (skipResult !== null) {
+    return handleSkip(skipResult, input, turnId, start, deps);
+  }
+
+  // ── 2. LLM classification ───────────────────────────────────────────
+
+  return handleLLM(input, turnId, start, deps, thresholds);
+}
+
+// ─── Skip path ─────────────────────────────────────────────────────────
+
+async function handleSkip(
+  result: NonNullable<ReturnType<typeof classifySkipRouter>>,
+  input: ClassifyTurnInput,
+  turnId: string,
+  start: number,
+  deps: ClassifyTurnDeps,
+): Promise<RouteDecision> {
+  // Empty message with no attachments — error, no label.
+  if (result.kind === "error") {
+    const decision = makeDecision({
+      source: "skip",
+      input: { messageText: "", truncated: false, attachments: [], activeFile: null, recentTurns: [] },
+      label: null,
+      confidence: null,
+      latencyMs: Math.round(performance.now() - start),
+      promptVersion: "",
+      skipReason: null,
+      fallbackReason: null,
+      needsDisambiguation: false,
+    });
+    return {
+      turnId,
+      label: null,
+      decision,
+      needsDisambiguation: false,
+      shortCircuit: false,
+    };
+  }
+
+  // Hard-signal skip — bypass LLM, label is always confident.
+  const classifierInput = prepareClassifierInput({
+    messageText: result.strippedText ?? input.messageText,
+    attachments: input.attachments,
+    activeFile: input.activeFile,
+    recentTurns: input.recentTurns,
+  });
+
+  const decision = makeDecision({
+    source: "skip",
+    input: classifierInput,
+    label: result.label,
+    confidence: 1.0,
+    latencyMs: Math.round(performance.now() - start),
+    promptVersion: "",
+    skipReason: result.reason,
+    fallbackReason: null,
+    needsDisambiguation: false,
+  });
+
+  // Meta from skip router is not possible in the current taxonomy —
+  // skip conditions only produce capture or ask.
+  const isMeta = result.label === "meta";
+
+  await writeDecisionEvent(turnId, decision, deps.eventWriter);
+
+  return {
+    turnId,
+    label: result.label,
+    decision,
+    needsDisambiguation: false,
+    shortCircuit: isMeta,
+    helpResponse: isMeta ? META_HELP_RESPONSE : undefined,
+  };
+}
+
+// ─── LLM path ──────────────────────────────────────────────────────────
+
+async function handleLLM(
+  input: ClassifyTurnInput,
+  turnId: string,
+  start: number,
+  deps: ClassifyTurnDeps,
+  thresholds: ClassifierThresholds,
+): Promise<RouteDecision> {
+  const classifierInput = prepareClassifierInput({
+    messageText: input.messageText,
+    attachments: input.attachments,
+    activeFile: input.activeFile,
+    recentTurns: input.recentTurns,
+  });
+
+  let result: Awaited<ReturnType<typeof classifyWithRetries>>;
+  try {
+    result = await classifyWithRetries(classifierInput, {
+      llm: deps.llm,
+      promptLoader: deps.promptLoader,
+    });
+  } catch (err) {
+    // Transport errors — re-throw for the caller to surface a Notice.
+    throw err;
+  }
+
+  const latencyMs = result.latencyMs;
+
+  // ── Fallback (null output) ────────────────────────────────────────
+
+  if (result.output === null) {
+    const decision = makeDecision({
+      source: "llm",
+      input: classifierInput,
+      label: null,
+      confidence: null,
+      latencyMs,
+      promptVersion: result.promptVersion,
+      skipReason: null,
+      fallbackReason: result.fallbackReason ?? null,
+      needsDisambiguation: true,
+    });
+
+    await writeDecisionEvent(turnId, decision, deps.eventWriter);
+
+    return {
+      turnId,
+      // Fallback: route to "ask" so the user at least gets a query
+      // attempt rather than a silent failure.  The disambiguation chip
+      // is shown because we have no confident label.
+      label: "ask",
+      decision,
+      needsDisambiguation: true,
+      shortCircuit: false,
+    };
+  }
+
+  // ── Success ───────────────────────────────────────────────────────
+
+  const { label, confidence } = result.output;
+  const confident = isConfident(label, confidence, thresholds);
+  const isMeta = label === "meta";
+
+  const decision = makeDecision({
+    source: "llm",
+    input: classifierInput,
+    label,
+    confidence,
+    latencyMs,
+    promptVersion: result.promptVersion,
+    skipReason: null,
+    fallbackReason: null,
+    needsDisambiguation: !confident,
+  });
+
+  await writeDecisionEvent(turnId, decision, deps.eventWriter);
+
+  return {
+    turnId,
+    label,
+    decision,
+    needsDisambiguation: !confident,
+    shortCircuit: isMeta,
+    helpResponse: isMeta ? META_HELP_RESPONSE : undefined,
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+interface MakeDecisionParams {
+  source: ClassifierSource;
+  input: ClassifierInput;
+  label: IntentLabel | null;
+  confidence: number | null;
+  latencyMs: number;
+  promptVersion: string;
+  skipReason: SkipReason | null;
+  fallbackReason: ClassifierDecision["fallbackReason"];
+  needsDisambiguation: boolean;
+}
+
+function makeDecision(params: MakeDecisionParams): ClassifierDecision {
+  return {
+    source: params.source,
+    input: params.input,
+    output:
+      params.label && params.confidence !== null
+        ? { label: params.label, confidence: params.confidence, rationale: "" }
+        : null,
+    latencyMs: params.latencyMs,
+    promptVersion: params.promptVersion,
+    skipReason: params.skipReason,
+    needsDisambiguation: params.needsDisambiguation,
+    fallbackReason: params.fallbackReason,
+  };
+}
+
+async function writeDecisionEvent(
+  turnId: string,
+  decision: ClassifierDecision,
+  writer: ClassifierEventWriter,
+): Promise<void> {
+  const row = toDecisionRow(turnId, {
+    source: decision.source,
+    skipReason: decision.skipReason,
+    promptVersion: decision.promptVersion,
+    latencyMs: decision.latencyMs,
+    input: decision.input,
+    output: decision.output,
+    confidence: decision.output?.confidence ?? null,
+    label: decision.output?.label ?? null,
+  });
+  await writer.writeDecision(row);
+}

--- a/src/services/classifier-thresholds.test.ts
+++ b/src/services/classifier-thresholds.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { isConfident } from "./classifier-thresholds";
+import {
+  ClassifierThresholds,
+  DEFAULT_CLASSIFIER_THRESHOLDS,
+} from "../contracts/classifier";
+
+describe("isConfident", () => {
+  // ─── Default thresholds ───────────────────────────────────────────────
+
+  it("capture threshold 0.85: confident at exactly 0.85", () => {
+    expect(isConfident("capture", 0.85)).toBe(true);
+  });
+
+  it("capture threshold 0.85: not confident below", () => {
+    expect(isConfident("capture", 0.849)).toBe(false);
+  });
+
+  it("capture threshold 0.85: confident above", () => {
+    expect(isConfident("capture", 0.86)).toBe(true);
+  });
+
+  it("ask threshold 0.70: confident at exactly 0.70", () => {
+    expect(isConfident("ask", 0.70)).toBe(true);
+  });
+
+  it("ask threshold 0.70: not confident below", () => {
+    expect(isConfident("ask", 0.699)).toBe(false);
+  });
+
+  it("mixed threshold 0.75: confident at exactly 0.75", () => {
+    expect(isConfident("mixed", 0.75)).toBe(true);
+  });
+
+  it("mixed threshold 0.75: not confident below", () => {
+    expect(isConfident("mixed", 0.749)).toBe(false);
+  });
+
+  it("meta threshold 0.70: confident at exactly 0.70", () => {
+    expect(isConfident("meta", 0.70)).toBe(true);
+  });
+
+  it("meta threshold 0.70: not confident below", () => {
+    expect(isConfident("meta", 0.699)).toBe(false);
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────
+
+  it("returns false for confidence 0", () => {
+    expect(isConfident("ask", 0)).toBe(false);
+  });
+
+  it("returns true for confidence 1.0 on any label", () => {
+    expect(isConfident("capture", 1.0)).toBe(true);
+    expect(isConfident("ask", 1.0)).toBe(true);
+    expect(isConfident("mixed", 1.0)).toBe(true);
+    expect(isConfident("meta", 1.0)).toBe(true);
+  });
+
+  // ─── Asymmetric thresholds: capture requires higher confidence ─────────
+
+  it("capture is stricter than ask (0.85 > 0.70)", () => {
+    // 0.72: passes ask threshold but fails capture
+    expect(isConfident("ask", 0.72)).toBe(true);
+    expect(isConfident("capture", 0.72)).toBe(false);
+  });
+
+  // ─── Custom thresholds ────────────────────────────────────────────────
+
+  it("accepts custom thresholds", () => {
+    const custom: ClassifierThresholds = {
+      capture: 0.5,
+      ask: 0.5,
+      mixed: 0.5,
+      meta: 0.5,
+    };
+    expect(isConfident("capture", 0.5, custom)).toBe(true);
+    expect(isConfident("capture", 0.49, custom)).toBe(false);
+  });
+
+  // ─── Unknown label ────────────────────────────────────────────────────
+
+  it("returns false for an unknown label", () => {
+    expect(isConfident("unknown" as any, 0.9)).toBe(false);
+  });
+
+  // ─── Default thresholds are the documented anchor values ──────────────
+
+  it("DEFAULT_CLASSIFIER_THRESHOLDS match the documented anchors", () => {
+    expect(DEFAULT_CLASSIFIER_THRESHOLDS).toEqual({
+      capture: 0.85,
+      ask: 0.70,
+      mixed: 0.75,
+      meta: 0.70,
+    });
+  });
+});

--- a/src/services/classifier-thresholds.ts
+++ b/src/services/classifier-thresholds.ts
@@ -1,0 +1,33 @@
+/**
+ * Confidence threshold gating — issue #77.
+ *
+ * Pure-function check against the asymmetric per-label thresholds
+ * documented in planning/classifier.md §"Confidence thresholds".
+ *
+ * #77
+ */
+
+import {
+  ClassifierThresholds,
+  DEFAULT_CLASSIFIER_THRESHOLDS,
+  IntentLabel,
+} from "../contracts/classifier";
+
+/**
+ * Check whether a classifier output's confidence meets the threshold
+ * for the given label.
+ *
+ * Returns `true` when confidence >= threshold.  Returns `false` for
+ * unknown labels and for any confidence below the label's threshold.
+ *
+ * The caller uses `false` to trigger the disambiguation chip.
+ */
+export function isConfident(
+  label: IntentLabel,
+  confidence: number,
+  thresholds: ClassifierThresholds = DEFAULT_CLASSIFIER_THRESHOLDS,
+): boolean {
+  const t = thresholds[label];
+  if (t === undefined) return false;
+  return confidence >= t;
+}

--- a/src/services/help-content.ts
+++ b/src/services/help-content.ts
@@ -1,0 +1,27 @@
+/**
+ * Static help response rendered when the classifier routes a turn to `meta`.
+ *
+ * The text is kept in a dedicated module so the orchestrator does not inline
+ * prose and the content can be iterated independently of routing logic.
+ *
+ * #79
+ */
+
+export const META_HELP_RESPONSE = [
+  "I'm Gemmera, your vault assistant. Here's what I can do:",
+  "",
+  "**Capture** — Save your thoughts, meeting notes, or selections as structured notes.",
+  '  • Type normally and press Enter, or use "Ctrl+Enter" to force capture.',
+  "  • Attach files (PDF, image, audio, text) and I'll include them.",
+  "",
+  "**Ask** — Search your vault and answer questions using your notes.",
+  '  • Start your message with "?" to force a question.',
+  "  • I'll cite the notes I used so you can verify.",
+  "",
+  "**Mixed** — I'll save what you're sharing, then answer your question",
+  "  using the newly saved note plus your existing vault.",
+  "",
+  "**Commands** — Right-click on a note or selection in the editor for quick actions.",
+  "",
+  "For more details, check the Gemmera settings tab.",
+].join("\n");


### PR DESCRIPTION
## Summary
- **#77** Asymmetric confidence threshold gating — per-label thresholds (capture 0.85, ask 0.70, mixed 0.75, meta 0.70) with `isConfident()` pure function.
- **#79** Route decisions into ingest/query/meta paths — `classifyTurn()` orchestrator wires the full pipeline (skip router → LLM → retries → confidence → events) and produces a `RouteDecision` consumed by the turn router.

## Changes
- `src/contracts/classifier.ts` — Added `RouteDecision` type and `DEFAULT_CLASSIFIER_THRESHOLDS` constants.
- `src/services/classifier-thresholds.ts` — `isConfident()` pure function for asymmetric threshold gating.
- `src/services/classifier-thresholds.test.ts` — 15 tests.
- `src/services/classifier-orchestrator.ts` — `classifyTurn()` orchestrator function.
- `src/services/classifier-orchestrator.test.ts` — 36 tests covering skip, LLM, fallback, meta short-circuit, and event writing.
- `src/services/help-content.ts` — Static help response for `meta` intents.