### PR TITLE
fix(classifier): preserve null original_label for fallback disambiguations

### DIFF
--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -154,12 +154,19 @@ export interface ClassifierDecisionRow {
 /**
  * Row written to the `classifier_disambiguation` table when the user
  * corrects a low-confidence classification via the disambiguation chip.
+ *
+ * `original_label` and `original_confidence` are nullable because the chip
+ * also fires on fallback decisions (timeout / unparseable / invalid-label /
+ * invalid-confidence) where the model emitted no usable output. For those
+ * rows the original-side is null; the fallback reason can be joined from
+ * `classifier_decision.fallback_reason` via `turn_id`. Eval queries that
+ * count "model-vs-user" corrections should filter `original_label IS NOT NULL`.
  */
 export interface ClassifierDisambiguationRow {
   turn_id: string;
   ts: number;
-  original_label: IntentLabel;
-  original_confidence: number;
+  original_label: IntentLabel | null;
+  original_confidence: number | null;
   /** The label the user chose, or null when they cancelled. */
   chosen_label: IntentLabel | null;
   /** True when the user dismissed the chip without choosing a label. */

--- a/src/services/classifier-events.test.ts
+++ b/src/services/classifier-events.test.ts
@@ -45,6 +45,19 @@ describe("classifier DDL", () => {
     }
   });
 
+  it("classifier_disambiguation original_label and original_confidence are nullable", () => {
+    // Fallback decisions (no model output) must still be writable with
+    // null on the original-side. Asserting via the absence of NOT NULL
+    // on those two columns guards against an accidental tightening.
+    const lines = CLASSIFIER_DISAMBIGUATION_DDL.split("\n");
+    const labelLine = lines.find((l) => /\boriginal_label\b/.test(l));
+    const confLine = lines.find((l) => /\boriginal_confidence\b/.test(l));
+    expect(labelLine).toBeDefined();
+    expect(confLine).toBeDefined();
+    expect(labelLine).not.toContain("NOT NULL");
+    expect(confLine).not.toContain("NOT NULL");
+  });
+
   it("CLASSIFIER_DDL is ordered (decision before disambiguation)", () => {
     expect(CLASSIFIER_DDL).toHaveLength(2);
     expect(CLASSIFIER_DDL[0]).toContain("classifier_decision");
@@ -201,6 +214,23 @@ describe("toDisambiguationRow", () => {
     expect(row.original_confidence).toBe(0.52);
     expect(row.chosen_label).toBe("capture");
     expect(row.cancelled).toBe(false);
+  });
+
+  it("preserves null originalLabel and originalConfidence for fallback decisions", () => {
+    // The chip fires on classifier fallbacks (timeout / unparseable / etc.)
+    // where the model emitted no usable output. Those rows must store null
+    // on the original-side so eval queries can distinguish "model said X →
+    // user corrected" from "no model output → user picked something".
+    const row = toDisambiguationRow("turn-fallback", {
+      originalLabel: null,
+      originalConfidence: null,
+      chosenLabel: "capture",
+      cancelled: false,
+    });
+
+    expect(row.original_label).toBeNull();
+    expect(row.original_confidence).toBeNull();
+    expect(row.chosen_label).toBe("capture");
   });
 });
 

--- a/src/services/classifier-events.ts
+++ b/src/services/classifier-events.ts
@@ -27,13 +27,16 @@ export const CLASSIFIER_DECISION_DDL = [
   ");",
 ].join("\n");
 
-/** SQL to create the `classifier_disambiguation` table. Idempotent. */
+/** SQL to create the `classifier_disambiguation` table. Idempotent.
+ *  `original_label` and `original_confidence` are nullable so fallback
+ *  decisions (no model output) can still emit a row when the user
+ *  resolves the chip. See ClassifierDisambiguationRow for details. */
 export const CLASSIFIER_DISAMBIGUATION_DDL = [
   "CREATE TABLE IF NOT EXISTS classifier_disambiguation (",
   "  turn_id            TEXT NOT NULL,",
   "  ts                 BIGINT NOT NULL,",
-  "  original_label     TEXT NOT NULL,",
-  "  original_confidence REAL NOT NULL,",
+  "  original_label     TEXT,",
+  "  original_confidence REAL,",
   "  chosen_label       TEXT,",
   "  cancelled          BOOLEAN NOT NULL DEFAULT FALSE",
   ");",
@@ -111,8 +114,8 @@ export function toDecisionRow(
 export function toDisambiguationRow(
   turnId: string,
   event: {
-    originalLabel: IntentLabel;
-    originalConfidence: number;
+    originalLabel: IntentLabel | null;
+    originalConfidence: number | null;
     chosenLabel: IntentLabel | null;
     cancelled: boolean;
   },

--- a/src/view.ts
+++ b/src/view.ts
@@ -216,8 +216,11 @@ export class GemmeraChatView extends ItemView {
       if (cancelled) {
         await this.services.classifierEventWriter.writeDisambiguation(
           toDisambiguationRow(cancelled.turnId, {
-            originalLabel: cancelled.originalDecision.output?.label ?? "ask",
-            originalConfidence: cancelled.originalDecision.output?.confidence ?? 0,
+            // null when the original decision was a fallback (no model output).
+            // Defaulting to "ask" here would mislabel fallback rows as model-
+            // emitted "ask" corrections in the eval golden set.
+            originalLabel: cancelled.originalDecision.output?.label ?? null,
+            originalConfidence: cancelled.originalDecision.output?.confidence ?? null,
             chosenLabel: null,
             cancelled: true,
           }),
@@ -229,8 +232,8 @@ export class GemmeraChatView extends ItemView {
         const chosenLabel: IntentLabel = action === "save" ? "capture" : "ask";
         await this.services.classifierEventWriter.writeDisambiguation(
           toDisambiguationRow(resolution.turnId, {
-            originalLabel: resolution.originalDecision.output?.label ?? "ask",
-            originalConfidence: resolution.originalDecision.output?.confidence ?? 0,
+            originalLabel: resolution.originalDecision.output?.label ?? null,
+            originalConfidence: resolution.originalDecision.output?.confidence ?? null,
             chosenLabel,
             cancelled: false,
           }),


### PR DESCRIPTION
## Summary

Follow-up to #108. The disambiguation chip fires both for low-confidence classifications **and** for classifier fallbacks (timeout / unparseable / invalid-label / invalid-confidence). For the latter, \`decision.output\` is null, so on Save / Ask / Cancel we were writing rows like:

\`\`\`ts
originalLabel: cancelled.originalDecision.output?.label ?? "ask",
originalConfidence: cancelled.originalDecision.output?.confidence ?? 0,
\`\`\`

That stamps every fallback row as if the model had confidently emitted \`ask\` and the user corrected it. \`planning/classifier.md\` calls \`classifier_disambiguation\` "a built-in labeled-example factory — every user correction becomes a labeled example," so the golden set picks up mislabelled examples for the entire fallback population.

## Changes

- \`ClassifierDisambiguationRow.original_label\` → \`IntentLabel | null\`
- \`ClassifierDisambiguationRow.original_confidence\` → \`number | null\`
- DDL: drop \`NOT NULL\` on both columns (\`chosen_label\` was already nullable)
- \`toDisambiguationRow\` accepts the nullable types directly
- \`view.ts\` writes \`null\` for both fields when the original decision had no output, instead of defaulting to \`"ask"\`/\`0\`

The fallback reason is already on \`classifier_decision.fallback_reason\` and joinable via \`turn_id\`, so we don't need a new column to distinguish "model said X → user corrected" from "no model output → user picked something." Eval queries that count model-vs-user corrections should filter \`original_label IS NOT NULL\`.

## Tests

- \`toDisambiguationRow\` preserves null \`originalLabel\` / \`originalConfidence\`
- DDL guard against accidental re-tightening of \`NOT NULL\` on those columns

## Verification

- \`npm test\` — 422 tests pass (was 420 before this branch)
- \`npx tsc --noEmit\` — clean

Refs #81, #108.