### PR TITLE
feat(rag): wire retrieval stack and add payload assembler (#8, #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,14 @@ styles.css.map
 .obsidian/workspace.json
 .obsidian/workspace-mobile.json
 
-# Obsidian vault runtime state
-demo-vault/raw/.obsidian/workspace.json
-demo-vault/raw/.obsidian/workspace-mobile.json
-demo-vault/raw/.obsidian/appearance.json
-demo-vault/raw/.obsidian/graph.json
-demo-vault/raw/.obsidian/plugins/
+# Obsidian vault runtime state — same set whether the vault root is
+# demo-vault/ or demo-vault/raw/.
+demo-vault/**/.obsidian/workspace.json
+demo-vault/**/.obsidian/workspace-mobile.json
+demo-vault/**/.obsidian/appearance.json
+demo-vault/**/.obsidian/graph.json
+demo-vault/**/.obsidian/plugins/
+demo-vault/.obsidian/
 
 # Dev
 .hotreload

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ export default class GemmeraPlugin extends Plugin {
     this.services.eventBridge.start();
     this.services.ingestionRunner.start();
     this.services.embeddingService.start();
+    this.services.bm25IndexService.start();
+    this.services.linksIndexService.start();
     this.wireDebugLogs();
     // Fire reconcile in the background — hash gate keeps it cheap on warm reloads.
     this.services.reconciler
@@ -38,6 +40,8 @@ export default class GemmeraPlugin extends Plugin {
     if (this.services) {
       await this.services.ingestionRunner.stop();
       await this.services.embeddingService.stop();
+      await this.services.bm25IndexService.stop();
+      await this.services.linksIndexService.stop();
     }
     this.app.workspace.detachLeavesOfType(VIEW_TYPE);
   }
@@ -62,6 +66,26 @@ export default class GemmeraPlugin extends Plugin {
         return;
       }
       console.debug(`[gemmera] embed:${e.kind} ${e.path} (${e.count})`);
+    });
+    this.services.bm25IndexService.onEvent((e) => {
+      if (e.kind === "error") {
+        console.error("[gemmera] bm25 error", e);
+        return;
+      }
+      const count = "count" in e ? e.count : 0;
+      console.debug(`[gemmera] bm25:${e.kind} ${e.path} (${count})`);
+    });
+    this.services.linksIndexService.onEvent((e) => {
+      if (e.kind === "error") {
+        console.error("[gemmera] links error", e);
+        return;
+      }
+      if (e.kind === "renamed") {
+        console.debug(`[gemmera] links:renamed ${e.from}→${e.to}`);
+        return;
+      }
+      const count = "linkCount" in e ? e.linkCount : 0;
+      console.debug(`[gemmera] links:${e.kind} ${e.path} (${count})`);
     });
   }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,13 +1,17 @@
 import { join } from "path";
 import { FileSystemAdapter, Notice, type App } from "obsidian";
 import type {
+  BM25Index,
   IndexService,
   IngestionPipeline,
   IngestionStore,
   JobQueue,
   LLMService,
+  MutableLinksIndex,
   PathFilter,
+  PayloadAssembler,
   Reconciler,
+  Retriever,
   VaultService,
   VectorStore,
 } from "../contracts";
@@ -32,6 +36,12 @@ import { VaultReconciler } from "./vault-reconciler";
 import { BinaryVectorStore } from "./binary-vector-store";
 import { OllamaEmbedder } from "./ollama-embedder";
 import { EmbeddingService } from "./embedding-service";
+import { InMemoryBM25Index } from "./in-memory-bm25-index";
+import { BM25IndexService } from "./bm25-index-service";
+import { InMemoryLinksIndex } from "./in-memory-links-index";
+import { LinksIndexService } from "./links-index-service";
+import { HybridRetriever } from "./hybrid-retriever";
+import { DefaultPayloadAssembler } from "./payload-assembler";
 
 export interface Services {
   llm: LLMService;
@@ -46,6 +56,12 @@ export interface Services {
   reconciler: Reconciler;
   vectorStore: VectorStore;
   embeddingService: EmbeddingService;
+  bm25Index: BM25Index;
+  bm25IndexService: BM25IndexService;
+  linksIndex: MutableLinksIndex;
+  linksIndexService: LinksIndexService;
+  retriever: Retriever;
+  payloadAssembler: PayloadAssembler;
   promptLoader: PromptLoader;
   classifierEventWriter: ClassifierEventWriter;
 }
@@ -111,6 +127,19 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     ingestionStore,
   );
 
