### PR TITLE
feat(classifier): dev-mode inline labels + silent-save indicator (closes #83)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ export default class GemmeraPlugin extends Plugin {
       .reconcile()
       .catch((err) => console.error("[gemmera] reconcile failed", err));
 
-    this.registerView(VIEW_TYPE, (leaf) => new GemmeraChatView(leaf, this.services));
+    this.registerView(VIEW_TYPE, (leaf) => new GemmeraChatView(leaf, this.services, this.settings));
 
     this.addRibbonIcon("message-square", "Gemmera", () => {
       this.openChatView();

--- a/src/message-decoration.test.ts
+++ b/src/message-decoration.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { buildMessageDecoration } from "./message-decoration";
+import type { RouteDecision, ClassifierDecision } from "./contracts/classifier";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeDecision(overrides: Partial<ClassifierDecision> = {}): ClassifierDecision {
+  return {
+    source: "llm",
+    input: { messageText: "save this", truncated: false, attachments: [], activeFile: null, recentTurns: [] },
+    output: { label: "capture", confidence: 0.91, rationale: "User wants to save content." },
+    latencyMs: 110,
+    promptVersion: "0.1.0",
+    skipReason: null,
+    needsDisambiguation: false,
+    fallbackReason: null,
+    ...overrides,
+  };
+}
+
+function makeRoute(overrides: Partial<RouteDecision> = {}): RouteDecision {
+  return {
+    turnId: "t-1",
+    label: "capture",
+    decision: makeDecision(),
+    needsDisambiguation: false,
+    shortCircuit: false,
+    ...overrides,
+  };
+}
+
+// ── Silent mode (devMode = false) ─────────────────────────────────────────
+
+describe("buildMessageDecoration — silent mode", () => {
+  it("snapshot: confident capture, silent saves on", () => {
+    const result = buildMessageDecoration(makeRoute(), false, false);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "badge": null,
+        "silentSave": true,
+        "tooltip": null,
+      }
+    `);
+  });
+
+  it("snapshot: confident capture, always-preview on", () => {
+    const result = buildMessageDecoration(makeRoute(), false, true);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "badge": null,
+        "silentSave": false,
+        "tooltip": null,
+      }
+    `);
+  });
+
+  it("snapshot: confident ask — no badge, no silent save", () => {
+    const result = buildMessageDecoration(makeRoute({ label: "ask", decision: makeDecision({ output: { label: "ask", confidence: 0.85, rationale: "User is asking." } }) }), false, false);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "badge": null,
+        "silentSave": false,
+        "tooltip": null,
+      }
+    `);
+  });
+
+  it("no route → all null", () => {
+    expect(buildMessageDecoration(null, false, false)).toMatchInlineSnapshot(`
+      {
+        "badge": null,
+        "silentSave": false,
+        "tooltip": null,
+      }
+    `);
+  });
+
+  it("needsDisambiguation suppresses silentSave even for capture", () => {
+    const result = buildMessageDecoration(makeRoute({ needsDisambiguation: true }), false, false);
+    expect(result.silentSave).toBe(false);
+  });
+});
+
+// ── Dev mode (devMode = true) ─────────────────────────────────────────────
+
+describe("buildMessageDecoration — dev mode", () => {
+  it("snapshot: confident capture in dev mode", () => {
+    const result = buildMessageDecoration(makeRoute(), true, false);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "badge": "capture · 0.91",
+        "silentSave": true,
+        "tooltip": "User wants to save content.",
+      }
+    `);
+  });
+
+  it("snapshot: confident ask in dev mode", () => {
+    const route = makeRoute({
+      label: "ask",
+      decision: makeDecision({ output: { label: "ask", confidence: 0.85, rationale: "User is asking a question." } }),
+    });
+    const result = buildMessageDecoration(route, true, false);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "badge": "ask · 0.85",
+        "silentSave": false,
+        "tooltip": "User is asking a question.",
+      }
+    `);
+  });
+
+  it("snapshot: skip-path decision in dev mode", () => {
+    const route = makeRoute({
+      label: "ask",
+      decision: makeDecision({
+        source: "skip",
+        skipReason: "leading-question-mark",
+        output: null,
+      }),
+    });
+    const result = buildMessageDecoration(route, true, false);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "badge": "ask · skip",
+        "silentSave": false,
+        "tooltip": "leading-question-mark",
+      }
+    `);
+  });
+
+  it("snapshot: LLM fallback (null output) in dev mode", () => {
+    const route = makeRoute({
+      label: "ask",
+      needsDisambiguation: true,
+      decision: makeDecision({ output: null, fallbackReason: "timeout" }),
+    });
+    const result = buildMessageDecoration(route, true, false);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "badge": "ask · fallback",
+        "silentSave": false,
+        "tooltip": null,
+      }
+    `);
+  });
+
+  it("badge confidence uses 2 decimal places", () => {
+    const route = makeRoute({ decision: makeDecision({ output: { label: "capture", confidence: 0.9, rationale: "" } }) });
+    expect(buildMessageDecoration(route, true, false).badge).toBe("capture · 0.90");
+  });
+
+  it("null rationale on output produces null tooltip", () => {
+    const route = makeRoute({ decision: makeDecision({ output: { label: "capture", confidence: 0.91, rationale: "" } }) });
+    expect(buildMessageDecoration(route, true, false).tooltip).toBeNull();
+  });
+});

--- a/src/message-decoration.ts
+++ b/src/message-decoration.ts
@@ -1,0 +1,53 @@
+import type { RouteDecision } from "./contracts/classifier";
+
+export interface MessageDecoration {
+  /** Inline label shown on the message in dev mode. Null when silent. */
+  badge: string | null;
+  /** Tooltip text on the badge. Null when no badge. */
+  tooltip: string | null;
+  /** True when the classifier silently routed to capture without user confirmation. */
+  silentSave: boolean;
+}
+
+/**
+ * Derive the message decoration for a single turn. Pure — no side effects.
+ *
+ * Silent mode (devMode=false): only silentSave is ever set.
+ * Dev mode: badge and tooltip are populated from the decision.
+ */
+export function buildMessageDecoration(
+  route: RouteDecision | null,
+  devMode: boolean,
+  alwaysPreviewBeforeSave: boolean,
+): MessageDecoration {
+  if (!route || !route.label) {
+    return { badge: null, tooltip: null, silentSave: false };
+  }
+
+  // Silent saves: confident capture when the user hasn't opted into preview.
+  const silentSave =
+    route.label === "capture" &&
+    !alwaysPreviewBeforeSave &&
+    !route.needsDisambiguation;
+
+  if (!devMode) {
+    return { badge: null, tooltip: null, silentSave };
+  }
+
+  // Dev mode: show label + source annotation on every message.
+  const { label, decision } = route;
+
+  if (decision.source === "skip" && decision.skipReason) {
+    return { badge: `${label} · skip`, tooltip: decision.skipReason, silentSave };
+  }
+
+  const confidence = decision.output?.confidence;
+  const rationale = decision.output?.rationale || null;
+
+  const badge =
+    confidence !== undefined
+      ? `${label} · ${confidence.toFixed(2)}`
+      : `${label} · fallback`;
+
+  return { badge, tooltip: rationale, silentSave };
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,8 +6,24 @@ export interface GemmeraSettings {
    * (or in code for tests). Intended for developers and CI, not end users.
    */
   llmBackend: "ollama" | "mock";
+
+  /**
+   * Show classifier label + confidence + rationale inline on every message.
+   * Wired to Settings → Advanced → "Show classifier decisions" (#67).
+   * Until that tab lands, toggle by editing `data.json`.
+   */
+  showClassifierDecisions: boolean;
+
+  /**
+   * When true, the user reviews a capture before it is written.
+   * When false, captures are silent and the silent-save indicator is shown.
+   * Wired to Settings → "Always preview before save" (#67).
+   */
+  alwaysPreviewBeforeSave: boolean;
 }
 
 export const DEFAULT_SETTINGS: GemmeraSettings = {
   llmBackend: "ollama",
+  showClassifierDecisions: false,
+  alwaysPreviewBeforeSave: false,
 };

--- a/src/view.ts
+++ b/src/view.ts
@@ -2,10 +2,12 @@ import { ItemView, WorkspaceLeaf } from "obsidian";
 import type { ChatMessage, IndexSearchResult } from "./contracts";
 import type { IntentLabel, RecentTurn, RouteDecision } from "./contracts/classifier";
 import type { Services } from "./services";
+import type { GemmeraSettings } from "./settings";
 import { parseFileOps, handleFileOps } from "./fileops";
 import { classifyTurn } from "./services/classifier-orchestrator";
 import { toDisambiguationRow } from "./services/classifier-events";
 import { DisambiguationChip } from "./disambiguation-chip";
+import { buildMessageDecoration } from "./message-decoration";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -21,7 +23,11 @@ export class GemmeraChatView extends ItemView {
   private chipEl: HTMLElement | null = null;
   private recentTurns: RecentTurn[] = [];
 
-  constructor(leaf: WorkspaceLeaf, private readonly services: Services) {
+  constructor(
+    leaf: WorkspaceLeaf,
+    private readonly services: Services,
+    private readonly settings: GemmeraSettings,
+  ) {
     super(leaf);
   }
 
@@ -132,12 +138,32 @@ export class GemmeraChatView extends ItemView {
     }
 
     // ── Chat ──────────────────────────────────────────────────────────
-    await this.runChat(text, forcedLabel ?? route?.label ?? "ask", turnId);
+    await this.runChat(text, forcedLabel ?? route?.label ?? "ask", turnId, route ?? null);
   }
 
-  private async runChat(text: string, intent: IntentLabel, turnId: string): Promise<void> {
+  private async runChat(
+    text: string,
+    intent: IntentLabel,
+    turnId: string,
+    route: RouteDecision | null = null,
+  ): Promise<void> {
+    const decoration = buildMessageDecoration(
+      route,
+      this.settings.showClassifierDecisions,
+      this.settings.alwaysPreviewBeforeSave,
+    );
+
     this.history.push({ role: "user", content: text });
-    this.appendMessage("user", text);
+    this.appendMessage("user", text, decoration);
+
+    // Silent-save indicator: appears before the LLM call and is removed after.
+    let silentSaveEl: HTMLElement | null = null;
+    if (decoration.silentSave) {
+      silentSaveEl = this.messagesEl.createEl("div", {
+        cls: "gemmera-silent-save-indicator",
+        text: "saving as note…",
+      });
+    }
 
     const { el: assistantEl, textEl } = this.appendStreamingMessage();
 
@@ -165,6 +191,7 @@ export class GemmeraChatView extends ItemView {
       assistantEl.addClass("gemmera-message--error");
       this.history.pop();
     } finally {
+      silentSaveEl?.remove();
       this.setInputDisabled(false);
       this.inputEl.focus();
     }
@@ -273,10 +300,18 @@ export class GemmeraChatView extends ItemView {
     return { el, textEl };
   }
 
-  private appendMessage(role: "user" | "assistant", text: string): void {
+  private appendMessage(
+    role: "user" | "assistant",
+    text: string,
+    decoration?: { badge: string | null; tooltip: string | null } | null,
+  ): void {
     const msg = this.messagesEl.createEl("div", { cls: `gemmera-message gemmera-message--${role}` });
     msg.createEl("span", { cls: "gemmera-message__role", text: role === "user" ? "Du" : "Gemma" });
     msg.createEl("p", { cls: "gemmera-message__text", text });
+    if (decoration?.badge) {
+      const badge = msg.createEl("span", { cls: "gemmera-classifier-badge", text: decoration.badge });
+      if (decoration.tooltip) badge.setAttribute("title", decoration.tooltip);
+    }
     this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
   }
 }


### PR DESCRIPTION
## Summary

- `buildMessageDecoration` pure function derives `badge`, `tooltip`, and `silentSave` from a `RouteDecision` + two settings flags — no DOM knowledge, fully unit-testable
- Dev mode (`showClassifierDecisions: true`): every user message gets an inline badge (`capture · 0.91`, `ask · skip`, `ask · fallback`) with rationale as a hover tooltip
- Silent-save indicator: a `"saving as note…"` element appears before the LLM call and is removed in `finally` whenever intent is `capture` + `alwaysPreviewBeforeSave` is false
- Both settings added to `GemmeraSettings` and wired through to the view; togglable via `data.json` until the settings tab (#67) lands
- `needsDisambiguation` correctly suppresses `silentSave` (user already saw the chip)

## Test plan

- [ ] 11 snapshot + unit tests for `buildMessageDecoration` — silent/dev-mode, confident/skip/fallback, confidence formatting, empty-rationale → null tooltip
- [ ] 424 tests pass, `tsc --noEmit` clean
- [ ] Manual: set `showClassifierDecisions: true` in `data.json` → badge appears on user messages with rationale tooltip
- [ ] Manual: send a capture-intent message with `alwaysPreviewBeforeSave: false` → "saving as note…" indicator appears briefly
- [ ] Manual: with `alwaysPreviewBeforeSave: true` → no indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)