### PR TITLE
feat(classifier): disambiguation chip in composer header (closes #81)

### DIFF
--- a/src/disambiguation-chip.test.ts
+++ b/src/disambiguation-chip.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { DisambiguationChip } from "./disambiguation-chip";
+import type { ClassifierDecision } from "./contracts/classifier";
+
+function makeDecision(overrides: Partial<ClassifierDecision> = {}): ClassifierDecision {
+  return {
+    source: "llm",
+    input: { messageText: "save this", truncated: false, attachments: [], activeFile: null, recentTurns: [] },
+    output: { label: "capture", confidence: 0.6, rationale: "User wants to save content." },
+    latencyMs: 120,
+    promptVersion: "0.1.0",
+    skipReason: null,
+    needsDisambiguation: true,
+    fallbackReason: null,
+    ...overrides,
+  };
+}
+
+describe("DisambiguationChip", () => {
+  // ── Initial state ────────────────────────────────────────────────────
+
+  it("starts not showing", () => {
+    const chip = new DisambiguationChip();
+    expect(chip.isShowing()).toBe(false);
+  });
+
+  it("drainQueue returns empty array when nothing queued", () => {
+    const chip = new DisambiguationChip();
+    expect(chip.drainQueue()).toEqual([]);
+  });
+
+  // ── hold ─────────────────────────────────────────────────────────────
+
+  it("hold transitions to showing", () => {
+    const chip = new DisambiguationChip();
+    const ok = chip.hold("save this", "t-1", makeDecision());
+    expect(ok).toBe(true);
+    expect(chip.isShowing()).toBe(true);
+  });
+
+  it("hold exposes rationale from decision output", () => {
+    const chip = new DisambiguationChip();
+    chip.hold("save this", "t-1", makeDecision({ output: { label: "capture", confidence: 0.6, rationale: "My rationale" } }));
+    expect(chip.rationale).toBe("My rationale");
+  });
+
+  it("hold exposes pendingTurnId", () => {
+    const chip = new DisambiguationChip();
+    chip.hold("save this", "t-42", makeDecision());
+    expect(chip.pendingTurnId).toBe("t-42");
+  });
+
+  it("hold returns false if a message is already held", () => {
+    const chip = new DisambiguationChip();
+    chip.hold("first", "t-1", makeDecision());
+    const second = chip.hold("second", "t-2", makeDecision());
+    expect(second).toBe(false);
+    expect(chip.pendingTurnId).toBe("t-1");
+  });
+
+  // ── resolve ──────────────────────────────────────────────────────────
+
+  it('resolve("save") clears pending and returns resolution', () => {
+    const chip = new DisambiguationChip();
+    const decision = makeDecision();
+    chip.hold("save this", "t-1", decision);
+    const res = chip.resolve("save");
+    expect(res).not.toBeNull();
+    expect(res!.action).toBe("save");
+    expect(res!.text).toBe("save this");
+    expect(res!.turnId).toBe("t-1");
+    expect(res!.originalDecision).toBe(decision);
+    expect(chip.isShowing()).toBe(false);
+  });
+
+  it('resolve("ask") clears pending and returns resolution', () => {
+    const chip = new DisambiguationChip();
+    chip.hold("what is this?", "t-2", makeDecision());
+    const res = chip.resolve("ask");
+    expect(res!.action).toBe("ask");
+    expect(chip.isShowing()).toBe(false);
+  });
+
+  it("resolve returns null when not showing", () => {
+    const chip = new DisambiguationChip();
+    expect(chip.resolve("save")).toBeNull();
+    expect(chip.resolve("ask")).toBeNull();
+  });
+
+  // ── cancel ───────────────────────────────────────────────────────────
+
+  it("cancel clears pending and returns cancellation metadata", () => {
+    const chip = new DisambiguationChip();
+    const decision = makeDecision();
+    chip.hold("save this", "t-3", decision);
+    const cancelled = chip.cancel();
+    expect(cancelled).not.toBeNull();
+    expect(cancelled!.turnId).toBe("t-3");
+    expect(cancelled!.originalDecision).toBe(decision);
+    expect(chip.isShowing()).toBe(false);
+  });
+
+  it("cancel returns null when not showing", () => {
+    const chip = new DisambiguationChip();
+    expect(chip.cancel()).toBeNull();
+  });
+
+  // ── enqueue / drainQueue ──────────────────────────────────────────────
+
+  it("enqueue stores messages submitted while chip is showing", () => {
+    const chip = new DisambiguationChip();
+    chip.hold("first", "t-1", makeDecision());
+    chip.enqueue("second");
+    chip.enqueue("third");
+    expect(chip.drainQueue()).toEqual(["second", "third"]);
+  });
+
+  it("drainQueue empties the queue", () => {
+    const chip = new DisambiguationChip();
+    chip.enqueue("msg");
+    chip.drainQueue();
+    expect(chip.drainQueue()).toEqual([]);
+  });
+
+  it("queued messages survive resolve", () => {
+    const chip = new DisambiguationChip();
+    chip.hold("first", "t-1", makeDecision());
+    chip.enqueue("queued");
+    chip.resolve("save");
+    expect(chip.drainQueue()).toEqual(["queued"]);
+  });
+
+  it("queued messages survive cancel", () => {
+    const chip = new DisambiguationChip();
+    chip.hold("first", "t-1", makeDecision());
+    chip.enqueue("queued");
+    chip.cancel();
+    expect(chip.drainQueue()).toEqual(["queued"]);
+  });
+
+  // ── Accessors when not showing ────────────────────────────────────────
+
+  it("rationale returns empty string when not showing", () => {
+    expect(new DisambiguationChip().rationale).toBe("");
+  });
+
+  it("pendingTurnId returns null when not showing", () => {
+    expect(new DisambiguationChip().pendingTurnId).toBeNull();
+  });
+
+  it("originalLabel returns null when not showing", () => {
+    expect(new DisambiguationChip().originalLabel).toBeNull();
+  });
+
+  it("originalConfidence returns 0 when not showing", () => {
+    expect(new DisambiguationChip().originalConfidence).toBe(0);
+  });
+
+  // ── rationale falls back when output is null ──────────────────────────
+
+  it("rationale returns empty string when decision has no output", () => {
+    const chip = new DisambiguationChip();
+    chip.hold("msg", "t-1", makeDecision({ output: null }));
+    expect(chip.rationale).toBe("");
+  });
+});

--- a/src/disambiguation-chip.ts
+++ b/src/disambiguation-chip.ts
@@ -1,0 +1,100 @@
+import type { ClassifierDecision, IntentLabel } from "./contracts/classifier";
+
+export type DisambiguationAction = "save" | "ask" | "cancel";
+
+export interface DisambiguationResolution {
+  action: "save" | "ask";
+  text: string;
+  turnId: string;
+  originalDecision: ClassifierDecision;
+}
+
+export interface DisambiguationCancellation {
+  turnId: string;
+  originalDecision: ClassifierDecision;
+}
+
+/**
+ * Pure state machine for the disambiguation chip. Tracks the held message,
+ * the queued messages, and the resolution state. Has no DOM knowledge —
+ * the view is responsible for rendering and destroying the chip element.
+ */
+export class DisambiguationChip {
+  private pending: { text: string; turnId: string; decision: ClassifierDecision } | null = null;
+  private queue: string[] = [];
+
+  /**
+   * Hold a message pending disambiguation. Returns false if a message is
+   * already held — the caller must not overwrite an unresolved chip.
+   */
+  hold(text: string, turnId: string, decision: ClassifierDecision): boolean {
+    if (this.pending !== null) return false;
+    this.pending = { text, turnId, decision };
+    return true;
+  }
+
+  isShowing(): boolean {
+    return this.pending !== null;
+  }
+
+  get rationale(): string {
+    return this.pending?.decision.output?.rationale ?? "";
+  }
+
+  get pendingTurnId(): string | null {
+    return this.pending?.turnId ?? null;
+  }
+
+  get originalLabel(): IntentLabel | null {
+    return this.pending?.decision.output?.label ?? null;
+  }
+
+  get originalConfidence(): number {
+    return this.pending?.decision.output?.confidence ?? 0;
+  }
+
+  /** Enqueue a message submitted while the chip is showing. */
+  enqueue(text: string): void {
+    this.queue.push(text);
+  }
+
+  /**
+   * Resolve via Save or Ask. Clears the held message and returns the
+   * resolution so the caller can re-submit with the chosen label.
+   */
+  resolve(action: "save" | "ask"): DisambiguationResolution | null {
+    if (!this.pending) return null;
+    const result: DisambiguationResolution = {
+      action,
+      text: this.pending.text,
+      turnId: this.pending.turnId,
+      originalDecision: this.pending.decision,
+    };
+    this.pending = null;
+    return result;
+  }
+
+  /**
+   * Cancel the disambiguation. Discards the held message and returns
+   * the metadata needed to write the classifier_disambiguation event.
+   */
+  cancel(): DisambiguationCancellation | null {
+    if (!this.pending) return null;
+    const result: DisambiguationCancellation = {
+      turnId: this.pending.turnId,
+      originalDecision: this.pending.decision,
+    };
+    this.pending = null;
+    return result;
+  }
+
+  /**
+   * Return all queued messages and reset the queue. Call after resolving
+   * or cancelling so queued messages can be dispatched.
+   */
+  drainQueue(): string[] {
+    const q = [...this.queue];
+    this.queue = [];
+    return q;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, WorkspaceLeaf } from "obsidian";
+import { FileSystemAdapter, Plugin, WorkspaceLeaf } from "obsidian";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
 import { DEFAULT_SETTINGS, GemmeraSettings } from "./settings";
@@ -9,7 +9,8 @@ export default class GemmeraPlugin extends Plugin {
 
   async onload(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-    this.services = await createServices(this.app, this.settings);
+    const pluginDir = (this.app.vault.adapter as FileSystemAdapter).getFullPath(this.manifest.dir ?? ".obsidian/plugins/gemmera");
+    this.services = await createServices(this.app, this.settings, pluginDir);
     this.services.eventBridge.start();
     this.services.ingestionRunner.start();
     this.services.embeddingService.start();

--- a/src/services/classifier-orchestrator.test.ts
+++ b/src/services/classifier-orchestrator.test.ts
@@ -486,3 +486,16 @@ describe("classifyTurn — full pipeline integration", () => {
     expect(result.label).toBe("ask");
   });
 });
+
+describe("classifyTurn — disambiguation chip 250 ms budget", () => {
+  it("full pipeline completes well within 250 ms on a warm mock LLM", async () => {
+    const deps = makeDeps({ llm: makeJsonLLM(validJson("capture", 0.5)) });
+    const start = performance.now();
+    const result = await classifyTurn(makeInput(), deps, "turn-perf");
+    const elapsed = performance.now() - start;
+    // The chip must render within 250 ms of the classifier returning.
+    // With a synchronous mock LLM the budget should be < 50 ms.
+    expect(elapsed).toBeLessThan(250);
+    expect(result.needsDisambiguation).toBe(true);
+  });
+});

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { FileSystemAdapter, Notice, type App } from "obsidian";
 import type {
   IndexService,
@@ -10,9 +11,13 @@ import type {
   VaultService,
   VectorStore,
 } from "../contracts";
+import type { ClassifierEventWriter } from "../contracts/classifier";
+import type { PromptLoader } from "../contracts/prompts";
 import type { GemmeraSettings } from "../settings";
 import { MockLLMService } from "./mock-llm";
 import { OllamaLLMService } from "./ollama-llm";
+import { FilePromptLoader } from "./file-prompt-loader";
+import { InMemoryClassifierEventWriter } from "./classifier-events";
 import { ObsidianVaultService } from "./real-vault";
 import { VaultLinearIndexService } from "./vault-index";
 import { InMemoryJobQueue } from "./in-memory-job-queue";
@@ -41,6 +46,8 @@ export interface Services {
   reconciler: Reconciler;
   vectorStore: VectorStore;
   embeddingService: EmbeddingService;
+  promptLoader: PromptLoader;
+  classifierEventWriter: ClassifierEventWriter;
 }
 
 const STATE_PATH = ".coworkmd/state.json";
@@ -63,7 +70,7 @@ export async function createLLMService(
   return ollama;
 }
 
-export async function createServices(app: App, settings: GemmeraSettings): Promise<Services> {
+export async function createServices(app: App, settings: GemmeraSettings, pluginDir: string): Promise<Services> {
   const vault = new ObsidianVaultService(app);
   const jobQueue = new InMemoryJobQueue();
   const pathFilter = new DefaultPathFilter();
@@ -117,6 +124,8 @@ export async function createServices(app: App, settings: GemmeraSettings): Promi
     reconciler,
     vectorStore,
     embeddingService,
+    promptLoader: new FilePromptLoader(join(pluginDir, "prompts")),
+    classifierEventWriter: new InMemoryClassifierEventWriter(),
   };
 }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -240,9 +240,16 @@ export class GemmeraChatView extends ItemView {
     }
 
     // Process any messages submitted while the chip was showing.
+    // Catch per-iteration: drainQueue() already cleared the internal queue,
+    // so an uncaught throw would silently drop everything after the failing item.
     for (const queued of this.chip.drainQueue()) {
       this.inputEl.value = queued;
-      await this.handleSend();
+      try {
+        await this.handleSend();
+      } catch {
+        // runChat handles display errors internally; this guard ensures the
+        // remaining queued messages are not lost on an unexpected throw.
+      }
     }
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,16 +1,25 @@
 import { ItemView, WorkspaceLeaf } from "obsidian";
 import type { ChatMessage, IndexSearchResult } from "./contracts";
+import type { IntentLabel, RecentTurn, RouteDecision } from "./contracts/classifier";
 import type { Services } from "./services";
 import { parseFileOps, handleFileOps } from "./fileops";
+import { classifyTurn } from "./services/classifier-orchestrator";
+import { toDisambiguationRow } from "./services/classifier-events";
+import { DisambiguationChip } from "./disambiguation-chip";
 
 export const VIEW_TYPE = "gemmera-chat";
 
 export class GemmeraChatView extends ItemView {
   private messagesEl!: HTMLElement;
+  private inputAreaEl!: HTMLElement;
   private inputEl!: HTMLTextAreaElement;
   private sendBtn!: HTMLButtonElement;
   private history: ChatMessage[] = [];
   private model = "gemma3:latest";
+
+  private chip = new DisambiguationChip();
+  private chipEl: HTMLElement | null = null;
+  private recentTurns: RecentTurn[] = [];
 
   constructor(leaf: WorkspaceLeaf, private readonly services: Services) {
     super(leaf);
@@ -39,12 +48,12 @@ export class GemmeraChatView extends ItemView {
 
     this.messagesEl = container.createEl("div", { cls: "gemmera-messages" });
 
-    const inputArea = container.createEl("div", { cls: "gemmera-input-area" });
-    this.inputEl = inputArea.createEl("textarea", {
+    this.inputAreaEl = container.createEl("div", { cls: "gemmera-input-area" });
+    this.inputEl = this.inputAreaEl.createEl("textarea", {
       cls: "gemmera-input",
       attr: { placeholder: "Skriv ett meddelande...", rows: "3" },
     });
-    this.sendBtn = inputArea.createEl("button", {
+    this.sendBtn = this.inputAreaEl.createEl("button", {
       cls: "gemmera-send",
       text: "Skicka",
     });
@@ -73,13 +82,60 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  private async handleSend(): Promise<void> {
+  private async handleSend(forcedLabel?: IntentLabel): Promise<void> {
     const text = this.inputEl.value.trim();
     if (!text) return;
+
+    // If chip is showing, queue and return — the chip is still for the
+    // first message and applies only to it.
+    if (this.chip.isShowing()) {
+      this.chip.enqueue(text);
+      this.inputEl.value = "";
+      return;
+    }
 
     this.inputEl.value = "";
     this.setInputDisabled(true);
 
+    const turnId = crypto.randomUUID();
+
+    // ── Classify ──────────────────────────────────────────────────────
+    let route: RouteDecision | null = null;
+    if (!forcedLabel) {
+      try {
+        route = await classifyTurn(
+          { messageText: text, attachments: [], activeFile: null, recentTurns: this.recentTurns },
+          { llm: this.services.llm, promptLoader: this.services.promptLoader, eventWriter: this.services.classifierEventWriter },
+          turnId,
+        );
+      } catch {
+        // Transport error — fall through as "ask" so the main chat can
+        // surface the Ollama error to the user.
+      }
+    }
+
+    // ── Meta short-circuit ────────────────────────────────────────────
+    if (route?.shortCircuit && route.helpResponse) {
+      this.appendMessage("assistant", route.helpResponse);
+      this.setInputDisabled(false);
+      this.inputEl.focus();
+      return;
+    }
+
+    // ── Disambiguation chip ───────────────────────────────────────────
+    if (!forcedLabel && route?.needsDisambiguation) {
+      this.setInputDisabled(false);
+      this.chip.hold(text, turnId, route.decision);
+      this.renderChip(route.decision.output?.rationale ?? "");
+      this.inputEl.focus();
+      return;
+    }
+
+    // ── Chat ──────────────────────────────────────────────────────────
+    await this.runChat(text, forcedLabel ?? route?.label ?? "ask", turnId);
+  }
+
+  private async runChat(text: string, intent: IntentLabel, turnId: string): Promise<void> {
     this.history.push({ role: "user", content: text });
     this.appendMessage("user", text);
 
@@ -98,6 +154,10 @@ export class GemmeraChatView extends ItemView {
         },
       });
       this.history.push({ role: "assistant", content: reply.content });
+
+      // Record for classifier context on the next turn (last 3 only).
+      this.recentTurns = [...this.recentTurns.slice(-2), { text, intent }];
+
       const ops = parseFileOps(reply.content);
       if (ops.length > 0) await handleFileOps(this.app, ops);
     } catch (err) {
@@ -109,6 +169,89 @@ export class GemmeraChatView extends ItemView {
       this.inputEl.focus();
     }
   }
+
+  // ── Disambiguation chip DOM ──────────────────────────────────────────
+
+  private renderChip(rationale: string): void {
+    this.removeChip();
+
+    const chip = this.inputAreaEl.createEl("div", {
+      cls: "gemmera-disambig-chip",
+      attr: { title: rationale },
+    });
+    chip.createEl("span", {
+      cls: "gemmera-disambig-chip__prompt",
+      text: "Did you mean to save this, or ask about it?",
+    });
+
+    const actions = chip.createEl("div", { cls: "gemmera-disambig-chip__actions" });
+
+    const saveBtn = actions.createEl("button", {
+      cls: "gemmera-disambig-chip__btn gemmera-disambig-chip__btn--save",
+      text: "Save",
+    });
+    const askBtn = actions.createEl("button", {
+      cls: "gemmera-disambig-chip__btn gemmera-disambig-chip__btn--ask",
+      text: "Ask",
+    });
+    const cancelBtn = actions.createEl("button", {
+      cls: "gemmera-disambig-chip__btn gemmera-disambig-chip__btn--cancel",
+      text: "Cancel",
+    });
+
+    saveBtn.addEventListener("click", () => this.handleChipAction("save"));
+    askBtn.addEventListener("click", () => this.handleChipAction("ask"));
+    cancelBtn.addEventListener("click", () => this.handleChipAction("cancel"));
+
+    // Prepend so the chip appears above the textarea.
+    this.inputAreaEl.insertBefore(chip, this.inputEl);
+    this.chipEl = chip;
+  }
+
+  private async handleChipAction(action: "save" | "ask" | "cancel"): Promise<void> {
+    this.removeChip();
+
+    if (action === "cancel") {
+      const cancelled = this.chip.cancel();
+      if (cancelled) {
+        await this.services.classifierEventWriter.writeDisambiguation(
+          toDisambiguationRow(cancelled.turnId, {
+            originalLabel: cancelled.originalDecision.output?.label ?? "ask",
+            originalConfidence: cancelled.originalDecision.output?.confidence ?? 0,
+            chosenLabel: null,
+            cancelled: true,
+          }),
+        );
+      }
+    } else {
+      const resolution = this.chip.resolve(action);
+      if (resolution) {
+        const chosenLabel: IntentLabel = action === "save" ? "capture" : "ask";
+        await this.services.classifierEventWriter.writeDisambiguation(
+          toDisambiguationRow(resolution.turnId, {
+            originalLabel: resolution.originalDecision.output?.label ?? "ask",
+            originalConfidence: resolution.originalDecision.output?.confidence ?? 0,
+            chosenLabel,
+            cancelled: false,
+          }),
+        );
+        await this.runChat(resolution.text, chosenLabel, resolution.turnId);
+      }
+    }
+
+    // Process any messages submitted while the chip was showing.
+    for (const queued of this.chip.drainQueue()) {
+      this.inputEl.value = queued;
+      await this.handleSend();
+    }
+  }
+
+  private removeChip(): void {
+    this.chipEl?.remove();
+    this.chipEl = null;
+  }
+
+  // ── DOM helpers ──────────────────────────────────────────────────────
 
   private setInputDisabled(disabled: boolean): void {
     this.inputEl.disabled = disabled;


### PR DESCRIPTION
## Summary

- `DisambiguationChip` pure state machine (`hold / resolve / cancel / enqueue / drainQueue`) with no DOM knowledge — fully unit-testable
- `view.ts` now calls `classifyTurn` before every send; shows the chip on `needsDisambiguation`, short-circuits on `meta`, falls through on confident labels
- Save/Ask re-submit the original message with the chosen intent hard-coded; Cancel discards; messages queued while chip is visible are drained after resolution
- `classifier_disambiguation` event written on all three button actions
- `recentTurns` tracked (last 3) for subsequent classifier calls
- `Services` wired with `promptLoader` (FilePromptLoader) and `classifierEventWriter` (InMemory)

## Test plan

- [ ] 20 unit tests for `DisambiguationChip` state machine — all three buttons, queued-message case, accessors when not showing
- [ ] 250 ms pipeline budget assertion added to `classifier-orchestrator.test.ts`
- [ ] 413 tests pass, `tsc --noEmit` clean (pre-existing `ajv` error unchanged)
- [ ] Manual: send a message that triggers low confidence → chip appears above textarea with rationale tooltip → Save/Ask/Cancel each behave correctly
- [ ] Manual: type a second message while chip is showing → it queues and sends after chip resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)