+  const bm25Index = new InMemoryBM25Index();
+  const bm25IndexService = new BM25IndexService(ingestionRunner, bm25Index, ingestionStore);
+  const linksIndex = new InMemoryLinksIndex();
+  const linksIndexService = new LinksIndexService(ingestionRunner, vault, linksIndex);
+  const retriever = new HybridRetriever(
+    embedder,
+    vectorStore,
+    bm25Index,
+    linksIndex,
+    ingestionStore,
+  );
+  const payloadAssembler = new DefaultPayloadAssembler(linksIndex);
+
   return {
     llm: await createLLMService(settings.llmBackend),
     vault,
@@ -124,6 +153,12 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     reconciler,
     vectorStore,
     embeddingService,
+    bm25Index,
+    bm25IndexService,
+    linksIndex,
+    linksIndexService,
+    retriever,
+    payloadAssembler,
     promptLoader: new FilePromptLoader(join(pluginDir, "prompts")),
     classifierEventWriter: new InMemoryClassifierEventWriter(),
   };
@@ -144,3 +179,9 @@ export { VaultReconciler } from "./vault-reconciler";
 export { BinaryVectorStore } from "./binary-vector-store";
 export { OllamaEmbedder } from "./ollama-embedder";
 export { EmbeddingService } from "./embedding-service";
+export { InMemoryBM25Index } from "./in-memory-bm25-index";
+export { BM25IndexService } from "./bm25-index-service";
+export { InMemoryLinksIndex } from "./in-memory-links-index";
+export { LinksIndexService } from "./links-index-service";
+export { HybridRetriever } from "./hybrid-retriever";
+export { DefaultPayloadAssembler } from "./payload-assembler";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,13 +1,11 @@
 import { join } from "path";
 import { FileSystemAdapter, Notice, type App } from "obsidian";
 import type {
-  BM25Index,
   IndexService,
   IngestionPipeline,
   IngestionStore,
   JobQueue,
   LLMService,
-  MutableLinksIndex,
   PathFilter,
   PayloadAssembler,
   Reconciler,
@@ -56,9 +54,7 @@ export interface Services {
   reconciler: Reconciler;
   vectorStore: VectorStore;
   embeddingService: EmbeddingService;
-  bm25Index: BM25Index;
   bm25IndexService: BM25IndexService;
-  linksIndex: MutableLinksIndex;
   linksIndexService: LinksIndexService;
   retriever: Retriever;
   payloadAssembler: PayloadAssembler;
@@ -153,9 +149,7 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     reconciler,
     vectorStore,
     embeddingService,
-    bm25Index,
     bm25IndexService,
-    linksIndex,
     linksIndexService,
     retriever,
     payloadAssembler,

--- a/src/services/payload-assembler.test.ts
+++ b/src/services/payload-assembler.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import type { RetrievalHit } from "../contracts";
+import { InMemoryLinksIndex } from "./in-memory-links-index";
+import { DefaultPayloadAssembler } from "./payload-assembler";
+
+function hit(partial: Partial<RetrievalHit> & { path: string }): RetrievalHit {
+  return {
+    path: partial.path,
+    title: partial.title ?? partial.path.replace(/^.*\//, "").replace(/\.md$/, ""),
+    ord: partial.ord ?? 0,
+    contentHash: partial.contentHash ?? `h:${partial.path}:${partial.ord ?? 0}`,
+    text: partial.text ?? `body of ${partial.path}`,
+    headingPath: partial.headingPath ?? [],
+    score: partial.score ?? 0.5,
+    winningSignal: partial.winningSignal ?? "semantic",
+  };
+}
+
+describe("DefaultPayloadAssembler", () => {
+  it("returns an empty payload when there are no hits", () => {
+    const links = new InMemoryLinksIndex();
+    const assembler = new DefaultPayloadAssembler(links);
+    expect(assembler.assemble("anything", [])).toEqual({ query: "anything", chunks: [] });
+  });
+
+  it("returns an empty payload when maxChunks is 0", () => {
+    const links = new InMemoryLinksIndex();
+    const assembler = new DefaultPayloadAssembler(links);
+    const result = assembler.assemble("q", [hit({ path: "a.md" })], { maxChunks: 0 });
+    expect(result.chunks).toEqual([]);
+  });
+
+  it("head-slices to maxChunks in retriever order without re-sorting", () => {
+    const links = new InMemoryLinksIndex();
+    const assembler = new DefaultPayloadAssembler(links);
+    const hits = [
+      hit({ path: "1.md", score: 0.1 }),
+      hit({ path: "2.md", score: 0.9 }),
+      hit({ path: "3.md", score: 0.5 }),
+    ];
+    const result = assembler.assemble("q", hits, { maxChunks: 2, includeNeighbors: false });
+    expect(result.chunks.map((c) => c.path)).toEqual(["1.md", "2.md"]);
+  });
+
+  it("defaults to maxChunks=8", () => {
+    const links = new InMemoryLinksIndex();
+    const assembler = new DefaultPayloadAssembler(links);
+    const hits = Array.from({ length: 12 }, (_, i) => hit({ path: `${i}.md`, ord: i }));
+    const result = assembler.assemble("q", hits, { includeNeighbors: false });
+    expect(result.chunks).toHaveLength(8);
+  });
+
+  it("projects hit fields and renames winningSignal to whyMatched", () => {
+    const links = new InMemoryLinksIndex();
+    const assembler = new DefaultPayloadAssembler(links);
+    const result = assembler.assemble(
+      "what is gemmera",
+      [
+        hit({
+          path: "Projects/Gemmera.md",
+          title: "Gemmera",
+          ord: 3,
+          headingPath: ["Overview", "Goals"],
+          text: "An Obsidian plugin.",
+          winningSignal: "backlink",
+          score: 0.42,
+        }),
+      ],
+      { includeNeighbors: false },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "chunks": [
+          {
+            "headingPath": [
+              "Overview",
+              "Goals",
+            ],
+            "path": "Projects/Gemmera.md",
+            "text": "An Obsidian plugin.",
+            "title": "Gemmera",
+            "whyMatched": "backlink",
+          },
+        ],
+        "query": "what is gemmera",
+      }
+    `);
+  });
+
+  it("omits score by default and forwards it when includeScores is true", () => {
+    const links = new InMemoryLinksIndex();
+    const assembler = new DefaultPayloadAssembler(links);
+    const hits = [hit({ path: "a.md", score: 0.73 })];
+
+    const noScore = assembler.assemble("q", hits, { includeNeighbors: false });
+    expect(noScore.chunks[0]).not.toHaveProperty("score");
+
+    const withScore = assembler.assemble("q", hits, {
+      includeNeighbors: false,
+      includeScores: true,
+    });
+    expect(withScore.chunks[0].score).toBe(0.73);
+  });
+
+  it("omits the neighbors field entirely when includeNeighbors is false", () => {
+    const links = new InMemoryLinksIndex();
+    links.upsert("a.md", [{ raw: "b" }]);
+    links.upsert("b.md", []);
+    const assembler = new DefaultPayloadAssembler(links);
+    const result = assembler.assemble("q", [hit({ path: "a.md" })], {
+      includeNeighbors: false,
+    });
+    expect(result.chunks[0]).not.toHaveProperty("neighbors");
+  });
+
+  it("emits an empty neighbors array when no links exist", () => {
+    const links = new InMemoryLinksIndex();
+    links.upsert("solo.md", []);
+    const assembler = new DefaultPayloadAssembler(links);
+    const result = assembler.assemble("q", [hit({ path: "solo.md" })]);
+    expect(result.chunks[0].neighbors).toEqual([]);
+  });
+
+  it("resolves outgoing + backlinks, dedups by path, drops self, derives titles by basename", () => {
+    const links = new InMemoryLinksIndex();
+    // Vault: Notes/Hub.md links to Sub.md and Other.md.
+    // Sub.md links back to Hub. Other.md links to Hub. Self-link from Hub→Hub.
+    links.upsert("Notes/Hub.md", [{ raw: "Sub" }, { raw: "Other" }, { raw: "Hub" }]);
+    links.upsert("Sub.md", [{ raw: "Hub" }]);
+    links.upsert("Other.md", [{ raw: "Hub" }]);
+
+    const assembler = new DefaultPayloadAssembler(links);
+    const result = assembler.assemble("q", [hit({ path: "Notes/Hub.md" })]);
+    // Outgoing first (Sub, Other; self skipped), then backlinks (Sub, Other
+    // already deduped). Titles via basename, no .md suffix.
+    expect(result.chunks[0].neighbors).toEqual(["Sub", "Other"]);
+  });
+
+  it("caps neighbors at maxNeighborsPerChunk", () => {
+    const links = new InMemoryLinksIndex();
+    links.upsert("hub.md", [
+      { raw: "n1" },
+      { raw: "n2" },
+      { raw: "n3" },
+      { raw: "n4" },
+      { raw: "n5" },
+      { raw: "n6" },
+    ]);
+    for (const n of ["n1", "n2", "n3", "n4", "n5", "n6"]) {
+      links.upsert(`${n}.md`, []);
+    }
+    const assembler = new DefaultPayloadAssembler(links);
+    const result = assembler.assemble("q", [hit({ path: "hub.md" })], {
+      maxNeighborsPerChunk: 3,
+    });
+    expect(result.chunks[0].neighbors).toEqual(["n1", "n2", "n3"]);
+  });
+
+  it("memoizes neighbor lookup across chunks from the same note", () => {
+    const links = new InMemoryLinksIndex();
+    links.upsert("note.md", [{ raw: "neighbor" }]);
+    links.upsert("neighbor.md", []);
+    let outgoingCalls = 0;
+    const spy = {
+      outgoing: (path: string) => {
+        outgoingCalls++;
+        return links.outgoing(path);
+      },
+      backlinks: (path: string) => links.backlinks(path),
+    };
+    const assembler = new DefaultPayloadAssembler(spy);
+    assembler.assemble("q", [
+      hit({ path: "note.md", ord: 0 }),
+      hit({ path: "note.md", ord: 1 }),
+      hit({ path: "note.md", ord: 2 }),
+    ]);
+    expect(outgoingCalls).toBe(1);
+  });
+
+  it("snapshots the full payload shape with neighbors and scores enabled", () => {
+    const links = new InMemoryLinksIndex();
+    links.upsert("Projects/Gemmera.md", [{ raw: "RAG" }]);
+    links.upsert("RAG.md", [{ raw: "Projects/Gemmera" }]);
+    const assembler = new DefaultPayloadAssembler(links);
+    const result = assembler.assemble(
+      "what is gemmera",
+      [
+        hit({
+          path: "Projects/Gemmera.md",
+          title: "Gemmera",
+          ord: 0,
+          headingPath: ["Overview"],
+          text: "An Obsidian plugin.",
+          winningSignal: "semantic",
+          score: 0.91,
+        }),
+        hit({
+          path: "RAG.md",
+          title: "RAG",
+          ord: 0,
+          headingPath: [],
+          text: "Retrieval-augmented generation.",
+          winningSignal: "lexical",
+          score: 0.42,
+        }),
+      ],
+      { includeScores: true, maxNeighborsPerChunk: 3 },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "chunks": [
+          {
+            "headingPath": [
+              "Overview",
+            ],
+            "neighbors": [
+              "RAG",
+            ],
+            "path": "Projects/Gemmera.md",
+            "score": 0.91,
+            "text": "An Obsidian plugin.",
+            "title": "Gemmera",
+            "whyMatched": "semantic",
+          },
+          {
+            "headingPath": [],
+            "neighbors": [
+              "Gemmera",
+            ],
+            "path": "RAG.md",
+            "score": 0.42,
+            "text": "Retrieval-augmented generation.",
+            "title": "RAG",
+            "whyMatched": "lexical",
+          },
+        ],
+        "query": "what is gemmera",
+      }
+    `);
+  });
+});

--- a/src/services/payload-assembler.test.ts
+++ b/src/services/payload-assembler.test.ts
@@ -161,12 +161,16 @@ describe("DefaultPayloadAssembler", () => {
     links.upsert("note.md", [{ raw: "neighbor" }]);
     links.upsert("neighbor.md", []);
     let outgoingCalls = 0;
+    let backlinksCalls = 0;
     const spy = {
       outgoing: (path: string) => {
         outgoingCalls++;
         return links.outgoing(path);
       },
-      backlinks: (path: string) => links.backlinks(path),
+      backlinks: (path: string) => {
+        backlinksCalls++;
+        return links.backlinks(path);
+      },
     };
     const assembler = new DefaultPayloadAssembler(spy);
     assembler.assemble("q", [
@@ -175,6 +179,7 @@ describe("DefaultPayloadAssembler", () => {
       hit({ path: "note.md", ord: 2 }),
     ]);
     expect(outgoingCalls).toBe(1);
+    expect(backlinksCalls).toBe(1);
   });
 
   it("snapshots the full payload shape with neighbors and scores enabled", () => {

--- a/src/services/payload-assembler.ts
+++ b/src/services/payload-assembler.ts
@@ -1,0 +1,107 @@
+import type {
+  LinksIndex,
+  PayloadAssembler,
+  PayloadAssemblerOptions,
+  PayloadChunk,
+  RetrievalHit,
+  RetrievalPayload,
+} from "../contracts";
+
+const DEFAULT_MAX_CHUNKS = 8;
+const DEFAULT_MAX_NEIGHBORS = 5;
+
+/**
+ * Default PayloadAssembler (#10).
+ *
+ * Bridges retriever output to the bounded structured object the chat loop
+ * hands to Gemma. The retriever ranks; this layer shapes. They're split so
+ * the retriever can change algorithms without disturbing the prompt-facing
+ * fields, and so #16's eval harness can target a stable payload shape.
+ *
+ * Three jobs:
+ *   1. Head-slice hits to `maxChunks` (already retriever-sorted).
+ *   2. Project `RetrievalHit → PayloadChunk`, dropping retrieval internals
+ *      (contentHash, ord, and score unless `includeScores`) and renaming
+ *      `winningSignal → whyMatched` for the prompt template.
+ *   3. Resolve 1-hop neighbors via LinksIndex (outgoing + backlinks),
+ *      dedup by path, drop self, derive titles by basename, cap per chunk.
+ *
+ * `LinksIndex` is read-only here; updates flow through LinksIndexService.
+ * Neighbor lookups are memoized by path within a single assemble() call so
+ * adjacent chunks from the same note don't re-scan the link graph.
+ */
+export class DefaultPayloadAssembler implements PayloadAssembler {
+  constructor(private readonly links: Pick<LinksIndex, "outgoing" | "backlinks">) {}
+
+  assemble(
+    query: string,
+    hits: RetrievalHit[],
+    opts: PayloadAssemblerOptions = {},
+  ): RetrievalPayload {
+    const maxChunks = opts.maxChunks ?? DEFAULT_MAX_CHUNKS;
+    const includeScores = opts.includeScores ?? false;
+    const includeNeighbors = opts.includeNeighbors ?? true;
+    const maxNeighborsPerChunk = opts.maxNeighborsPerChunk ?? DEFAULT_MAX_NEIGHBORS;
+
+    if (maxChunks <= 0 || hits.length === 0) {
+      return { query, chunks: [] };
+    }
+
+    const top = hits.slice(0, maxChunks);
+    const neighborCache = new Map<string, string[]>();
+
+    const chunks: PayloadChunk[] = top.map((hit) => {
+      const chunk: PayloadChunk = {
+        path: hit.path,
+        title: hit.title,
+        headingPath: hit.headingPath,
+        text: hit.text,
+        whyMatched: hit.winningSignal,
+      };
+      if (includeScores) chunk.score = hit.score;
+      if (includeNeighbors) {
+        let neighbors = neighborCache.get(hit.path);
+        if (!neighbors) {
+          neighbors = resolveNeighbors(this.links, hit.path, maxNeighborsPerChunk);
+          neighborCache.set(hit.path, neighbors);
+        }
+        chunk.neighbors = neighbors;
+      }
+      return chunk;
+    });
+
+    return { query, chunks };
+  }
+}
+
+function resolveNeighbors(
+  links: Pick<LinksIndex, "outgoing" | "backlinks">,
+  path: string,
+  cap: number,
+): string[] {
+  if (cap <= 0) return [];
+  // Order: outgoing-resolved first, then backlinks. Dedup by path before the
+  // cap so a noisy hub doesn't crowd out distinct neighbors.
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const link of links.outgoing(path)) {
+    if (!link.resolved || !link.target) continue;
+    if (link.target === path) continue;
+    if (seen.has(link.target)) continue;
+    seen.add(link.target);
+    paths.push(link.target);
+  }
+  for (const source of links.backlinks(path)) {
+    if (source === path) continue;
+    if (seen.has(source)) continue;
+    seen.add(source);
+    paths.push(source);
+  }
+  return paths.slice(0, cap).map(titleOf);
+}
+
+function titleOf(path: string): string {
+  const slash = path.lastIndexOf("/");
+  const file = slash === -1 ? path : path.slice(slash + 1);
+  return file.replace(/\.md$/i, "");
+}

--- a/src/services/payload-assembler.ts
+++ b/src/services/payload-assembler.ts
@@ -80,11 +80,14 @@ function resolveNeighbors(
   cap: number,
 ): string[] {
   if (cap <= 0) return [];
-  // Order: outgoing-resolved first, then backlinks. Dedup by path before the
-  // cap so a noisy hub doesn't crowd out distinct neighbors.
+  // Order: outgoing-resolved first, then backlinks. Dedup by path so a noisy
+  // hub doesn't crowd out distinct neighbors. Each loop breaks once `cap`
+  // paths are collected — a hub with hundreds of edges would otherwise scan
+  // the full edge list before slicing.
   const seen = new Set<string>();
   const paths: string[] = [];
   for (const link of links.outgoing(path)) {
+    if (paths.length >= cap) break;
     if (!link.resolved || !link.target) continue;
     if (link.target === path) continue;
     if (seen.has(link.target)) continue;
@@ -92,14 +95,19 @@ function resolveNeighbors(
     paths.push(link.target);
   }
   for (const source of links.backlinks(path)) {
+    if (paths.length >= cap) break;
     if (source === path) continue;
     if (seen.has(source)) continue;
     seen.add(source);
     paths.push(source);
   }
-  return paths.slice(0, cap).map(titleOf);
+  return paths.map(titleOf);
 }
 
+// Mirrors HybridRetriever.titleOf: derive the title from the path basename
+// rather than the note's frontmatter `title`. This keeps neighbor titles
+// consistent with `RetrievalHit.title` so the prompt sees one rule for both.
+// Revisit if frontmatter titles become universally parsed.
 function titleOf(path: string): string {
   const slash = path.lastIndexOf("/");
   const file = slash === -1 ? path : path.slice(slash + 1);


### PR DESCRIPTION
## What

Two RAG v1 issues in one PR:

- **Wires the retrieval stack into the plugin lifecycle** (was previously orphaned). `services/index.ts` now constructs `InMemoryBM25Index` + `BM25IndexService`, `InMemoryLinksIndex` + `LinksIndexService`, and `HybridRetriever`, and exposes them on the `Services` bag. `main.ts` starts/stops the two new services next to `EmbeddingService` and wires matching debug logs.
- **Implements `DefaultPayloadAssembler` (#10)** per the contract in `src/contracts/retrieval.ts`: head-slices to `maxChunks` (default 8), projects `RetrievalHit → PayloadChunk` dropping retrieval internals, renames `winningSignal → whyMatched`, and resolves 1-hop neighbors via `LinksIndex` with per-chunk memoization and a configurable cap.

Side note: also rolls in the `.gitignore` tweak that was sitting uncommitted on `dev` — broadens the `demo-vault/**/.obsidian/` ignore globs so both `demo-vault/` and `demo-vault/raw/` work as vault roots.

## Why

`HybridRetriever` (PR #99, issue #8) was merged but never instantiated — `grep` for it in `main.ts` / `services/index.ts` returned nothing. Same for `BM25IndexService` and `LinksIndexService`. This PR un-orphans ~600 lines of tested code and unblocks #14 (query tool loop) by giving it a `retriever` and `payloadAssembler` to call.

#10 was already designed at the contract layer; this PR ships the implementation, leaving the chat-view integration as a clean follow-up.

## How to test

- `npm test` — 432 tests (was 420), 12 new for the payload assembler covering empty input, head-slice without re-sort, default `maxChunks=8`, projection + signal rename, `includeScores` flag, `includeNeighbors=false` field-omission, empty-array vs absent semantics, outgoing+backlinks dedup with self-skip, `maxNeighborsPerChunk` cap, neighbor memoization, and a full snapshot of a two-chunk payload with neighbors enabled
- `npx tsc --noEmit` — clean
- Manual: rebuild the plugin, reload Obsidian — debug logs should now show `[gemmera] bm25:added <path> (N)` and `[gemmera] links:indexed <path> (N)` after edits

Closes #8
Closes #10