### PR TITLE
feat(rag): indexer ops surface (#15) + ingest tool loop (#13)

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -12,3 +12,22 @@ export class Plugin {}
 export class WorkspaceLeaf {}
 export class ItemView {}
 export class MarkdownRenderer {}
+
+// Minimal stand-ins for tests that reference UI types but don't actually
+// render. Real Obsidian provides full implementations at runtime.
+export class Modal {
+  contentEl: { empty: () => void; createEl: () => unknown } = {
+    empty: () => {},
+    createEl: () => ({}),
+  };
+  open(): void {}
+  close(): void {}
+}
+export class PluginSettingTab {}
+export class Setting {
+  setName(_n: string): this { return this; }
+  setDesc(_d: string): this { return this; }
+  addToggle(_cb: (...args: unknown[]) => unknown): this { return this; }
+  addButton(_cb: (...args: unknown[]) => unknown): this { return this; }
+  addText(_cb: (...args: unknown[]) => unknown): this { return this; }
+}

--- a/prompts/dedup-decider.md
+++ b/prompts/dedup-decider.md
@@ -1,18 +1,28 @@
-version: 0.1.0
+version: 0.2.0
 
 # dedup-decider
 
-Given a candidate note and its top-k similar existing notes, decides
-the dedup strategy: propose new, append to existing, or split into
-multiple notes.
+You compare a candidate note against the user's most-similar existing
+notes and pick a storage strategy.
 
-## Input
-- Candidate NoteSpec.
-- Top-k similar notes with similarity scores.
+## Decisions
+
+- `new` — the candidate is genuinely distinct, even if related notes
+  exist. Default to this when in doubt.
+- `append` — the candidate naturally extends one specific existing note
+  (the user is adding to an ongoing log, project page, or person profile).
+  Provide its `targetPath`.
+- `ask_user` — there is a near-duplicate but you can't tell whether the
+  user wants to merge or branch off. Provide the closest match in
+  `targetPath`. The app will surface a confirmation modal.
+
+## Inputs
+
+- `candidate.title`, `candidate.summary`, `candidate.tags`
+- `similar[]`: ranked existing notes with `path`, `title`, `score`, and a
+  short `snippet`.
 
 ## Output
-JSON with `strategy` (one of `new`, `append`, `split`, `ask_user`),
-`targetPath` (for append), and brief reasoning shown to the user.
 
-## Status
-Scaffold. Exact wording filled in by a separate task.
+Return ONLY a JSON object: `{ "strategy": "new"|"append"|"ask_user",
+"targetPath"?: string, "reason": string }`. No prose, no code fences.

--- a/prompts/ingest-parser.md
+++ b/prompts/ingest-parser.md
@@ -1,16 +1,31 @@
-version: 0.1.0
+version: 0.2.0
 
 # ingest-parser
 
-Turns raw user content into a structured NoteSpec candidate.
+You convert raw user content into a structured note candidate (a NoteSpec).
+Your output is consumed by a deterministic writer; off-schema responses are
+rejected.
 
-## Input
-- Raw user content (Markdown, plain text, or pasted snippet).
-- Optional user instruction (e.g. "save this as a meeting note").
+## Goals
+
+1. Pick a concise, descriptive `title` (≤ 80 chars).
+2. Choose a `type` from: source, evergreen, project, meeting, person,
+   concept. Default to "source" when unsure.
+3. Extract `tags` (lowercase, kebab-case) and `entities` (proper nouns).
+4. Write a 1–3 sentence `summary` and a few `key_points`.
+5. Place the user's content (lightly cleaned, no frontmatter) in
+   `body_markdown`.
+
+## Hard rules
+
+- `body_markdown` MUST NOT begin with `---` or contain a YAML frontmatter
+  block. The app composes the file's frontmatter separately.
+- Every list field (tags, aliases, entities, related, key_points) must be
+  an array. Use `[]` if there's nothing to add.
+- `confidence` is your own self-assessment of how certain you are about
+  the type and tags. Low confidence will route the result through a
+  preview modal.
 
 ## Output
-JSON matching the NoteSpec contract in `planning/rag.md`. Includes a title
-guess, type, tags, summary, and the body Markdown.
 
-## Status
-Scaffold. Exact wording filled in by a separate task.
+Return ONLY a JSON object. No prose, no code fences.

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -15,3 +15,4 @@ export * from "./prompts";
 export * from "./constrained-decoder";
 export * from "./hard-stops";
 export * from "./classifier";
+export * from "./ingest";

--- a/src/contracts/ingest.ts
+++ b/src/contracts/ingest.ts
@@ -1,0 +1,78 @@
+/**
+ * Contracts for the ingest tool loop (#13). The shape that
+ * `IngestOrchestrator` produces and the preview modal consumes. Mirrors the
+ * frontmatter contract in planning/rag.md §"Frontmatter contract".
+ */
+
+export type NoteType =
+  | "source"
+  | "evergreen"
+  | "project"
+  | "meeting"
+  | "person"
+  | "concept";
+
+export type NoteSource =
+  | "chat-paste"
+  | "pdf"
+  | "webpage"
+  | "image"
+  | "audio"
+  | "manual";
+
+export type CoworkConfidence = "high" | "medium" | "low";
+
+/**
+ * Structured candidate produced by the ingest parser. Validated against
+ * `prompts/ingest-parser.schema.json` before reaching the writer.
+ */
+export interface NoteSpec {
+  title: string;
+  type: NoteType;
+  tags: string[];
+  aliases: string[];
+  source: NoteSource;
+  entities: string[];
+  /** Suggested related note paths from retrieve_similar_notes. */
+  related: string[];
+  status: "inbox" | "processed" | "linked" | "archived";
+  summary: string;
+  key_points: string[];
+  body_markdown: string;
+  cowork: {
+    source: "ingest" | "synthesis";
+    run_id: string;
+    model: string;
+    version: string;
+    confidence: CoworkConfidence;
+  };
+}
+
+/**
+ * Decision the strategy step makes after parse + search_similar.
+ *
+ * - `create`: write a new note. `related` carries any link suggestions.
+ * - `append`: append the body under a dated heading in `target`.
+ * - `dedup_ask`: a near or exact duplicate exists; the preview modal asks
+ *    the user to append, save anyway, or cancel. `target` is the matched note.
+ */
+export type IngestStrategy =
+  | { kind: "create"; related: string[] }
+  | { kind: "append"; target: string }
+  | { kind: "dedup_ask"; target: string; similarity: number };
+
+/** What the user picked in the dedup modal. */
+export type DedupChoice = "append" | "save_anyway" | "cancel";
+
+export interface IngestInput {
+  /** Raw user content (chat paste, drop, etc). */
+  text: string;
+  /** Optional explicit instruction ("save this as a meeting note"). */
+  instruction?: string;
+}
+
+export type IngestOutcome =
+  | { kind: "saved"; path: string; mode: "create" | "append"; spec: NoteSpec }
+  | { kind: "skipped_existing"; path: string; reason: "exact_duplicate" }
+  | { kind: "cancelled" }
+  | { kind: "failed"; reason: string };

--- a/src/contracts/ingestion.ts
+++ b/src/contracts/ingestion.ts
@@ -101,6 +101,13 @@ export interface IngestionStore {
 
   /** Write a runtime metadata value. Persisted alongside note state. */
   setMeta<K extends keyof IngestionMeta>(key: K, value: IngestionMeta[K]): Promise<void>;
+
+  /**
+   * Find note paths whose stored `bodyHash` matches `hash`. Used by the
+   * ingest tool loop (#13) to short-circuit exact-content duplicates
+   * without paying for an LLM call. Returns `[]` for no match.
+   */
+  findByBodyHash(hash: string): Promise<string[]>;
 }
 
 export interface IngestionPipeline {

--- a/src/contracts/ingestion.ts
+++ b/src/contracts/ingestion.ts
@@ -6,7 +6,47 @@ export interface NoteState {
   bodyHash: string; // sha256 of body after frontmatter strip
   mtime: number;
   frontmatter: string | null; // raw YAML between --- fences, null if absent
+  /**
+   * Rebuild epoch this note was last processed under (#15d). When the user
+   * triggers "Rebuild index", the global `rebuildEpoch` meta value is bumped;
+   * any note with `lastEpoch < rebuildEpoch` is treated as stale by the
+   * reconciler and re-enqueued. Resumability falls out for free: an interrupted
+   * rebuild just leaves some `lastEpoch` values un-bumped.
+   */
+  lastEpoch?: number;
 }
+
+/**
+ * Drift summary produced by the weekly reconciler (#15e). Counts what changed
+ * between the disk vault and the ingestion store since the last reconcile.
+ */
+export interface DriftReport {
+  ranAt: number;
+  added: string[];
+  removed: string[];
+  hashChanged: string[];
+}
+
+/**
+ * Process-wide ingestion metadata — runtime knobs that need to survive plugin
+ * reloads. Distinct from per-note state because it's keyed by setting name,
+ * not path. Persisted in the same JSON store under a separate `meta` namespace.
+ */
+export interface IngestionMeta {
+  paused: boolean;
+  rebuildEpoch: number;
+  lastReconciledAt: number;
+  lastRebuiltAt: number;
+  lastDriftReport: DriftReport | null;
+}
+
+export const DEFAULT_INGESTION_META: IngestionMeta = {
+  paused: false,
+  rebuildEpoch: 0,
+  lastReconciledAt: 0,
+  lastRebuiltAt: 0,
+  lastDriftReport: null,
+};
 
 export type IngestDecision =
   | { kind: "skip"; state: NoteState }
@@ -52,6 +92,15 @@ export interface IngestionStore {
    * the retriever to hydrate `RetrievalHit` rows from a hash-keyed search.
    */
   getChunksByHash(contentHash: string): Promise<Chunk[]>;
+
+  /**
+   * Read a runtime metadata value (#15). Returns `null` for unset keys so
+   * callers can distinguish "never written" from "explicitly false/0".
+   */
+  getMeta<K extends keyof IngestionMeta>(key: K): Promise<IngestionMeta[K] | null>;
+
+  /** Write a runtime metadata value. Persisted alongside note state. */
+  setMeta<K extends keyof IngestionMeta>(key: K, value: IngestionMeta[K]): Promise<void>;
 }
 
 export interface IngestionPipeline {

--- a/src/contracts/mocks/in-memory-ingestion-store.ts
+++ b/src/contracts/mocks/in-memory-ingestion-store.ts
@@ -1,9 +1,10 @@
 import type { Chunk } from "../chunker";
-import type { IngestionStore, NoteState } from "../ingestion";
+import type { IngestionMeta, IngestionStore, NoteState } from "../ingestion";
 
 export class InMemoryIngestionStore implements IngestionStore {
   private notes = new Map<string, NoteState>();
   private chunks = new Map<string, Chunk[]>();
+  private meta: Partial<IngestionMeta> = {};
 
   async get(path: string): Promise<NoteState | null> {
     return this.notes.get(path) ?? null;
@@ -48,6 +49,15 @@ export class InMemoryIngestionStore implements IngestionStore {
       }
     }
     return false;
+  }
+
+  async getMeta<K extends keyof IngestionMeta>(key: K): Promise<IngestionMeta[K] | null> {
+    const value = this.meta[key];
+    return value === undefined ? null : (value as IngestionMeta[K]);
+  }
+
+  async setMeta<K extends keyof IngestionMeta>(key: K, value: IngestionMeta[K]): Promise<void> {
+    this.meta[key] = value;
   }
 
   async getChunksByHash(contentHash: string): Promise<Chunk[]> {

--- a/src/contracts/mocks/in-memory-ingestion-store.ts
+++ b/src/contracts/mocks/in-memory-ingestion-store.ts
@@ -69,4 +69,12 @@ export class InMemoryIngestionStore implements IngestionStore {
     }
     return out;
   }
+
+  async findByBodyHash(hash: string): Promise<string[]> {
+    const out: string[] = [];
+    for (const state of this.notes.values()) {
+      if (state.bodyHash === hash) out.push(state.path);
+    }
+    return out;
+  }
 }

--- a/src/contracts/mocks/mock-vault.ts
+++ b/src/contracts/mocks/mock-vault.ts
@@ -1,8 +1,9 @@
-import type { HeadingRef, VaultFileRef, VaultService } from "../vault";
+import type { HeadingRef, VaultFileRef, VaultService, VaultStat } from "../vault";
 
 export class MockVaultService implements VaultService {
   private files = new Map<string, string>();
   private headings = new Map<string, HeadingRef[]>();
+  private mtimes = new Map<string, number>();
 
   constructor(initial: Record<string, string> = {}) {
     for (const [path, content] of Object.entries(initial)) {
@@ -44,6 +45,16 @@ export class MockVaultService implements VaultService {
 
   async getHeadings(path: string): Promise<HeadingRef[]> {
     return this.headings.get(path) ?? [];
+  }
+
+  async stat(path: string): Promise<VaultStat> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`File not found: ${path}`);
+    return { mtime: this.mtimes.get(path) ?? 0, size: content.length };
+  }
+
+  setMtime(path: string, mtime: number): void {
+    this.mtimes.set(path, mtime);
   }
 
   setHeadings(path: string, headings: HeadingRef[] | string[]): void {

--- a/src/contracts/vault.ts
+++ b/src/contracts/vault.ts
@@ -9,6 +9,11 @@ export interface HeadingRef {
   offset: number; // character offset of the heading line in the raw file
 }
 
+export interface VaultStat {
+  mtime: number;
+  size: number;
+}
+
 export interface VaultService {
   listMarkdownFiles(): Promise<VaultFileRef[]>;
   read(path: string): Promise<string>;
@@ -16,4 +21,10 @@ export interface VaultService {
   create(path: string, content: string): Promise<void>;
   append(path: string, content: string): Promise<void>;
   getHeadings(path: string): Promise<HeadingRef[]>;
+  /**
+   * Lightweight metadata accessor. Avoids reading file contents — used by
+   * the weekly reconciler (#15e) to skip rehashing files whose mtime hasn't
+   * changed.
+   */
+  stat(path: string): Promise<VaultStat>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,15 +31,18 @@ export default class GemmeraPlugin extends Plugin {
       .start()
       .catch((err) => console.error("[gemmera] scheduled reconcile failed", err));
 
-    this.addSettingTab(
-      new GemmeraSettingsTab(
-        this.app,
-        this,
-        this.services.runnerControls,
-        this.services.scheduledReconciler,
-        this.services.ingestionStore,
-      ),
+    const settingsTab = new GemmeraSettingsTab(
+      this.app,
+      this,
+      this.services.runnerControls,
+      this.services.scheduledReconciler,
+      this.services.ingestionStore,
+      this.settings,
+      () => this.saveData(this.settings),
     );
+    // Pre-load the snapshot so the first paint of the tab is sync.
+    void settingsTab.refresh();
+    this.addSettingTab(settingsTab);
 
     this.registerView(
       VIEW_TYPE,

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,10 @@ export default class GemmeraPlugin extends Plugin {
       ),
     );
 
-    this.registerView(VIEW_TYPE, (leaf) => new GemmeraChatView(leaf, this.services));
+    this.registerView(
+      VIEW_TYPE,
+      (leaf) => new GemmeraChatView(leaf, this.services, this.settings),
+    );
 
     this.addRibbonIcon("message-square", "Gemmera", () => {
       this.openChatView();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { FileSystemAdapter, Plugin, WorkspaceLeaf } from "obsidian";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
 import { DEFAULT_SETTINGS, GemmeraSettings } from "./settings";
+import { GemmeraSettingsTab } from "./ui/settings-tab";
 
 export default class GemmeraPlugin extends Plugin {
   private services!: Services;
@@ -14,11 +15,29 @@ export default class GemmeraPlugin extends Plugin {
     this.services.eventBridge.start();
     this.services.ingestionRunner.start();
     this.services.embeddingService.start();
+    this.services.runnerStatus.start();
+    // Restore persisted pause flag before any work claims start.
+    await this.services.runnerControls.applyPersistedState();
     this.wireDebugLogs();
     // Fire reconcile in the background — hash gate keeps it cheap on warm reloads.
     this.services.reconciler
       .reconcile()
+      .then(() => this.services.runnerStatus.recompute())
       .catch((err) => console.error("[gemmera] reconcile failed", err));
+    // Schedule the weekly drift check (#15e). Runs immediately if overdue.
+    this.services.scheduledReconciler
+      .start()
+      .catch((err) => console.error("[gemmera] scheduled reconcile failed", err));
+
+    this.addSettingTab(
+      new GemmeraSettingsTab(
+        this.app,
+        this,
+        this.services.runnerControls,
+        this.services.scheduledReconciler,
+        this.services.ingestionStore,
+      ),
+    );
 
     this.registerView(VIEW_TYPE, (leaf) => new GemmeraChatView(leaf, this.services));
 
@@ -35,6 +54,8 @@ export default class GemmeraPlugin extends Plugin {
 
   async onunload(): Promise<void> {
     this.services?.eventBridge.stop();
+    this.services?.runnerStatus.stop();
+    this.services?.scheduledReconciler.stop();
     if (this.services) {
       await this.services.ingestionRunner.stop();
       await this.services.embeddingService.stop();

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,14 @@ export default class GemmeraPlugin extends Plugin {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
     const pluginDir = (this.app.vault.adapter as FileSystemAdapter).getFullPath(this.manifest.dir ?? ".obsidian/plugins/gemmera");
     this.services = await createServices(this.app, this.settings, pluginDir);
+    // Apply persisted pause flag BEFORE any service can claim work — otherwise
+    // a vault event firing between subscribe and applyPersistedState could
+    // process jobs the user expected to stay paused.
+    await this.services.runnerControls.applyPersistedState();
     this.services.eventBridge.start();
     this.services.ingestionRunner.start();
     this.services.embeddingService.start();
     this.services.runnerStatus.start();
-    // Restore persisted pause flag before any work claims start.
-    await this.services.runnerControls.applyPersistedState();
     this.wireDebugLogs();
     // Fire reconcile in the background — hash gate keeps it cheap on warm reloads.
     this.services.reconciler

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -36,7 +36,8 @@ import { RunnerStatus } from "./runner-status";
 import { RunnerControls } from "./runner-controls";
 import { ScheduledReconciler } from "./scheduled-reconciler";
 import { IngestWriter } from "./ingest-writer";
-import type { Retriever } from "../contracts";
+import { InMemoryEventLog } from "./event-log";
+import type { EventLog, Retriever } from "../contracts";
 
 /**
  * Cold-vault stand-in retriever. Returns no hits — used until the hybrid
@@ -67,6 +68,7 @@ export interface Services {
   scheduledReconciler: ScheduledReconciler;
   ingestWriter: IngestWriter;
   retriever: Retriever;
+  eventLog: EventLog;
 }
 
 const STATE_PATH = ".coworkmd/state.json";
@@ -177,6 +179,7 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     scheduledReconciler,
     ingestWriter: new IngestWriter(vault),
     retriever: new EmptyRetriever(),
+    eventLog: new InMemoryEventLog(),
   };
 }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -32,6 +32,9 @@ import { VaultReconciler } from "./vault-reconciler";
 import { BinaryVectorStore } from "./binary-vector-store";
 import { OllamaEmbedder } from "./ollama-embedder";
 import { EmbeddingService } from "./embedding-service";
+import { RunnerStatus } from "./runner-status";
+import { RunnerControls } from "./runner-controls";
+import { ScheduledReconciler } from "./scheduled-reconciler";
 
 export interface Services {
   llm: LLMService;
@@ -48,6 +51,9 @@ export interface Services {
   embeddingService: EmbeddingService;
   promptLoader: PromptLoader;
   classifierEventWriter: ClassifierEventWriter;
+  runnerStatus: RunnerStatus;
+  runnerControls: RunnerControls;
+  scheduledReconciler: ScheduledReconciler;
 }
 
 const STATE_PATH = ".coworkmd/state.json";
@@ -87,13 +93,40 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     );
   }
   const ingestionStore = new JsonIngestionStore(adapter.getFullPath(STATE_PATH));
+  // Closure capture: RunnerControls bumps `meta.rebuildEpoch`; the pipeline
+  // reads it on every ingest. We can't `await` here, so we stash the latest
+  // value in a process-local cell and refresh on every meta write below.
+  const epochCell = { value: 0 };
   const ingestionPipeline = new HashGatedIngestionPipeline(
     vault,
     new MarkdownChunker(),
     ingestionStore,
+    () => epochCell.value,
   );
   const ingestionRunner = new IngestionRunner(jobQueue, ingestionPipeline, ingestionStore);
   const reconciler = new VaultReconciler(vault, ingestionStore, jobQueue, pathFilter);
+  const runnerStatus = new RunnerStatus(jobQueue, ingestionRunner);
+  const runnerControls = new RunnerControls(
+    ingestionRunner,
+    runnerStatus,
+    ingestionStore,
+    reconciler,
+    jobQueue,
+  );
+  const scheduledReconciler = new ScheduledReconciler({
+    vault,
+    store: ingestionStore,
+    reconciler,
+  });
+  // Seed the epoch cell from persisted meta so rebuilds survive reload.
+  epochCell.value = (await ingestionStore.getMeta("rebuildEpoch")) ?? 0;
+  // Re-read after rebuild so the pipeline's hash gate sees the new epoch.
+  const origRebuild = runnerControls.rebuild.bind(runnerControls);
+  runnerControls.rebuild = async () => {
+    const result = await origRebuild();
+    epochCell.value = (await ingestionStore.getMeta("rebuildEpoch")) ?? epochCell.value;
+    return result;
+  };
   const vectorStore = new BinaryVectorStore(
     adapter.getFullPath(VECTORS_BIN_PATH),
     adapter.getFullPath(VECTORS_JSON_PATH),
@@ -126,6 +159,9 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     embeddingService,
     promptLoader: new FilePromptLoader(join(pluginDir, "prompts")),
     classifierEventWriter: new InMemoryClassifierEventWriter(),
+    runnerStatus,
+    runnerControls,
+    scheduledReconciler,
   };
 }
 
@@ -144,3 +180,6 @@ export { VaultReconciler } from "./vault-reconciler";
 export { BinaryVectorStore } from "./binary-vector-store";
 export { OllamaEmbedder } from "./ollama-embedder";
 export { EmbeddingService } from "./embedding-service";
+export { RunnerStatus } from "./runner-status";
+export { RunnerControls } from "./runner-controls";
+export { ScheduledReconciler } from "./scheduled-reconciler";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -35,6 +35,17 @@ import { EmbeddingService } from "./embedding-service";
 import { RunnerStatus } from "./runner-status";
 import { RunnerControls } from "./runner-controls";
 import { ScheduledReconciler } from "./scheduled-reconciler";
+import { IngestWriter } from "./ingest-writer";
+import type { Retriever } from "../contracts";
+
+/**
+ * Cold-vault stand-in retriever. Returns no hits — used until the hybrid
+ * retriever (#8) is wired into the dev branch. The strategy step already
+ * tolerates an empty result and falls through to a `create` decision.
+ */
+class EmptyRetriever implements Retriever {
+  async retrieve() { return []; }
+}
 
 export interface Services {
   llm: LLMService;
@@ -54,6 +65,8 @@ export interface Services {
   runnerStatus: RunnerStatus;
   runnerControls: RunnerControls;
   scheduledReconciler: ScheduledReconciler;
+  ingestWriter: IngestWriter;
+  retriever: Retriever;
 }
 
 const STATE_PATH = ".coworkmd/state.json";
@@ -162,6 +175,8 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     runnerStatus,
     runnerControls,
     scheduledReconciler,
+    ingestWriter: new IngestWriter(vault),
+    retriever: new EmptyRetriever(),
   };
 }
 
@@ -183,3 +198,10 @@ export { EmbeddingService } from "./embedding-service";
 export { RunnerStatus } from "./runner-status";
 export { RunnerControls } from "./runner-controls";
 export { ScheduledReconciler } from "./scheduled-reconciler";
+export { IngestWriter } from "./ingest-writer";
+export { runIngest } from "./ingest-orchestrator";
+export type {
+  IngestPreview,
+  PreviewDecision,
+  PreviewHandler,
+} from "./ingest-orchestrator";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -41,11 +41,23 @@ import type { EventLog, Retriever } from "../contracts";
 
 /**
  * Cold-vault stand-in retriever. Returns no hits — used until the hybrid
- * retriever (#8) is wired into the dev branch. The strategy step already
- * tolerates an empty result and falls through to a `create` decision.
+ * retriever (#8) is wired into the dev branch. The strategy step tolerates
+ * an empty result and falls through to a `create` decision.
+ *
+ * TODO(#8): replace with HybridRetriever once the wiring branch lands.
  */
 class EmptyRetriever implements Retriever {
-  async retrieve() { return []; }
+  private warned = false;
+  async retrieve(): Promise<[]> {
+    if (!this.warned) {
+      this.warned = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[gemmera] retriever stub — similarity-based dedup is disabled until #8 lands",
+      );
+    }
+    return [];
+  }
 }
 
 export interface Services {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -120,10 +120,11 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     );
   }
   const ingestionStore = new JsonIngestionStore(adapter.getFullPath(STATE_PATH));
-  // Closure capture: RunnerControls bumps `meta.rebuildEpoch`; the pipeline
-  // reads it on every ingest. We can't `await` here, so we stash the latest
-  // value in a process-local cell and refresh on every meta write below.
-  const epochCell = { value: 0 };
+  // Closure cell so the synchronous epoch source the pipeline reads can be
+  // refreshed after async rebuilds. RunnerControls calls `onRebuild` once
+  // the new epoch is in store meta; the hook below refreshes the cell so
+  // the pipeline's hash gate sees the bump on the next ingest.
+  const epochCell = { value: (await ingestionStore.getMeta("rebuildEpoch")) ?? 0 };
   const ingestionPipeline = new HashGatedIngestionPipeline(
     vault,
     new MarkdownChunker(),
@@ -139,21 +140,17 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
     ingestionStore,
     reconciler,
     jobQueue,
+    {
+      onRebuild: async () => {
+        epochCell.value = (await ingestionStore.getMeta("rebuildEpoch")) ?? epochCell.value;
+      },
+    },
   );
   const scheduledReconciler = new ScheduledReconciler({
     vault,
     store: ingestionStore,
     reconciler,
   });
-  // Seed the epoch cell from persisted meta so rebuilds survive reload.
-  epochCell.value = (await ingestionStore.getMeta("rebuildEpoch")) ?? 0;
-  // Re-read after rebuild so the pipeline's hash gate sees the new epoch.
-  const origRebuild = runnerControls.rebuild.bind(runnerControls);
-  runnerControls.rebuild = async () => {
-    const result = await origRebuild();
-    epochCell.value = (await ingestionStore.getMeta("rebuildEpoch")) ?? epochCell.value;
-    return result;
-  };
   const vectorStore = new BinaryVectorStore(
     adapter.getFullPath(VECTORS_BIN_PATH),
     adapter.getFullPath(VECTORS_JSON_PATH),

--- a/src/services/ingest-orchestrator.test.ts
+++ b/src/services/ingest-orchestrator.test.ts
@@ -200,6 +200,41 @@ describe("runIngest", () => {
     expect(result.kind).toBe("cancelled");
   });
 
+  it("alwaysPreview=false: bypasses preview for high-confidence creates", async () => {
+    let previewCalls = 0;
+    const handler: PreviewHandler = async () => {
+      previewCalls++;
+      return { action: "confirm" };
+    };
+    const { deps } = setup({ preview: handler });
+    const result = await runIngest(
+      { text: "x" },
+      { ...deps, alwaysPreview: false },
+    );
+    expect(result.kind).toBe("saved");
+    expect(previewCalls).toBe(0);
+  });
+
+  it("alwaysPreview=false: still previews for append and dedup_ask", async () => {
+    const body = "# Decisions\n\nWe ship v2.";
+    const bodyHash = createHash("sha256").update(body).digest("hex");
+    let previewCalls = 0;
+    const handler: PreviewHandler = async () => {
+      previewCalls++;
+      return { action: "dedup_choice", choice: "append" };
+    };
+    const { deps } = setup({
+      vaultFiles: { "Existing/standup.md": "# Existing\n" },
+      storeNotes: [{ path: "Existing/standup.md", bodyHash }],
+      preview: handler,
+    });
+    await runIngest(
+      { text: "Q2 standup notes" },
+      { ...deps, alwaysPreview: false },
+    );
+    expect(previewCalls).toBeGreaterThan(0);
+  });
+
   it("emits an event-log entry for every orchestrator phase (issue #13 acceptance)", async () => {
     const { deps } = setup({ preview: autoConfirm });
     const eventLog = new InMemoryEventLog();

--- a/src/services/ingest-orchestrator.test.ts
+++ b/src/services/ingest-orchestrator.test.ts
@@ -7,7 +7,6 @@ import { IngestWriter } from "./ingest-writer";
 import { runIngest, type PreviewDecision, type PreviewHandler } from "./ingest-orchestrator";
 import type {
   ChatOptions,
-  Chunk,
   LLMReachability,
   LLMResponse,
   LLMService,
@@ -61,16 +60,16 @@ function setup(opts: {
   vaultFiles?: Record<string, string>;
   retrieverHits?: RetrievalHit[];
   preview: PreviewHandler;
-  storeChunks?: Array<{ path: string; chunk: Chunk }>;
+  /** Seed an existing note with the given body hash for dedup tests. */
+  storeNotes?: Array<{ path: string; bodyHash: string }>;
 }) {
   const vault = new MockVaultService(opts.vaultFiles ?? {});
   const store = new InMemoryIngestionStore();
-  if (opts.storeChunks) {
-    for (const { path, chunk } of opts.storeChunks) {
-      // upsert one note per chunk
+  if (opts.storeNotes) {
+    for (const { path, bodyHash } of opts.storeNotes) {
       store.upsert(
-        { path, contentHash: "x", bodyHash: "x", mtime: 0, frontmatter: null },
-        [chunk],
+        { path, contentHash: bodyHash, bodyHash, mtime: 0, frontmatter: null },
+        [],
       );
     }
   }
@@ -121,15 +120,6 @@ describe("runIngest", () => {
   it("dedup_ask: exact-hash duplicate routes to preview, append choice writes to existing", async () => {
     const body = "# Decisions\n\nWe ship v2.";
     const bodyHash = createHash("sha256").update(body).digest("hex");
-    const chunk: Chunk = {
-      path: "Existing/standup.md",
-      ord: 0,
-      headingPath: [],
-      text: body,
-      textForEmbed: body,
-      tokenCount: 5,
-      contentHash: bodyHash,
-    };
 
     let askedKind = "";
     const handler: PreviewHandler = async (p) => {
@@ -138,7 +128,7 @@ describe("runIngest", () => {
     };
     const { deps, vault, queue } = setup({
       vaultFiles: { "Existing/standup.md": "# Existing\n\n" },
-      storeChunks: [{ path: "Existing/standup.md", chunk }],
+      storeNotes: [{ path: "Existing/standup.md", bodyHash }],
       preview: handler,
     });
 
@@ -158,18 +148,9 @@ describe("runIngest", () => {
   it("dedup_ask: save_anyway turns into create with the matched path linked", async () => {
     const body = "# Decisions\n\nWe ship v2.";
     const bodyHash = createHash("sha256").update(body).digest("hex");
-    const chunk: Chunk = {
-      path: "Existing/standup.md",
-      ord: 0,
-      headingPath: [],
-      text: body,
-      textForEmbed: body,
-      tokenCount: 5,
-      contentHash: bodyHash,
-    };
     const handler: PreviewHandler = async () => ({ action: "dedup_choice", choice: "save_anyway" });
     const { deps, vault } = setup({
-      storeChunks: [{ path: "Existing/standup.md", chunk }],
+      storeNotes: [{ path: "Existing/standup.md", bodyHash }],
       preview: handler,
     });
 
@@ -218,4 +199,26 @@ describe("runIngest", () => {
     const result = await runIngest({ text: "   " }, deps);
     expect(result.kind).toBe("cancelled");
   });
+
+  it("emits an event-log entry for every orchestrator phase (issue #13 acceptance)", async () => {
+    const { deps } = setup({ preview: autoConfirm });
+    const eventLog = new InMemoryEventLog();
+    const turnId = "test-turn-1";
+    const result = await runIngest(
+      { text: "Q2 standup notes" },
+      { ...deps, eventLog, turnId },
+    );
+    expect(result.kind).toBe("saved");
+    const entries = await eventLog.eventsFor(turnId);
+    const states = entries.map((e) => e.state);
+    expect(states).toContain("PARSE_CONTENT");
+    expect(states).toContain("SEARCH_SIMILAR");
+    expect(states).toContain("DECIDE_STRATEGY");
+    expect(states).toContain("PREVIEW");
+    expect(states).toContain("WRITE");
+    expect(states).toContain("UPDATE_INDEX");
+    expect(states).toContain("DONE");
+  });
 });
+
+import { InMemoryEventLog } from "./event-log";

--- a/src/services/ingest-orchestrator.test.ts
+++ b/src/services/ingest-orchestrator.test.ts
@@ -1,0 +1,221 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { IngestWriter } from "./ingest-writer";
+import { runIngest, type PreviewDecision, type PreviewHandler } from "./ingest-orchestrator";
+import type {
+  ChatOptions,
+  Chunk,
+  LLMReachability,
+  LLMResponse,
+  LLMService,
+  LoadedPrompt,
+  NoteSpec,
+  PromptLoader,
+  RetrievalHit,
+  Retriever,
+} from "../contracts";
+
+class StaticLLM implements LLMService {
+  constructor(public reply: string) {}
+  async chat(_opts: ChatOptions): Promise<LLMResponse> { return { content: this.reply }; }
+  async isReachable(): Promise<LLMReachability> { return "running"; }
+  async listModels() { return []; }
+  async pickDefaultModel() { return "mock"; }
+}
+
+class StubRetriever implements Retriever {
+  constructor(public hits: RetrievalHit[] = []) {}
+  async retrieve(): Promise<RetrievalHit[]> { return this.hits; }
+}
+
+const promptLoader: PromptLoader = {
+  async load(): Promise<LoadedPrompt> {
+    return { id: "ingest-parser", version: "0.1", body: "stub" };
+  },
+  invalidate() {},
+};
+
+function specReply(overrides: Partial<NoteSpec> = {}): string {
+  return JSON.stringify({
+    title: "Q2 standup",
+    type: "meeting",
+    tags: ["q2"],
+    aliases: [],
+    source: "chat-paste",
+    entities: [],
+    related: [],
+    status: "inbox",
+    summary: "Decisions.",
+    key_points: [],
+    body_markdown: "# Decisions\n\nWe ship v2.",
+    confidence: "high",
+    ...overrides,
+  });
+}
+
+function setup(opts: {
+  llmReply?: string;
+  vaultFiles?: Record<string, string>;
+  retrieverHits?: RetrievalHit[];
+  preview: PreviewHandler;
+  storeChunks?: Array<{ path: string; chunk: Chunk }>;
+}) {
+  const vault = new MockVaultService(opts.vaultFiles ?? {});
+  const store = new InMemoryIngestionStore();
+  if (opts.storeChunks) {
+    for (const { path, chunk } of opts.storeChunks) {
+      // upsert one note per chunk
+      store.upsert(
+        { path, contentHash: "x", bodyHash: "x", mtime: 0, frontmatter: null },
+        [chunk],
+      );
+    }
+  }
+  const queue = new InMemoryJobQueue();
+  const writer = new IngestWriter(vault);
+  return {
+    vault,
+    store,
+    queue,
+    writer,
+    deps: {
+      llm: new StaticLLM(opts.llmReply ?? specReply()),
+      promptLoader,
+      retriever: new StubRetriever(opts.retrieverHits),
+      store,
+      vault,
+      writer,
+      jobQueue: queue,
+      preview: opts.preview,
+      inboxFolder: "Inbox/",
+      runId: () => "run-1",
+      model: "test-model",
+      version: "0.0.1",
+    },
+  };
+}
+
+const autoConfirm: PreviewHandler = async () => ({ action: "confirm" });
+
+describe("runIngest", () => {
+  it("happy path: parses, decides create, writes, enqueues index", async () => {
+    const { deps, vault, queue } = setup({ preview: autoConfirm });
+
+    const result = await runIngest({ text: "Q2 standup notes" }, deps);
+
+    expect(result.kind).toBe("saved");
+    if (result.kind !== "saved") return;
+    expect(result.mode).toBe("create");
+    expect(result.path.startsWith("Inbox/")).toBe(true);
+
+    const written = await vault.read(result.path);
+    expect(written).toContain("cowork_managed: true");
+    expect(written).toContain("# Decisions");
+
+    expect(queue.size()).toBe(1);
+  });
+
+  it("dedup_ask: exact-hash duplicate routes to preview, append choice writes to existing", async () => {
+    const body = "# Decisions\n\nWe ship v2.";
+    const bodyHash = createHash("sha256").update(body).digest("hex");
+    const chunk: Chunk = {
+      path: "Existing/standup.md",
+      ord: 0,
+      headingPath: [],
+      text: body,
+      textForEmbed: body,
+      tokenCount: 5,
+      contentHash: bodyHash,
+    };
+
+    let askedKind = "";
+    const handler: PreviewHandler = async (p) => {
+      askedKind = p.kind;
+      return { action: "dedup_choice", choice: "append" };
+    };
+    const { deps, vault, queue } = setup({
+      vaultFiles: { "Existing/standup.md": "# Existing\n\n" },
+      storeChunks: [{ path: "Existing/standup.md", chunk }],
+      preview: handler,
+    });
+
+    const result = await runIngest({ text: "Q2 standup notes" }, deps);
+    expect(askedKind).toBe("dedup");
+    expect(result.kind).toBe("saved");
+    if (result.kind !== "saved") return;
+    expect(result.mode).toBe("append");
+    expect(result.path).toBe("Existing/standup.md");
+
+    const after = await vault.read("Existing/standup.md");
+    expect(after).toMatch(/##\s+\d{4}-\d{2}-\d{2}/);
+    expect(after).toContain("# Decisions");
+    expect(queue.size()).toBe(1);
+  });
+
+  it("dedup_ask: save_anyway turns into create with the matched path linked", async () => {
+    const body = "# Decisions\n\nWe ship v2.";
+    const bodyHash = createHash("sha256").update(body).digest("hex");
+    const chunk: Chunk = {
+      path: "Existing/standup.md",
+      ord: 0,
+      headingPath: [],
+      text: body,
+      textForEmbed: body,
+      tokenCount: 5,
+      contentHash: bodyHash,
+    };
+    const handler: PreviewHandler = async () => ({ action: "dedup_choice", choice: "save_anyway" });
+    const { deps, vault } = setup({
+      storeChunks: [{ path: "Existing/standup.md", chunk }],
+      preview: handler,
+    });
+
+    const result = await runIngest({ text: "Q2 standup notes" }, deps);
+    expect(result.kind).toBe("saved");
+    if (result.kind !== "saved") return;
+    expect(result.mode).toBe("create");
+
+    const written = await vault.read(result.path);
+    expect(written).toContain("Existing/standup.md");
+  });
+
+  it("cancel propagates", async () => {
+    const handler: PreviewHandler = async () => ({ action: "cancel" });
+    const { deps, queue } = setup({ preview: handler });
+    const result = await runIngest({ text: "anything" }, deps);
+    expect(result.kind).toBe("cancelled");
+    expect(queue.size()).toBe(0);
+  });
+
+  it("edit then confirm uses the edited spec", async () => {
+    let calls = 0;
+    const handler: PreviewHandler = async ({ spec }): Promise<PreviewDecision> => {
+      calls++;
+      if (calls === 1) {
+        return { action: "edit", spec: { ...spec, title: "Edited title" } };
+      }
+      return { action: "confirm" };
+    };
+    const { deps, vault } = setup({ preview: handler });
+    const result = await runIngest({ text: "x" }, deps);
+    expect(result.kind).toBe("saved");
+    if (result.kind !== "saved") return;
+    const written = await vault.read(result.path);
+    expect(written).toContain("title: Edited title");
+  });
+
+  it("returns failed when parse fails (invalid JSON from LLM)", async () => {
+    const { deps } = setup({ llmReply: "not json", preview: autoConfirm });
+    const result = await runIngest({ text: "x" }, deps);
+    expect(result.kind).toBe("failed");
+  });
+
+  it("returns cancelled for empty input without calling LLM", async () => {
+    const { deps } = setup({ preview: autoConfirm });
+    const result = await runIngest({ text: "   " }, deps);
+    expect(result.kind).toBe("cancelled");
+  });
+});

--- a/src/services/ingest-orchestrator.test.ts
+++ b/src/services/ingest-orchestrator.test.ts
@@ -235,6 +235,23 @@ describe("runIngest", () => {
     expect(previewCalls).toBeGreaterThan(0);
   });
 
+  it("rejects a plain confirm on a dedup_ask preview (handler returned wrong shape)", async () => {
+    const body = "# Decisions\n\nWe ship v2.";
+    const bodyHash = createHash("sha256").update(body).digest("hex");
+    const handler: PreviewHandler = async () => ({ action: "confirm" });
+    const { deps, vault, queue } = setup({
+      vaultFiles: { "Existing/standup.md": "# Existing\n" },
+      storeNotes: [{ path: "Existing/standup.md", bodyHash }],
+      preview: handler,
+    });
+    const result = await runIngest({ text: "Q2 standup notes" }, deps);
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return;
+    expect(result.reason).toBe("confirm_on_dedup_ask");
+    expect(queue.size()).toBe(0);
+    expect(await vault.read("Existing/standup.md")).toBe("# Existing\n");
+  });
+
   it("emits an event-log entry for every orchestrator phase (issue #13 acceptance)", async () => {
     const { deps } = setup({ preview: autoConfirm });
     const eventLog = new InMemoryEventLog();

--- a/src/services/ingest-orchestrator.ts
+++ b/src/services/ingest-orchestrator.ts
@@ -1,0 +1,168 @@
+import type {
+  DedupChoice,
+  IngestInput,
+  IngestOutcome,
+  IngestStrategy,
+  IngestionStore,
+  JobQueue,
+  LLMService,
+  NoteSpec,
+  PromptLoader,
+  Retriever,
+  VaultService,
+} from "../contracts";
+import { parseContent } from "./ingest-parser";
+import { decideStrategy } from "./ingest-strategy";
+import { IngestWriter } from "./ingest-writer";
+
+export interface IngestPreview {
+  /** "save" | "append" | "dedup" — drives which buttons the preview shows. */
+  kind: "save" | "append" | "dedup";
+  spec: NoteSpec;
+  strategy: IngestStrategy;
+}
+
+export type PreviewDecision =
+  | { action: "confirm" }
+  | { action: "edit"; spec: NoteSpec }
+  | { action: "cancel" }
+  | { action: "dedup_choice"; choice: DedupChoice };
+
+export type PreviewHandler = (
+  preview: IngestPreview,
+) => Promise<PreviewDecision>;
+
+export interface IngestOrchestratorDeps {
+  llm: LLMService;
+  promptLoader: PromptLoader;
+  retriever: Retriever;
+  store: IngestionStore;
+  vault: VaultService;
+  writer: IngestWriter;
+  jobQueue: JobQueue;
+  /** Returns `confirm` immediately for the bypass path used in tests. */
+  preview: PreviewHandler;
+  inboxFolder?: string;
+  dedupThreshold?: number;
+  alwaysPreview?: boolean;
+  model?: string;
+  version?: string;
+  runId?: () => string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Drives the ingest tool loop (#13): parse → search_similar → decide →
+ * preview → write → update_index.
+ *
+ * The preview gate is an injected callback so the orchestrator stays
+ * UI-agnostic; tests pass a function that auto-confirms or simulates a
+ * cancel. The chat view passes a callback that opens an Obsidian Modal.
+ *
+ * The preview is the only state allowed to bounce back to itself: the user
+ * can edit the candidate and re-render before confirming. A hard cap of 10
+ * iterations prevents pathological loops from a misbehaving handler.
+ */
+export async function runIngest(
+  input: IngestInput,
+  deps: IngestOrchestratorDeps,
+): Promise<IngestOutcome> {
+  // ── PARSE_CONTENT ────────────────────────────────────────────────────
+  const parse = await parseContent(input.text, input.instruction, {
+    llm: deps.llm,
+    promptLoader: deps.promptLoader,
+    runId: deps.runId,
+    model: deps.model,
+    version: deps.version,
+  }, deps.signal);
+  if (!parse.ok) {
+    if (parse.reason === "empty") return { kind: "cancelled" };
+    return { kind: "failed", reason: `parse:${parse.reason}` };
+  }
+  let spec = parse.spec;
+
+  // ── SEARCH_SIMILAR + DECIDE_STRATEGY ─────────────────────────────────
+  const decision = await decideStrategy(spec, {
+    llm: deps.llm,
+    promptLoader: deps.promptLoader,
+    retriever: deps.retriever,
+    store: deps.store,
+    dedupThreshold: deps.dedupThreshold,
+  }, deps.signal);
+  let strategy = decision.strategy;
+
+  // ── PREVIEW ──────────────────────────────────────────────────────────
+  for (let i = 0; i < 10; i++) {
+    const previewKind = previewKindFor(strategy);
+    const result = await deps.preview({ kind: previewKind, spec, strategy });
+    if (result.action === "cancel") return { kind: "cancelled" };
+    if (result.action === "edit") {
+      spec = result.spec;
+      continue;
+    }
+    if (result.action === "dedup_choice") {
+      if (result.choice === "cancel") return { kind: "cancelled" };
+      if (strategy.kind !== "dedup_ask") {
+        return { kind: "failed", reason: "dedup_choice_without_dedup_ask" };
+      }
+      if (result.choice === "append") {
+        strategy = { kind: "append", target: strategy.target };
+      } else {
+        // save_anyway — fall through to a regular create. Surface the
+        // matched note as a related link so the user sees the connection.
+        strategy = {
+          kind: "create",
+          related: unique([...spec.related, strategy.target]),
+        };
+      }
+      // The user has resolved the dedup; proceed straight to write.
+      break;
+    }
+    // confirm
+    break;
+  }
+
+  // ── WRITE ────────────────────────────────────────────────────────────
+  if (strategy.kind === "dedup_ask") {
+    return { kind: "failed", reason: "preview_unresolved" };
+  }
+  if (strategy.kind === "append") {
+    if (!(await deps.vault.exists(strategy.target))) {
+      return { kind: "failed", reason: "append_target_missing" };
+    }
+    try {
+      await deps.writer.appendUnderDatedHeading(strategy.target, spec.body_markdown);
+    } catch (err) {
+      return { kind: "failed", reason: `write:${stringifyError(err)}` };
+    }
+    deps.jobQueue.enqueue({ kind: "index", path: strategy.target });
+    return { kind: "saved", path: strategy.target, mode: "append", spec };
+  }
+
+  // create
+  spec = { ...spec, related: strategy.related };
+  let path: string;
+  try {
+    const result = await deps.writer.writeNew(spec, { folder: deps.inboxFolder });
+    path = result.path;
+  } catch (err) {
+    return { kind: "failed", reason: `write:${stringifyError(err)}` };
+  }
+  deps.jobQueue.enqueue({ kind: "index", path });
+  return { kind: "saved", path, mode: "create", spec };
+}
+
+function previewKindFor(strategy: IngestStrategy): IngestPreview["kind"] {
+  if (strategy.kind === "dedup_ask") return "dedup";
+  if (strategy.kind === "append") return "append";
+  return "save";
+}
+
+function unique(items: string[]): string[] {
+  return [...new Set(items)];
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/services/ingest-orchestrator.ts
+++ b/src/services/ingest-orchestrator.ts
@@ -16,6 +16,7 @@ import type {
 import { parseContent } from "./ingest-parser";
 import { decideStrategy } from "./ingest-strategy";
 import { IngestWriter } from "./ingest-writer";
+import { unique } from "./util";
 
 const STATES = {
   parse: "PARSE_CONTENT",
@@ -139,43 +140,65 @@ export async function runIngest(
   let strategy = decision.strategy;
   await enter(STATES.decide, { kind: strategy.kind });
 
+  // For append/dedup_ask, capture the target's mtime now so the writer can
+  // detect drift between preview and write. If the user edited the target
+  // during preview, we abort rather than silently clobber.
+  let expectedMtime: number | undefined;
+  if (strategy.kind === "append" || strategy.kind === "dedup_ask") {
+    try {
+      expectedMtime = (await deps.vault.stat(strategy.target)).mtime;
+    } catch {
+      expectedMtime = undefined;
+    }
+  }
+
   // ── PREVIEW ──────────────────────────────────────────────────────────
-  await enter(STATES.preview, { kind: previewKindFor(strategy) });
-  for (let i = 0; i < 10; i++) {
-    const previewKind = previewKindFor(strategy);
-    const result = await deps.preview({ kind: previewKind, spec, strategy });
-    if (result.action === "cancel") {
-      await enter(STATES.cancelled, { from: "preview" });
-      return { kind: "cancelled" };
-    }
-    if (result.action === "edit") {
-      spec = result.spec;
-      continue;
-    }
-    if (result.action === "dedup_choice") {
-      if (result.choice === "cancel") {
-        await enter(STATES.cancelled, { from: "dedup" });
+  // Bypass when the user has opted out of always-preview AND the case is
+  // unambiguous: a plain create with high confidence. Append and dedup_ask
+  // always preview — they touch existing notes.
+  const skipPreview =
+    deps.alwaysPreview === false &&
+    strategy.kind === "create" &&
+    spec.cowork.confidence === "high";
+
+  if (!skipPreview) {
+    await enter(STATES.preview, { kind: previewKindFor(strategy) });
+    for (let i = 0; i < 10; i++) {
+      const previewKind = previewKindFor(strategy);
+      const result = await deps.preview({ kind: previewKind, spec, strategy });
+      if (result.action === "cancel") {
+        await enter(STATES.cancelled, { from: "preview" });
         return { kind: "cancelled" };
       }
-      if (strategy.kind !== "dedup_ask") {
-        await enter(STATES.failed, { reason: "dedup_choice_without_dedup_ask" });
-        return { kind: "failed", reason: "dedup_choice_without_dedup_ask" };
+      if (result.action === "edit") {
+        spec = result.spec;
+        continue;
       }
-      if (result.choice === "append") {
-        strategy = { kind: "append", target: strategy.target };
-      } else {
-        // save_anyway — fall through to a regular create. Surface the
-        // matched note as a related link so the user sees the connection.
-        strategy = {
-          kind: "create",
-          related: unique([...spec.related, strategy.target]),
-        };
+      if (result.action === "dedup_choice") {
+        if (result.choice === "cancel") {
+          await enter(STATES.cancelled, { from: "dedup" });
+          return { kind: "cancelled" };
+        }
+        if (strategy.kind !== "dedup_ask") {
+          await enter(STATES.failed, { reason: "dedup_choice_without_dedup_ask" });
+          return { kind: "failed", reason: "dedup_choice_without_dedup_ask" };
+        }
+        if (result.choice === "append") {
+          strategy = { kind: "append", target: strategy.target };
+        } else {
+          // save_anyway — fall through to a regular create. Surface the
+          // matched note as a related link so the user sees the connection.
+          strategy = {
+            kind: "create",
+            related: unique([...spec.related, strategy.target]),
+          };
+        }
+        // The user has resolved the dedup; proceed straight to write.
+        break;
       }
-      // The user has resolved the dedup; proceed straight to write.
+      // confirm
       break;
     }
-    // confirm
-    break;
   }
 
   // ── WRITE ────────────────────────────────────────────────────────────
@@ -190,7 +213,9 @@ export async function runIngest(
       return { kind: "failed", reason: "append_target_missing" };
     }
     try {
-      await deps.writer.appendUnderDatedHeading(strategy.target, spec.body_markdown);
+      await deps.writer.appendUnderDatedHeading(strategy.target, spec.body_markdown, {
+        expectedMtime,
+      });
     } catch (err) {
       const reason = `write:${stringifyError(err)}`;
       await enter(STATES.failed, { reason });
@@ -220,20 +245,13 @@ export async function runIngest(
 }
 
 function freshTurnId(): string {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-    return crypto.randomUUID();
-  }
-  return `turn_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+  return crypto.randomUUID();
 }
 
 function previewKindFor(strategy: IngestStrategy): IngestPreview["kind"] {
   if (strategy.kind === "dedup_ask") return "dedup";
   if (strategy.kind === "append") return "append";
   return "save";
-}
-
-function unique(items: string[]): string[] {
-  return [...new Set(items)];
 }
 
 function stringifyError(err: unknown): string {

--- a/src/services/ingest-orchestrator.ts
+++ b/src/services/ingest-orchestrator.ts
@@ -1,5 +1,7 @@
 import type {
   DedupChoice,
+  EventLog,
+  EventLogEntry,
   IngestInput,
   IngestOutcome,
   IngestStrategy,
@@ -14,6 +16,18 @@ import type {
 import { parseContent } from "./ingest-parser";
 import { decideStrategy } from "./ingest-strategy";
 import { IngestWriter } from "./ingest-writer";
+
+const STATES = {
+  parse: "PARSE_CONTENT",
+  search: "SEARCH_SIMILAR",
+  decide: "DECIDE_STRATEGY",
+  preview: "PREVIEW",
+  write: "WRITE",
+  updateIndex: "UPDATE_INDEX",
+  done: "DONE",
+  cancelled: "CANCELLED",
+  failed: "TOOL_FAILED",
+} as const;
 
 export interface IngestPreview {
   /** "save" | "append" | "dedup" — drives which buttons the preview shows. */
@@ -42,6 +56,15 @@ export interface IngestOrchestratorDeps {
   jobQueue: JobQueue;
   /** Returns `confirm` immediately for the bypass path used in tests. */
   preview: PreviewHandler;
+  /**
+   * Optional event log. The orchestrator writes one `enter` row per
+   * orchestrator state (parse → search → decide → preview → write →
+   * update_index → done/cancelled/failed) so the turn inspector and the
+   * #13 acceptance test can replay what happened.
+   */
+  eventLog?: EventLog;
+  /** Turn id used for event-log entries. Defaults to a fresh uuid. */
+  turnId?: string;
   inboxFolder?: string;
   dedupThreshold?: number;
   alwaysPreview?: boolean;
@@ -67,7 +90,26 @@ export async function runIngest(
   input: IngestInput,
   deps: IngestOrchestratorDeps,
 ): Promise<IngestOutcome> {
+  const turnId = deps.turnId ?? freshTurnId();
+  let prevState = "IDLE";
+  const enter = async (state: string, payload?: Record<string, unknown>) => {
+    if (!deps.eventLog) return;
+    const entry: EventLogEntry = {
+      turnId,
+      kind: "enter",
+      state,
+      fromState: prevState,
+      timestamp: Date.now(),
+      triggeringEvent: payload
+        ? { kind: "tool_result", name: state, payload }
+        : null,
+    };
+    await deps.eventLog.write(entry);
+    prevState = state;
+  };
+
   // ── PARSE_CONTENT ────────────────────────────────────────────────────
+  await enter(STATES.parse);
   const parse = await parseContent(input.text, input.instruction, {
     llm: deps.llm,
     promptLoader: deps.promptLoader,
@@ -76,12 +118,17 @@ export async function runIngest(
     version: deps.version,
   }, deps.signal);
   if (!parse.ok) {
-    if (parse.reason === "empty") return { kind: "cancelled" };
+    if (parse.reason === "empty") {
+      await enter(STATES.cancelled, { reason: "empty_input" });
+      return { kind: "cancelled" };
+    }
+    await enter(STATES.failed, { reason: `parse:${parse.reason}` });
     return { kind: "failed", reason: `parse:${parse.reason}` };
   }
   let spec = parse.spec;
 
   // ── SEARCH_SIMILAR + DECIDE_STRATEGY ─────────────────────────────────
+  await enter(STATES.search);
   const decision = await decideStrategy(spec, {
     llm: deps.llm,
     promptLoader: deps.promptLoader,
@@ -90,19 +137,28 @@ export async function runIngest(
     dedupThreshold: deps.dedupThreshold,
   }, deps.signal);
   let strategy = decision.strategy;
+  await enter(STATES.decide, { kind: strategy.kind });
 
   // ── PREVIEW ──────────────────────────────────────────────────────────
+  await enter(STATES.preview, { kind: previewKindFor(strategy) });
   for (let i = 0; i < 10; i++) {
     const previewKind = previewKindFor(strategy);
     const result = await deps.preview({ kind: previewKind, spec, strategy });
-    if (result.action === "cancel") return { kind: "cancelled" };
+    if (result.action === "cancel") {
+      await enter(STATES.cancelled, { from: "preview" });
+      return { kind: "cancelled" };
+    }
     if (result.action === "edit") {
       spec = result.spec;
       continue;
     }
     if (result.action === "dedup_choice") {
-      if (result.choice === "cancel") return { kind: "cancelled" };
+      if (result.choice === "cancel") {
+        await enter(STATES.cancelled, { from: "dedup" });
+        return { kind: "cancelled" };
+      }
       if (strategy.kind !== "dedup_ask") {
+        await enter(STATES.failed, { reason: "dedup_choice_without_dedup_ask" });
         return { kind: "failed", reason: "dedup_choice_without_dedup_ask" };
       }
       if (result.choice === "append") {
@@ -123,19 +179,26 @@ export async function runIngest(
   }
 
   // ── WRITE ────────────────────────────────────────────────────────────
+  await enter(STATES.write, { kind: strategy.kind });
   if (strategy.kind === "dedup_ask") {
+    await enter(STATES.failed, { reason: "preview_unresolved" });
     return { kind: "failed", reason: "preview_unresolved" };
   }
   if (strategy.kind === "append") {
     if (!(await deps.vault.exists(strategy.target))) {
+      await enter(STATES.failed, { reason: "append_target_missing" });
       return { kind: "failed", reason: "append_target_missing" };
     }
     try {
       await deps.writer.appendUnderDatedHeading(strategy.target, spec.body_markdown);
     } catch (err) {
-      return { kind: "failed", reason: `write:${stringifyError(err)}` };
+      const reason = `write:${stringifyError(err)}`;
+      await enter(STATES.failed, { reason });
+      return { kind: "failed", reason };
     }
     deps.jobQueue.enqueue({ kind: "index", path: strategy.target });
+    await enter(STATES.updateIndex, { path: strategy.target });
+    await enter(STATES.done, { mode: "append", path: strategy.target });
     return { kind: "saved", path: strategy.target, mode: "append", spec };
   }
 
@@ -146,10 +209,21 @@ export async function runIngest(
     const result = await deps.writer.writeNew(spec, { folder: deps.inboxFolder });
     path = result.path;
   } catch (err) {
-    return { kind: "failed", reason: `write:${stringifyError(err)}` };
+    const reason = `write:${stringifyError(err)}`;
+    await enter(STATES.failed, { reason });
+    return { kind: "failed", reason };
   }
   deps.jobQueue.enqueue({ kind: "index", path });
+  await enter(STATES.updateIndex, { path });
+  await enter(STATES.done, { mode: "create", path });
   return { kind: "saved", path, mode: "create", spec };
+}
+
+function freshTurnId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `turn_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
 }
 
 function previewKindFor(strategy: IngestStrategy): IngestPreview["kind"] {

--- a/src/services/ingest-orchestrator.ts
+++ b/src/services/ingest-orchestrator.ts
@@ -196,7 +196,14 @@ export async function runIngest(
         // The user has resolved the dedup; proceed straight to write.
         break;
       }
-      // confirm
+      // confirm — must not arrive when the strategy is dedup_ask. The
+      // dedup modal exposes append / save-anyway / cancel buttons only;
+      // a plain `confirm` here means the handler returned the wrong shape
+      // and writing would clobber the matched note. Reject explicitly.
+      if (strategy.kind === "dedup_ask") {
+        await enter(STATES.failed, { reason: "confirm_on_dedup_ask" });
+        return { kind: "failed", reason: "confirm_on_dedup_ask" };
+      }
       break;
     }
   }

--- a/src/services/ingest-parser.test.ts
+++ b/src/services/ingest-parser.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ChatOptions,
+  LLMReachability,
+  LLMResponse,
+  LLMService,
+  LoadedPrompt,
+  PromptLoader,
+} from "../contracts";
+import { parseContent } from "./ingest-parser";
+
+class StaticLLM implements LLMService {
+  constructor(public reply: string) {}
+  async chat(_opts: ChatOptions): Promise<LLMResponse> {
+    return { content: this.reply };
+  }
+  async isReachable(): Promise<LLMReachability> {
+    return "running";
+  }
+  async listModels(): Promise<string[]> { return ["mock"]; }
+  async pickDefaultModel(): Promise<string> { return "mock"; }
+}
+
+const stubPromptLoader: PromptLoader = {
+  async load(): Promise<LoadedPrompt> {
+    return { id: "ingest-parser", version: "0.1.0", body: "stub-prompt" };
+  },
+  invalidate() {},
+};
+
+describe("parseContent", () => {
+  it("returns a NoteSpec for valid LLM JSON", async () => {
+    const llm = new StaticLLM(
+      JSON.stringify({
+        title: "Q2 standup",
+        type: "meeting",
+        tags: ["q2"],
+        aliases: [],
+        source: "chat-paste",
+        entities: ["Alice"],
+        related: [],
+        status: "inbox",
+        summary: "Decisions from standup.",
+        key_points: ["Switch to v2"],
+        body_markdown: "# Decisions\n\nWe ship v2.",
+        confidence: "high",
+      }),
+    );
+    const result = await parseContent("Q2 standup notes", undefined, {
+      llm,
+      promptLoader: stubPromptLoader,
+      runId: () => "test-run",
+      model: "test-model",
+      version: "0.0.1",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.spec.title).toBe("Q2 standup");
+    expect(result.spec.cowork.run_id).toBe("test-run");
+    expect(result.spec.cowork.source).toBe("ingest");
+  });
+
+  it("returns parse_failed on invalid JSON", async () => {
+    const llm = new StaticLLM("not json at all");
+    const result = await parseContent("anything", undefined, {
+      llm,
+      promptLoader: stubPromptLoader,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("parse_failed");
+  });
+
+  it("returns schema_failed on missing required fields", async () => {
+    const llm = new StaticLLM(JSON.stringify({ title: "ok" }));
+    const result = await parseContent("anything", undefined, {
+      llm,
+      promptLoader: stubPromptLoader,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("schema_failed");
+  });
+
+  it("rejects bodies that contain frontmatter blocks", async () => {
+    const llm = new StaticLLM(
+      JSON.stringify({
+        title: "x",
+        type: "source",
+        body_markdown: "---\nhijack: yes\n---\n\nbad",
+      }),
+    );
+    const result = await parseContent("anything", undefined, {
+      llm,
+      promptLoader: stubPromptLoader,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns empty for whitespace-only input without calling LLM", async () => {
+    let called = false;
+    const llm = {
+      async chat() {
+        called = true;
+        return { content: "" };
+      },
+      async isReachable(): Promise<LLMReachability> { return "running"; },
+      async listModels() { return []; },
+      async pickDefaultModel() { return "mock"; },
+    } as LLMService;
+    const result = await parseContent("   \n  ", undefined, {
+      llm,
+      promptLoader: stubPromptLoader,
+    });
+    expect(result.ok).toBe(false);
+    expect(called).toBe(false);
+  });
+});

--- a/src/services/ingest-parser.ts
+++ b/src/services/ingest-parser.ts
@@ -177,8 +177,5 @@ function stringList(v: unknown): string[] {
 }
 
 function defaultRunId(): string {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-    return crypto.randomUUID();
-  }
-  return `run_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+  return crypto.randomUUID();
 }

--- a/src/services/ingest-parser.ts
+++ b/src/services/ingest-parser.ts
@@ -1,0 +1,184 @@
+import type { LLMService, NoteSpec, PromptLoader } from "../contracts";
+
+export interface IngestParserDeps {
+  llm: LLMService;
+  promptLoader: PromptLoader;
+  /** Override for tests so the test doesn't depend on real time/randomness. */
+  runId?: () => string;
+  model?: string;
+  version?: string;
+}
+
+export type ParseResult =
+  | { ok: true; spec: NoteSpec }
+  | { ok: false; reason: "parse_failed" | "schema_failed" | "empty"; raw: string };
+
+/**
+ * Calls the ingest-parser prompt with `format: "json"` and produces a
+ * structured `NoteSpec`. The cowork-block fields (run_id, model, version)
+ * are filled in by the orchestrator after parsing — the LLM only produces
+ * the user-derived fields.
+ *
+ * Validation is intentionally permissive on optional list fields (defaults
+ * to `[]`) but strict on the required scalars (`title`, `type`, `source`,
+ * `body_markdown`). A parse miss returns a typed `ParseResult` so the
+ * orchestrator can decide between retry and error-state.
+ */
+export async function parseContent(
+  text: string,
+  instruction: string | undefined,
+  deps: IngestParserDeps,
+  signal?: AbortSignal,
+): Promise<ParseResult> {
+  if (!text.trim()) return { ok: false, reason: "empty", raw: "" };
+
+  const prompt = await deps.promptLoader.load("ingest-parser");
+  const userPrompt = composeUserPrompt(text, instruction);
+
+  const response = await deps.llm.chat({
+    messages: [
+      { role: "system", content: prompt.body + SCHEMA_HINT },
+      { role: "user", content: userPrompt },
+    ],
+    format: "json",
+    stream: false,
+    signal,
+  });
+
+  const raw = response.content?.trim() ?? "";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: "parse_failed", raw };
+  }
+
+  const spec = coerceSpec(parsed, {
+    runId: (deps.runId ?? defaultRunId)(),
+    model: deps.model ?? "gemma3:latest",
+    version: deps.version ?? "0.0.1",
+  });
+  if (!spec) return { ok: false, reason: "schema_failed", raw };
+
+  return { ok: true, spec };
+}
+
+function composeUserPrompt(text: string, instruction?: string): string {
+  if (instruction) {
+    return `Instruction: ${instruction}\n\nContent:\n${text}`;
+  }
+  return text;
+}
+
+const SCHEMA_HINT = `
+
+Return ONLY a JSON object with this shape:
+{
+  "title": string,
+  "type": "source"|"evergreen"|"project"|"meeting"|"person"|"concept",
+  "tags": string[],
+  "aliases": string[],
+  "source": "chat-paste"|"pdf"|"webpage"|"image"|"audio"|"manual",
+  "entities": string[],
+  "related": string[],
+  "status": "inbox"|"processed"|"linked"|"archived",
+  "summary": string,
+  "key_points": string[],
+  "body_markdown": string,
+  "confidence": "high"|"medium"|"low"
+}
+
+Rules:
+- "title" is short (≤ 80 chars) and never empty.
+- "body_markdown" must NOT contain its own frontmatter block (no leading ---).
+- "tags", "aliases", "entities", "related", "key_points" are arrays (use [] if none).
+- Default "source" is "chat-paste" unless the input clearly originates elsewhere.
+- Default "status" is "inbox".
+`;
+
+interface CoworkDefaults {
+  runId: string;
+  model: string;
+  version: string;
+}
+
+function coerceSpec(raw: unknown, cowork: CoworkDefaults): NoteSpec | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  const title = stringOrNull(r.title);
+  const type = enumOr<NoteSpec["type"]>(r.type, [
+    "source",
+    "evergreen",
+    "project",
+    "meeting",
+    "person",
+    "concept",
+  ]);
+  const source = enumOr<NoteSpec["source"]>(r.source, [
+    "chat-paste",
+    "pdf",
+    "webpage",
+    "image",
+    "audio",
+    "manual",
+  ]) ?? "chat-paste";
+  const status = enumOr<NoteSpec["status"]>(r.status, [
+    "inbox",
+    "processed",
+    "linked",
+    "archived",
+  ]) ?? "inbox";
+  const body = stringOrNull(r.body_markdown);
+  if (!title || !type || !body) return null;
+  if (/^---\s*\r?\n/.test(body)) return null;
+
+  const confidence = enumOr<"high" | "medium" | "low">(r.confidence, [
+    "high",
+    "medium",
+    "low",
+  ]) ?? "medium";
+
+  return {
+    title: title.slice(0, 120),
+    type,
+    tags: stringList(r.tags),
+    aliases: stringList(r.aliases),
+    source,
+    entities: stringList(r.entities),
+    related: stringList(r.related),
+    status,
+    summary: stringOrNull(r.summary) ?? "",
+    key_points: stringList(r.key_points),
+    body_markdown: body,
+    cowork: {
+      source: "ingest",
+      run_id: cowork.runId,
+      model: cowork.model,
+      version: cowork.version,
+      confidence,
+    },
+  };
+}
+
+function stringOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.trim().length > 0 ? v : null;
+}
+
+function enumOr<T extends string>(v: unknown, allowed: readonly T[]): T | null {
+  return typeof v === "string" && (allowed as readonly string[]).includes(v)
+    ? (v as T)
+    : null;
+}
+
+function stringList(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string" && x.length > 0);
+}
+
+function defaultRunId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `run_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+}

--- a/src/services/ingest-strategy.test.ts
+++ b/src/services/ingest-strategy.test.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
+import type {
+  ChatOptions,
+  Chunk,
+  LLMReachability,
+  LLMResponse,
+  LLMService,
+  LoadedPrompt,
+  NoteSpec,
+  PromptLoader,
+  RetrievalHit,
+  Retriever,
+} from "../contracts";
+import { decideStrategy } from "./ingest-strategy";
+
+function spec(body: string, overrides: Partial<NoteSpec> = {}): NoteSpec {
+  return {
+    title: "candidate",
+    type: "source",
+    tags: [],
+    aliases: [],
+    source: "chat-paste",
+    entities: [],
+    related: [],
+    status: "inbox",
+    summary: "",
+    key_points: [],
+    body_markdown: body,
+    cowork: {
+      source: "ingest",
+      run_id: "r",
+      model: "m",
+      version: "v",
+      confidence: "high",
+    },
+    ...overrides,
+  };
+}
+
+class StubRetriever implements Retriever {
+  constructor(public hits: RetrievalHit[]) {}
+  async retrieve(): Promise<RetrievalHit[]> {
+    return this.hits;
+  }
+}
+
+class CrashingRetriever implements Retriever {
+  async retrieve(): Promise<RetrievalHit[]> {
+    throw new Error("boom");
+  }
+}
+
+class StaticLLM implements LLMService {
+  constructor(public reply: string) {}
+  async chat(_opts: ChatOptions): Promise<LLMResponse> { return { content: this.reply }; }
+  async isReachable(): Promise<LLMReachability> { return "running"; }
+  async listModels() { return []; }
+  async pickDefaultModel() { return "mock"; }
+}
+
+const promptLoader: PromptLoader = {
+  async load(): Promise<LoadedPrompt> {
+    return { id: "dedup-decider", version: "0.1", body: "stub" };
+  },
+  invalidate() {},
+};
+
+function hit(path: string, score: number, text = "snippet"): RetrievalHit {
+  return {
+    path,
+    title: path.replace(/\.md$/, ""),
+    ord: 0,
+    contentHash: "h",
+    text,
+    headingPath: [],
+    score,
+    winningSignal: "semantic",
+  };
+}
+
+describe("decideStrategy", () => {
+  it("short-circuits to dedup_ask on exact-hash content match", async () => {
+    const store = new InMemoryIngestionStore();
+    const body = "exact body";
+    const bodyHash = createHash("sha256").update(body).digest("hex");
+    const chunk: Chunk = {
+      path: "Existing/Note.md",
+      ord: 0,
+      headingPath: [],
+      text: body,
+      textForEmbed: body,
+      tokenCount: 2,
+      contentHash: bodyHash,
+    };
+    await store.upsert(
+      {
+        path: "Existing/Note.md",
+        contentHash: "x",
+        bodyHash: "x",
+        mtime: 0,
+        frontmatter: null,
+      },
+      [chunk],
+    );
+
+    const result = await decideStrategy(spec(body), {
+      llm: new StaticLLM(""),
+      promptLoader,
+      retriever: new StubRetriever([]),
+      store,
+    });
+    expect(result.strategy.kind).toBe("dedup_ask");
+    if (result.strategy.kind !== "dedup_ask") return;
+    expect(result.strategy.target).toBe("Existing/Note.md");
+  });
+
+  it("returns create when retriever has no hits", async () => {
+    const store = new InMemoryIngestionStore();
+    const result = await decideStrategy(spec("body"), {
+      llm: new StaticLLM(""),
+      promptLoader,
+      retriever: new StubRetriever([]),
+      store,
+    });
+    expect(result.strategy.kind).toBe("create");
+  });
+
+  it("returns dedup_ask when top hit exceeds threshold", async () => {
+    const store = new InMemoryIngestionStore();
+    const result = await decideStrategy(spec("body"), {
+      llm: new StaticLLM(""),
+      promptLoader,
+      retriever: new StubRetriever([hit("Some/Note.md", 0.95)]),
+      store,
+      dedupThreshold: 0.85,
+    });
+    expect(result.strategy.kind).toBe("dedup_ask");
+  });
+
+  it("uses LLM decision when below threshold (append branch)", async () => {
+    const store = new InMemoryIngestionStore();
+    const result = await decideStrategy(spec("body"), {
+      llm: new StaticLLM(JSON.stringify({ strategy: "append", targetPath: "Parent.md", reason: "extends it" })),
+      promptLoader,
+      retriever: new StubRetriever([hit("Parent.md", 0.5)]),
+      store,
+    });
+    expect(result.strategy.kind).toBe("append");
+    if (result.strategy.kind !== "append") return;
+    expect(result.strategy.target).toBe("Parent.md");
+  });
+
+  it("falls back to create with related links when LLM output is malformed", async () => {
+    const store = new InMemoryIngestionStore();
+    const result = await decideStrategy(spec("body"), {
+      llm: new StaticLLM("not json"),
+      promptLoader,
+      retriever: new StubRetriever([hit("a.md", 0.4), hit("b.md", 0.3)]),
+      store,
+    });
+    expect(result.strategy.kind).toBe("create");
+    if (result.strategy.kind !== "create") return;
+    expect(result.strategy.related).toEqual(["a.md", "b.md"]);
+  });
+
+  it("treats retriever errors as cold vault and returns create", async () => {
+    const store = new InMemoryIngestionStore();
+    const result = await decideStrategy(spec("body"), {
+      llm: new StaticLLM(""),
+      promptLoader,
+      retriever: new CrashingRetriever(),
+      store,
+    });
+    expect(result.strategy.kind).toBe("create");
+  });
+});

--- a/src/services/ingest-strategy.test.ts
+++ b/src/services/ingest-strategy.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
 import type {
   ChatOptions,
-  Chunk,
   LLMReachability,
   LLMResponse,
   LLMService,
@@ -85,24 +84,15 @@ describe("decideStrategy", () => {
     const store = new InMemoryIngestionStore();
     const body = "exact body";
     const bodyHash = createHash("sha256").update(body).digest("hex");
-    const chunk: Chunk = {
-      path: "Existing/Note.md",
-      ord: 0,
-      headingPath: [],
-      text: body,
-      textForEmbed: body,
-      tokenCount: 2,
-      contentHash: bodyHash,
-    };
     await store.upsert(
       {
         path: "Existing/Note.md",
         contentHash: "x",
-        bodyHash: "x",
+        bodyHash,
         mtime: 0,
         frontmatter: null,
       },
-      [chunk],
+      [],
     );
 
     const result = await decideStrategy(spec(body), {

--- a/src/services/ingest-strategy.test.ts
+++ b/src/services/ingest-strategy.test.ts
@@ -155,6 +155,25 @@ describe("decideStrategy", () => {
     expect(result.strategy.related).toEqual(["a.md", "b.md"]);
   });
 
+  it("short-circuits past LLM when top hit score is below the floor", async () => {
+    const store = new InMemoryIngestionStore();
+    let llmCalled = false;
+    const llm: LLMService = {
+      async chat() { llmCalled = true; return { content: "" }; },
+      async isReachable() { return "running"; },
+      async listModels() { return []; },
+      async pickDefaultModel() { return "mock"; },
+    };
+    const result = await decideStrategy(spec("body"), {
+      llm,
+      promptLoader,
+      retriever: new StubRetriever([hit("a.md", 0.1), hit("b.md", 0.05)]),
+      store,
+    });
+    expect(llmCalled).toBe(false);
+    expect(result.strategy.kind).toBe("create");
+  });
+
   it("treats retriever errors as cold vault and returns create", async () => {
     const store = new InMemoryIngestionStore();
     const result = await decideStrategy(spec("body"), {

--- a/src/services/ingest-strategy.ts
+++ b/src/services/ingest-strategy.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import type {
+  IngestStrategy,
+  IngestionStore,
+  LLMService,
+  NoteSpec,
+  PromptLoader,
+  RetrievalHit,
+  Retriever,
+} from "../contracts";
+
+export interface IngestStrategyDeps {
+  llm: LLMService;
+  promptLoader: PromptLoader;
+  retriever: Retriever;
+  store: IngestionStore;
+  /** Cosine / fused-score above which we treat a candidate as a near-dupe. */
+  dedupThreshold?: number;
+  /** topK passed to retriever. Defaults to 5. */
+  topK?: number;
+}
+
+const DEFAULT_DEDUP_THRESHOLD = 0.85;
+
+/**
+ * Decide whether the candidate becomes a new note, an append, or asks the
+ * user about deduplication.
+ *
+ * Order of decisions:
+ *   1. Deterministic: if any chunk in the store has the same content hash
+ *      as the candidate body, return `dedup_ask` for that chunk's note.
+ *      No LLM call needed — the answer is binary.
+ *   2. Retrieve top-k similar; if no hits, return `create`.
+ *   3. If the top hit's score exceeds the dedup threshold, return
+ *      `dedup_ask` with that note as target.
+ *   4. Otherwise consult the LLM (`dedup-decider` prompt) for a fuzzy
+ *      decision among `new`, `append`, `ask_user`. The LLM call is the
+ *      heaviest path; for v1 we keep the schema permissive and fall back
+ *      to `create` on any parse failure.
+ */
+export async function decideStrategy(
+  spec: NoteSpec,
+  deps: IngestStrategyDeps,
+  signal?: AbortSignal,
+): Promise<{ strategy: IngestStrategy; topHits: RetrievalHit[] }> {
+  const threshold = deps.dedupThreshold ?? DEFAULT_DEDUP_THRESHOLD;
+  const topK = deps.topK ?? 5;
+
+  // 1. Exact-hash dedup short-circuit.
+  const bodyHash = sha256(spec.body_markdown);
+  const exactMatches = await deps.store.getChunksByHash(bodyHash);
+  if (exactMatches.length > 0) {
+    return {
+      strategy: { kind: "dedup_ask", target: exactMatches[0].path, similarity: 1 },
+      topHits: [],
+    };
+  }
+
+  // 2. Retrieve top-k similar.
+  const query = `${spec.title}\n\n${spec.summary}\n\n${spec.body_markdown.slice(0, 2000)}`;
+  let hits: RetrievalHit[] = [];
+  try {
+    hits = await deps.retriever.retrieve(query, { topK });
+  } catch {
+    // Empty index or retriever transport error — treat as cold vault.
+    hits = [];
+  }
+
+  if (hits.length === 0) {
+    return { strategy: { kind: "create", related: spec.related }, topHits: [] };
+  }
+
+  // 3. Threshold-based dedup_ask.
+  const top = hits[0];
+  if (top.score >= threshold) {
+    return {
+      strategy: { kind: "dedup_ask", target: top.path, similarity: top.score },
+      topHits: hits,
+    };
+  }
+
+  // 4. LLM-driven fuzzy decision. Permissive parsing — anything off-schema
+  //    falls back to `create` so a flaky model can't block ingestion.
+  const llmDecision = await consultLlm(spec, hits, deps, signal);
+  if (llmDecision) return { strategy: llmDecision, topHits: hits };
+
+  // Default: create with related links populated from top hits.
+  const related = unique([...spec.related, ...hits.slice(0, 3).map((h) => h.path)]);
+  return { strategy: { kind: "create", related }, topHits: hits };
+}
+
+async function consultLlm(
+  spec: NoteSpec,
+  hits: RetrievalHit[],
+  deps: IngestStrategyDeps,
+  signal?: AbortSignal,
+): Promise<IngestStrategy | null> {
+  let promptBody = "";
+  try {
+    const loaded = await deps.promptLoader.load("dedup-decider");
+    promptBody = loaded.body;
+  } catch {
+    // Prompt missing — skip LLM step.
+    return null;
+  }
+
+  const userPrompt = JSON.stringify(
+    {
+      candidate: {
+        title: spec.title,
+        summary: spec.summary,
+        type: spec.type,
+        tags: spec.tags,
+      },
+      similar: hits.slice(0, 5).map((h) => ({
+        path: h.path,
+        title: h.title,
+        score: h.score,
+        snippet: h.text.slice(0, 400),
+      })),
+    },
+    null,
+    2,
+  );
+
+  let raw = "";
+  try {
+    const response = await deps.llm.chat({
+      messages: [
+        { role: "system", content: promptBody + STRATEGY_HINT },
+        { role: "user", content: userPrompt },
+      ],
+      format: "json",
+      stream: false,
+      signal,
+    });
+    raw = response.content?.trim() ?? "";
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return interpret(parsed, hits, spec);
+}
+
+const STRATEGY_HINT = `
+
+Return ONLY a JSON object with this shape:
+{ "strategy": "new" | "append" | "ask_user", "targetPath"?: string, "reason": string }
+
+Rules:
+- "new" when the candidate is genuinely distinct from the similar notes.
+- "append" only when one similar note clearly belongs as the parent and the
+  candidate would naturally extend it. Provide its path in "targetPath".
+- "ask_user" when there's a near-duplicate but you're not sure whether to
+  append or branch off. Provide the closest match in "targetPath".
+`;
+
+function interpret(
+  raw: unknown,
+  hits: RetrievalHit[],
+  spec: NoteSpec,
+): IngestStrategy | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const strategy = r.strategy;
+  const target = typeof r.targetPath === "string" ? r.targetPath : undefined;
+
+  if (strategy === "append" && target) return { kind: "append", target };
+  if (strategy === "ask_user" && target) {
+    const score = hits.find((h) => h.path === target)?.score ?? 0;
+    return { kind: "dedup_ask", target, similarity: score };
+  }
+  if (strategy === "new") {
+    const related = unique([...spec.related, ...hits.slice(0, 3).map((h) => h.path)]);
+    return { kind: "create", related };
+  }
+  return null;
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+function unique(items: string[]): string[] {
+  return [...new Set(items)];
+}

--- a/src/services/ingest-strategy.ts
+++ b/src/services/ingest-strategy.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { unique } from "./util";
 import type {
   IngestStrategy,
   IngestionStore,
@@ -21,6 +22,12 @@ export interface IngestStrategyDeps {
 }
 
 const DEFAULT_DEDUP_THRESHOLD = 0.85;
+/**
+ * Below this score the LLM dedup-decider almost always returns `new`. Skip
+ * the LLM call and short-circuit to create+related-links instead. Saves a
+ * round-trip on the common "candidate has weak/no signal" case.
+ */
+const LLM_FLOOR_SCORE = 0.3;
 
 /**
  * Decide whether the candidate becomes a new note, an append, or asks the
@@ -82,7 +89,15 @@ export async function decideStrategy(
     };
   }
 
-  // 4. LLM-driven fuzzy decision. Permissive parsing — anything off-schema
+  // 4. Low-score floor: if even the top hit is weak, skip the LLM call.
+  //    The dedup-decider will almost always return `new` for these and the
+  //    LLM round-trip is pure latency.
+  if (top.score < LLM_FLOOR_SCORE) {
+    const related = unique([...spec.related, ...hits.slice(0, 3).map((h) => h.path)]);
+    return { strategy: { kind: "create", related }, topHits: hits };
+  }
+
+  // 5. LLM-driven fuzzy decision. Permissive parsing — anything off-schema
   //    falls back to `create` so a flaky model can't block ingestion.
   const llmDecision = await consultLlm(spec, hits, deps, signal);
   if (llmDecision) return { strategy: llmDecision, topHits: hits };
@@ -187,8 +202,4 @@ function interpret(
 
 function sha256(s: string): string {
   return createHash("sha256").update(s, "utf8").digest("hex");
-}
-
-function unique(items: string[]): string[] {
-  return [...new Set(items)];
 }

--- a/src/services/ingest-strategy.ts
+++ b/src/services/ingest-strategy.ts
@@ -46,12 +46,15 @@ export async function decideStrategy(
   const threshold = deps.dedupThreshold ?? DEFAULT_DEDUP_THRESHOLD;
   const topK = deps.topK ?? 5;
 
-  // 1. Exact-hash dedup short-circuit.
+  // 1. Exact-hash dedup short-circuit. The pipeline stores `bodyHash =
+  //    sha256(body_after_frontmatter_strip)` per note, so hashing the
+  //    candidate body the same way matches existing notes whose body is
+  //    byte-identical regardless of frontmatter or chunk boundaries.
   const bodyHash = sha256(spec.body_markdown);
-  const exactMatches = await deps.store.getChunksByHash(bodyHash);
+  const exactMatches = await deps.store.findByBodyHash(bodyHash);
   if (exactMatches.length > 0) {
     return {
-      strategy: { kind: "dedup_ask", target: exactMatches[0].path, similarity: 1 },
+      strategy: { kind: "dedup_ask", target: exactMatches[0], similarity: 1 },
       topHits: [],
     };
   }

--- a/src/services/ingest-strategy.ts
+++ b/src/services/ingest-strategy.ts
@@ -55,8 +55,16 @@ export async function decideStrategy(
 
   // 1. Exact-hash dedup short-circuit. The pipeline stores `bodyHash =
   //    sha256(body_after_frontmatter_strip)` per note, so hashing the
-  //    candidate body the same way matches existing notes whose body is
-  //    byte-identical regardless of frontmatter or chunk boundaries.
+  //    candidate body the same way matches notes whose body is byte-
+  //    identical regardless of frontmatter or chunk boundaries.
+  //
+  //    Caveat: this is a *byte* match, not a *semantic* match. The LLM
+  //    parser may normalise whitespace, list bullets, or quotes differently
+  //    on two runs of the same input — those produce different bytes and
+  //    will fall through to the threshold + LLM branches below. That's the
+  //    correct degradation: the slower paths still catch true near-dupes
+  //    via vector similarity. The hash short-circuit is purely a fast path
+  //    for the "user pasted the exact same thing twice" case.
   const bodyHash = sha256(spec.body_markdown);
   const exactMatches = await deps.store.findByBodyHash(bodyHash);
   if (exactMatches.length > 0) {

--- a/src/services/ingest-writer.test.ts
+++ b/src/services/ingest-writer.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { IngestWriter } from "./ingest-writer";
+import type { NoteSpec } from "../contracts";
+
+function makeSpec(overrides: Partial<NoteSpec> = {}): NoteSpec {
+  return {
+    title: "Q2 standup",
+    type: "meeting",
+    tags: ["q2", "team"],
+    aliases: [],
+    source: "chat-paste",
+    entities: ["Alice"],
+    related: [],
+    status: "inbox",
+    summary: "Decisions about billing-v2.",
+    key_points: ["Switch to v2 by July"],
+    body_markdown: "# Decisions\n\nWe agreed to roll out billing-v2 next quarter.",
+    cowork: {
+      source: "ingest",
+      run_id: "01HW000",
+      model: "gemma3:latest",
+      version: "0.0.1",
+      confidence: "high",
+    },
+    ...overrides,
+  };
+}
+
+describe("IngestWriter", () => {
+  it("writes a new note in the default Inbox/ folder with a dated filename", async () => {
+    const vault = new MockVaultService({});
+    const writer = new IngestWriter(vault);
+    const fixedNow = () => Date.UTC(2026, 4, 6); // 2026-05-06
+
+    const result = await writer.writeNew(makeSpec(), { now: fixedNow });
+
+    expect(result.path).toBe("Inbox/2026-05-06 Q2 standup.md");
+    const written = await vault.read(result.path);
+    expect(written).toContain("---\n");
+    expect(written).toContain("cowork_managed: true");
+    expect(written).toContain("type: meeting");
+    expect(written).toContain("# Decisions");
+    expect(written).toContain("cowork:");
+    expect(written).toContain("source: ingest");
+  });
+
+  it("disambiguates filename collisions with (2), (3), ...", async () => {
+    const vault = new MockVaultService({
+      "Inbox/2026-05-06 Q2 standup.md": "existing",
+    });
+    const writer = new IngestWriter(vault);
+    const fixedNow = () => Date.UTC(2026, 4, 6);
+
+    const result = await writer.writeNew(makeSpec(), { now: fixedNow });
+    expect(result.path).toBe("Inbox/2026-05-06 Q2 standup (2).md");
+  });
+
+  it("appends under a new dated heading when target lacks today's heading", async () => {
+    const target = "Projects/billing-v2.md";
+    const vault = new MockVaultService({
+      [target]: "---\ntitle: Billing v2\ncowork_managed: true\n---\n\n# Billing v2\n\nNotes go here.\n",
+    });
+    const writer = new IngestWriter(vault);
+    const fixedNow = () => Date.UTC(2026, 4, 6);
+
+    await writer.appendUnderDatedHeading(target, "New paragraph from chat.", { now: fixedNow });
+    const result = await vault.read(target);
+
+    expect(result).toContain("## 2026-05-06");
+    expect(result).toContain("New paragraph from chat.");
+  });
+
+  it("appends under existing dated heading without creating a duplicate", async () => {
+    const target = "daily.md";
+    const vault = new MockVaultService({
+      [target]: "# Daily\n\n## 2026-05-06\n\nFirst entry.\n",
+    });
+    const writer = new IngestWriter(vault);
+    const fixedNow = () => Date.UTC(2026, 4, 6);
+
+    await writer.appendUnderDatedHeading(target, "Second entry.", { now: fixedNow });
+    const result = await vault.read(target);
+
+    const headingMatches = result.match(/## 2026-05-06/g) ?? [];
+    expect(headingMatches.length).toBe(1);
+    expect(result).toContain("Second entry.");
+  });
+
+  it("rejects bodies that contain their own frontmatter block", async () => {
+    const vault = new MockVaultService({});
+    const writer = new IngestWriter(vault);
+    const spec = makeSpec({
+      body_markdown: "---\ntitle: hijack\n---\n\nbad",
+    });
+    await expect(writer.writeNew(spec)).rejects.toThrow(/frontmatter/);
+  });
+
+  it("throws when append target is missing", async () => {
+    const vault = new MockVaultService({});
+    const writer = new IngestWriter(vault);
+    await expect(
+      writer.appendUnderDatedHeading("does/not/exist.md", "x"),
+    ).rejects.toThrow(/missing/);
+  });
+});

--- a/src/services/ingest-writer.test.ts
+++ b/src/services/ingest-writer.test.ts
@@ -103,4 +103,29 @@ describe("IngestWriter", () => {
       writer.appendUnderDatedHeading("does/not/exist.md", "x"),
     ).rejects.toThrow(/missing/);
   });
+
+  it("throws when expectedMtime no longer matches the target's mtime (drift)", async () => {
+    const target = "Notes/log.md";
+    const vault = new MockVaultService({ [target]: "old\n" });
+    vault.setMtime(target, 1000);
+    const writer = new IngestWriter(vault);
+
+    // Simulate an external edit while preview was open: bump mtime.
+    vault.setMtime(target, 2000);
+
+    await expect(
+      writer.appendUnderDatedHeading(target, "new content", { expectedMtime: 1000 }),
+    ).rejects.toThrow(/drifted/);
+  });
+
+  it("appends when expectedMtime matches", async () => {
+    const target = "Notes/log.md";
+    const vault = new MockVaultService({ [target]: "old\n" });
+    vault.setMtime(target, 1000);
+    const writer = new IngestWriter(vault);
+
+    await writer.appendUnderDatedHeading(target, "new content", { expectedMtime: 1000 });
+    const result = await vault.read(target);
+    expect(result).toContain("new content");
+  });
 });

--- a/src/services/ingest-writer.test.ts
+++ b/src/services/ingest-writer.test.ts
@@ -71,6 +71,22 @@ describe("IngestWriter", () => {
     expect(result).toContain("New paragraph from chat.");
   });
 
+  it("does not duplicate heading when target ends with the heading and no trailing newline", async () => {
+    const target = "daily.md";
+    const vault = new MockVaultService({
+      [target]: "# Daily\n\n## 2026-05-06",
+    });
+    const writer = new IngestWriter(vault);
+    const fixedNow = () => Date.UTC(2026, 4, 6);
+
+    await writer.appendUnderDatedHeading(target, "Late entry.", { now: fixedNow });
+    const result = await vault.read(target);
+
+    const headingMatches = result.match(/## 2026-05-06/g) ?? [];
+    expect(headingMatches.length).toBe(1);
+    expect(result).toContain("Late entry.");
+  });
+
   it("appends under existing dated heading without creating a duplicate", async () => {
     const target = "daily.md";
     const vault = new MockVaultService({

--- a/src/services/ingest-writer.ts
+++ b/src/services/ingest-writer.ts
@@ -1,0 +1,140 @@
+import type { NoteSpec, VaultService } from "../contracts";
+
+export interface WriteNewOptions {
+  /** Folder to place the new note in. Default `Inbox/`. Trailing slash optional. */
+  folder?: string;
+  /** Override for tests (defaults to `Date.now`). */
+  now?: () => number;
+}
+
+export interface AppendOptions {
+  /** Override for tests. */
+  now?: () => number;
+}
+
+/**
+ * Atomic write paths for the ingest tool loop (#13). Composes the cowork
+ * frontmatter block from planning/rag.md §"Frontmatter contract" and stamps
+ * `cowork_managed: true` so subsequent writes know the file is app-managed.
+ *
+ * Append mode places the new content under a dated H2 heading (`## YYYY-MM-DD`)
+ * inside the target note. Idempotency for append-on-the-same-day is not
+ * promised — repeated appends accumulate paragraphs under the same heading,
+ * which is the desired behavior for daily-note-style flows.
+ */
+export class IngestWriter {
+  constructor(private readonly vault: VaultService) {}
+
+  async writeNew(
+    spec: NoteSpec,
+    opts: WriteNewOptions = {},
+  ): Promise<{ path: string }> {
+    const folder = normalizeFolder(opts.folder ?? "Inbox/");
+    const now = opts.now ?? (() => Date.now());
+    const datePrefix = isoDate(now());
+    const slug = slugifyTitle(spec.title);
+    const baseName = `${datePrefix} ${slug}`;
+    const path = await uniquePath(this.vault, folder, baseName);
+    const content = composeFile(spec);
+    await this.vault.create(path, content);
+    return { path };
+  }
+
+  async appendUnderDatedHeading(
+    targetPath: string,
+    body: string,
+    opts: AppendOptions = {},
+  ): Promise<void> {
+    const now = opts.now ?? (() => Date.now());
+    if (!(await this.vault.exists(targetPath))) {
+      throw new Error(`append target missing: ${targetPath}`);
+    }
+    const existing = await this.vault.read(targetPath);
+    const heading = `## ${isoDate(now())}`;
+    const trimmed = body.trim();
+    const append = existing.includes(`\n${heading}\n`)
+      ? `\n\n${trimmed}\n`
+      : `\n\n${heading}\n\n${trimmed}\n`;
+    await this.vault.append(targetPath, append);
+  }
+}
+
+function isoDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function slugifyTitle(title: string): string {
+  const cleaned = title.replace(/[\\/:*?"<>|#]/g, " ").replace(/\s+/g, " ").trim();
+  return cleaned.length > 0 ? cleaned.slice(0, 80) : "Untitled";
+}
+
+function normalizeFolder(folder: string): string {
+  if (!folder) return "";
+  return folder.endsWith("/") ? folder : `${folder}/`;
+}
+
+async function uniquePath(
+  vault: VaultService,
+  folder: string,
+  baseName: string,
+): Promise<string> {
+  const first = `${folder}${baseName}.md`;
+  if (!(await vault.exists(first))) return first;
+  for (let i = 2; i < 1000; i++) {
+    const candidate = `${folder}${baseName} (${i}).md`;
+    if (!(await vault.exists(candidate))) return candidate;
+  }
+  throw new Error(`Could not find unused path for ${baseName}`);
+}
+
+/**
+ * Compose the file contents: frontmatter + body. The body MUST NOT contain
+ * its own frontmatter block (the parser strips it; we re-fail here as
+ * defense in depth so a buggy parser cannot corrupt the file format).
+ */
+function composeFile(spec: NoteSpec): string {
+  const body = spec.body_markdown ?? "";
+  if (/^---\s*\r?\n/.test(body)) {
+    throw new Error("body_markdown must not contain its own frontmatter block");
+  }
+  const frontmatter = renderFrontmatter(spec);
+  return `${frontmatter}\n${body.endsWith("\n") ? body : `${body}\n`}`;
+}
+
+function renderFrontmatter(spec: NoteSpec): string {
+  const lines: string[] = ["---"];
+  lines.push(`title: ${yamlScalar(spec.title)}`);
+  lines.push(`type: ${spec.type}`);
+  lines.push(`status: ${spec.status}`);
+  lines.push(`source: ${spec.source}`);
+  lines.push(`cowork_managed: true`);
+  lines.push(`tags: ${yamlList(spec.tags)}`);
+  lines.push(`aliases: ${yamlList(spec.aliases)}`);
+  lines.push(`entities: ${yamlList(spec.entities)}`);
+  lines.push(`related: ${yamlList(spec.related)}`);
+  if (spec.summary) lines.push(`summary: ${yamlScalar(spec.summary)}`);
+  if (spec.key_points.length > 0) {
+    lines.push(`key_points:`);
+    for (const k of spec.key_points) lines.push(`  - ${yamlScalar(k)}`);
+  }
+  lines.push(`cowork:`);
+  lines.push(`  source: ${spec.cowork.source}`);
+  lines.push(`  run_id: ${yamlScalar(spec.cowork.run_id)}`);
+  lines.push(`  model: ${yamlScalar(spec.cowork.model)}`);
+  lines.push(`  version: ${yamlScalar(spec.cowork.version)}`);
+  lines.push(`  confidence: ${spec.cowork.confidence}`);
+  lines.push("---");
+  return lines.join("\n");
+}
+
+function yamlScalar(s: string): string {
+  if (s === "" || /[:#\-?,&*!|>%@`{}\[\]\n]/.test(s) || /^\s|\s$/.test(s)) {
+    return JSON.stringify(s);
+  }
+  return s;
+}
+
+function yamlList(items: string[]): string {
+  if (items.length === 0) return "[]";
+  return `[${items.map(yamlScalar).join(", ")}]`;
+}

--- a/src/services/ingest-writer.ts
+++ b/src/services/ingest-writer.ts
@@ -10,6 +10,12 @@ export interface WriteNewOptions {
 export interface AppendOptions {
   /** Override for tests. */
   now?: () => number;
+  /**
+   * Expected mtime of the target captured during preview. If the file's
+   * actual mtime no longer matches, the append throws — protects against
+   * a concurrent edit between preview confirmation and write.
+   */
+  expectedMtime?: number;
 }
 
 /**
@@ -48,6 +54,14 @@ export class IngestWriter {
     const now = opts.now ?? (() => Date.now());
     if (!(await this.vault.exists(targetPath))) {
       throw new Error(`append target missing: ${targetPath}`);
+    }
+    if (opts.expectedMtime !== undefined) {
+      const stat = await this.vault.stat(targetPath);
+      if (stat.mtime !== opts.expectedMtime) {
+        throw new Error(
+          `append target drifted: ${targetPath} (expected mtime ${opts.expectedMtime}, found ${stat.mtime})`,
+        );
+      }
     }
     const existing = await this.vault.read(targetPath);
     const heading = `## ${isoDate(now())}`;

--- a/src/services/ingest-writer.ts
+++ b/src/services/ingest-writer.ts
@@ -66,7 +66,10 @@ export class IngestWriter {
     const existing = await this.vault.read(targetPath);
     const heading = `## ${isoDate(now())}`;
     const trimmed = body.trim();
-    const append = existing.includes(`\n${heading}\n`)
+    // Match the heading even when it sits at the very end of the file with
+    // no trailing newline. The stricter form `\n${heading}\n` would miss
+    // "...\n## 2026-05-07" (no closing \n) and create a duplicate heading.
+    const append = existing.includes(`\n${heading}`)
       ? `\n\n${trimmed}\n`
       : `\n\n${heading}\n\n${trimmed}\n`;
     await this.vault.append(targetPath, append);

--- a/src/services/ingestion-pipeline.test.ts
+++ b/src/services/ingestion-pipeline.test.ts
@@ -4,10 +4,15 @@ import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-s
 import { MarkdownChunker } from "./markdown-chunker";
 import { HashGatedIngestionPipeline } from "./ingestion-pipeline";
 
-function setup(files: Record<string, string>) {
+function setup(files: Record<string, string>, epoch = () => 0) {
   const vault = new MockVaultService(files);
   const store = new InMemoryIngestionStore();
-  const pipeline = new HashGatedIngestionPipeline(vault, new MarkdownChunker(), store);
+  const pipeline = new HashGatedIngestionPipeline(
+    vault,
+    new MarkdownChunker(),
+    store,
+    epoch,
+  );
   return { vault, store, pipeline };
 }
 
@@ -103,5 +108,27 @@ describe("HashGatedIngestionPipeline", () => {
     await pipeline.ingest("Notes/a.md", { mtime: 1234567890 });
     const persisted = await store.get("Notes/a.md");
     expect(persisted?.mtime).toBe(1234567890);
+  });
+
+  it("re-processes a hash-clean note when its lastEpoch is below currentEpoch (rebuild)", async () => {
+    let epoch = 0;
+    const { pipeline, store } = setup(
+      { "Notes/a.md": "hello world" },
+      () => epoch,
+    );
+
+    const first = await pipeline.ingest("Notes/a.md");
+    expect(first.kind).toBe("rechunk");
+    expect((await store.get("Notes/a.md"))?.lastEpoch).toBe(0);
+
+    // Same content, same epoch → skip.
+    const stable = await pipeline.ingest("Notes/a.md");
+    expect(stable.kind).toBe("skip");
+
+    // Bump epoch (simulate rebuild). The hash gate must release.
+    epoch = 100;
+    const rebuilt = await pipeline.ingest("Notes/a.md");
+    expect(rebuilt.kind).not.toBe("skip");
+    expect((await store.get("Notes/a.md"))?.lastEpoch).toBe(100);
   });
 });

--- a/src/services/ingestion-pipeline.ts
+++ b/src/services/ingestion-pipeline.ts
@@ -14,14 +14,26 @@ export class HashGatedIngestionPipeline implements IngestionPipeline {
     private readonly vault: VaultService,
     private readonly chunker: Chunker,
     private readonly store: IngestionStore,
+    /**
+     * Returns the current rebuild epoch (#15d). When a note's `lastEpoch`
+     * is below this value, the hash gate is bypassed so the rebuild can
+     * re-stamp it. Defaults to 0 — backward-compatible with callers that
+     * haven't wired the controls service yet.
+     */
+    private readonly currentEpoch: () => number = () => 0,
   ) {}
 
   async ingest(path: string, opts: IngestOptions = {}): Promise<IngestDecision> {
     const raw = await this.vault.read(path);
     const contentHash = sha256(raw);
+    const epoch = this.currentEpoch();
 
     const prior = await this.store.get(path);
-    if (prior && prior.contentHash === contentHash) {
+    if (
+      prior &&
+      prior.contentHash === contentHash &&
+      (prior.lastEpoch ?? 0) >= epoch
+    ) {
       return { kind: "skip", state: prior };
     }
 
@@ -35,6 +47,7 @@ export class HashGatedIngestionPipeline implements IngestionPipeline {
       bodyHash,
       mtime,
       frontmatter,
+      lastEpoch: epoch,
     };
 
     if (prior && prior.bodyHash === bodyHash) {

--- a/src/services/ingestion-runner.ts
+++ b/src/services/ingestion-runner.ts
@@ -26,6 +26,11 @@ export class IngestionRunner {
   private running = false;
   private paused = false;
   private listeners = new Set<(e: RunnerEvent) => void>();
+  // Jobs the runner has drained from the queue but has not yet emitted a
+  // result for. Necessary because `processUntilEmpty` drains in batches —
+  // `queue.size()` alone underreports work-in-progress and would tell
+  // RunnerStatus the indexer is idle while 999 jobs are still iterating.
+  private inFlightJobs = 0;
 
   constructor(
     private readonly queue: JobQueue,
@@ -70,7 +75,17 @@ export class IngestionRunner {
   }
 
   isIdle(): boolean {
-    return !this.running && this.queue.size() === 0;
+    return !this.running && this.queue.size() === 0 && this.inFlightJobs === 0;
+  }
+
+  /**
+   * Total work the runner currently knows about: queued + drained-but-not-
+   * yet-emitted. RunnerStatus reads this so the chat-header pill reflects
+   * actual progress rather than dropping to "idle" the moment the runner
+   * empties the queue at the start of a batch.
+   */
+  workSize(): number {
+    return this.queue.size() + this.inFlightJobs;
   }
 
   /** Run the queue until empty. Safe to call concurrently — work coalesces. */
@@ -90,19 +105,28 @@ export class IngestionRunner {
     try {
       while (!this.paused && this.queue.size() > 0) {
         const jobs = this.queue.drain();
+        this.inFlightJobs += jobs.length;
         for (const job of jobs) {
           if (this.paused) {
             // Re-queue jobs we drained but haven't started. Order is
             // preserved because nothing else has run between drain and
-            // re-enqueue.
+            // re-enqueue. Decrement in-flight by one for each job moved
+            // back to the queue so workSize() stays consistent.
             this.queue.enqueue(job);
+            this.inFlightJobs--;
             continue;
           }
+          let event: RunnerEvent;
           try {
-            await this.runOne(job);
+            event = await this.runOne(job);
           } catch (error) {
-            this.emit({ kind: "error", job, error });
+            event = { kind: "error", job, error };
           }
+          // Decrement BEFORE emit. Listeners (RunnerStatus) read workSize()
+          // from inside the emit callback; a job about to emit a result
+          // must already be counted as done, not in flight.
+          this.inFlightJobs--;
+          this.emit(event);
         }
       }
     } finally {
@@ -110,27 +134,24 @@ export class IngestionRunner {
     }
   }
 
-  private async runOne(job: IndexJob): Promise<void> {
+  private async runOne(job: IndexJob): Promise<RunnerEvent> {
     if (job.kind === "index") {
       const decision = await this.pipeline.ingest(job.path);
-      this.emit({ kind: "decision", job, decision });
-      return;
+      return { kind: "decision", job, decision };
     }
     if (job.kind === "delete") {
       await this.store.delete(job.path);
-      this.emit({ kind: "deleted", path: job.path });
-      return;
+      return { kind: "deleted", path: job.path };
     }
     // rename
     const prior = await this.store.get(job.from);
     if (prior) {
       await this.store.rename(job.from, job.to);
-      this.emit({ kind: "renamed", from: job.from, to: job.to });
-      return;
+      return { kind: "renamed", from: job.from, to: job.to };
     }
     // Unknown source — fall through to a normal index of the new path.
     const decision = await this.pipeline.ingest(job.to);
-    this.emit({ kind: "decision", job, decision });
+    return { kind: "decision", job, decision };
   }
 
   private emit(event: RunnerEvent): void {

--- a/src/services/ingestion-runner.ts
+++ b/src/services/ingestion-runner.ts
@@ -24,6 +24,7 @@ export class IngestionRunner {
   private unsubscribe: (() => void) | null = null;
   private inFlight: Promise<void> = Promise.resolve();
   private running = false;
+  private paused = false;
   private listeners = new Set<(e: RunnerEvent) => void>();
 
   constructor(
@@ -39,6 +40,20 @@ export class IngestionRunner {
     });
     // Pick up anything already pending at start time.
     if (this.queue.size() > 0) void this.kick();
+  }
+
+  /**
+   * Halt new job claims. In-flight jobs run to completion. While paused,
+   * arrivals enqueue but don't run; resume() re-kicks the loop.
+   */
+  setPaused(paused: boolean): void {
+    if (this.paused === paused) return;
+    this.paused = paused;
+    if (!paused && this.queue.size() > 0) void this.kick();
+  }
+
+  isPaused(): boolean {
+    return this.paused;
   }
 
   async stop(): Promise<void> {
@@ -73,9 +88,16 @@ export class IngestionRunner {
   private async processUntilEmpty(): Promise<void> {
     this.running = true;
     try {
-      while (this.queue.size() > 0) {
+      while (!this.paused && this.queue.size() > 0) {
         const jobs = this.queue.drain();
         for (const job of jobs) {
+          if (this.paused) {
+            // Re-queue jobs we drained but haven't started. Order is
+            // preserved because nothing else has run between drain and
+            // re-enqueue.
+            this.queue.enqueue(job);
+            continue;
+          }
           try {
             await this.runOne(job);
           } catch (error) {

--- a/src/services/json-ingestion-store.ts
+++ b/src/services/json-ingestion-store.ts
@@ -102,6 +102,15 @@ export class JsonIngestionStore implements IngestionStore {
     return out;
   }
 
+  async findByBodyHash(hash: string): Promise<string[]> {
+    const data = await this.load();
+    const out: string[] = [];
+    for (const [path, state] of Object.entries(data.notes)) {
+      if (state.bodyHash === hash) out.push(path);
+    }
+    return out;
+  }
+
   private async load(): Promise<StoreShape> {
     if (this.cache) return this.cache;
     try {

--- a/src/services/json-ingestion-store.ts
+++ b/src/services/json-ingestion-store.ts
@@ -1,14 +1,15 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import type { Chunk, IngestionStore, NoteState } from "../contracts";
+import type { Chunk, IngestionMeta, IngestionStore, NoteState } from "../contracts";
 
 interface StoreShape {
   version: 1;
   notes: Record<string, NoteState>;
   chunks: Record<string, Chunk[]>;
+  meta: Partial<IngestionMeta>;
 }
 
-const EMPTY: StoreShape = { version: 1, notes: {}, chunks: {} };
+const EMPTY: StoreShape = { version: 1, notes: {}, chunks: {}, meta: {} };
 
 /**
  * JSON-backed ingestion store. Single file, full-rewrite on each upsert via
@@ -78,6 +79,18 @@ export class JsonIngestionStore implements IngestionStore {
     return false;
   }
 
+  async getMeta<K extends keyof IngestionMeta>(key: K): Promise<IngestionMeta[K] | null> {
+    const data = await this.load();
+    const value = data.meta[key];
+    return value === undefined ? null : (value as IngestionMeta[K]);
+  }
+
+  async setMeta<K extends keyof IngestionMeta>(key: K, value: IngestionMeta[K]): Promise<void> {
+    const data = await this.load();
+    data.meta[key] = value;
+    await this.flush(data);
+  }
+
   async getChunksByHash(contentHash: string): Promise<Chunk[]> {
     const data = await this.load();
     const out: Chunk[] = [];
@@ -98,10 +111,11 @@ export class JsonIngestionStore implements IngestionStore {
         version: 1,
         notes: parsed.notes ?? {},
         chunks: parsed.chunks ?? {},
+        meta: parsed.meta ?? {},
       };
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-      this.cache = { ...EMPTY, notes: {}, chunks: {} };
+      this.cache = { ...EMPTY, notes: {}, chunks: {}, meta: {} };
     }
     return this.cache;
   }

--- a/src/services/real-vault.ts
+++ b/src/services/real-vault.ts
@@ -1,5 +1,5 @@
 import type { App, TFile } from "obsidian";
-import type { HeadingRef, VaultFileRef, VaultService } from "../contracts";
+import type { HeadingRef, VaultFileRef, VaultService, VaultStat } from "../contracts";
 
 export class ObsidianVaultService implements VaultService {
   constructor(private readonly app: App) {}
@@ -29,6 +29,11 @@ export class ObsidianVaultService implements VaultService {
   async append(path: string, content: string): Promise<void> {
     const file = this.requireFile(path);
     await this.app.vault.append(file, content);
+  }
+
+  async stat(path: string): Promise<VaultStat> {
+    const file = this.requireFile(path);
+    return { mtime: file.stat.mtime, size: file.stat.size };
   }
 
   async getHeadings(path: string): Promise<HeadingRef[]> {

--- a/src/services/runner-controls.test.ts
+++ b/src/services/runner-controls.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { IngestionRunner } from "./ingestion-runner";
+import { RunnerControls } from "./runner-controls";
+import { RunnerStatus } from "./runner-status";
+import type {
+  IndexJob,
+  IngestDecision,
+  IngestionPipeline,
+  Reconciler,
+} from "../contracts";
+
+class StubPipeline implements IngestionPipeline {
+  ran: string[] = [];
+  async ingest(path: string): Promise<IngestDecision> {
+    this.ran.push(path);
+    return {
+      kind: "skip",
+      state: {
+        path,
+        contentHash: "h",
+        bodyHash: "h",
+        mtime: 0,
+        frontmatter: null,
+      },
+    };
+  }
+}
+
+class StubReconciler implements Reconciler {
+  constructor(
+    private readonly queue: InMemoryJobQueue,
+    private readonly paths: string[],
+  ) {}
+  async reconcile() {
+    for (const p of this.paths) this.queue.enqueue({ kind: "index", path: p });
+    return { enqueuedIndex: this.paths.length, enqueuedDelete: 0 };
+  }
+}
+
+function setup(paths: string[] = []) {
+  const queue = new InMemoryJobQueue();
+  const store = new InMemoryIngestionStore();
+  const pipeline = new StubPipeline();
+  const runner = new IngestionRunner(queue, pipeline, store);
+  const status = new RunnerStatus(queue, runner);
+  status.start();
+  const reconciler = new StubReconciler(queue, paths);
+  const controls = new RunnerControls(runner, status, store, reconciler, queue);
+  return { queue, store, pipeline, runner, status, controls };
+}
+
+describe("RunnerControls", () => {
+  it("pause persists and stops new claims", async () => {
+    const { queue, store, controls, runner, pipeline } = setup();
+    runner.start();
+    await controls.pause();
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    // Allow microtasks to settle. Runner should not have processed.
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(pipeline.ran).toHaveLength(0);
+    expect(queue.size()).toBe(1);
+    expect(await store.getMeta("paused")).toBe(true);
+    expect(controls.isPaused()).toBe(true);
+  });
+
+  it("resume drains queued jobs", async () => {
+    const { queue, controls, runner, pipeline } = setup();
+    runner.start();
+    await controls.pause();
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    queue.enqueue({ kind: "index", path: "b.md" });
+    await controls.resume();
+    // Wait for runner to drain.
+    await runner.drainNow();
+
+    expect(pipeline.ran).toEqual(["a.md", "b.md"]);
+  });
+
+  it("pause survives reload via persisted meta", async () => {
+    const { store, controls, runner } = setup();
+    runner.start();
+    await controls.pause();
+
+    // Simulate reload: new runner/status against the same store.
+    const queue2 = new InMemoryJobQueue();
+    const pipeline2 = new StubPipeline();
+    const runner2 = new IngestionRunner(queue2, pipeline2, store);
+    const status2 = new RunnerStatus(queue2, runner2);
+    status2.start();
+    const reconciler2 = new StubReconciler(queue2, []);
+    const controls2 = new RunnerControls(runner2, status2, store, reconciler2, queue2);
+    runner2.start();
+    await controls2.applyPersistedState();
+
+    expect(controls2.isPaused()).toBe(true);
+    queue2.enqueue({ kind: "index", path: "x.md" } as IndexJob);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(pipeline2.ran).toHaveLength(0);
+  });
+
+  it("rebuild bumps rebuildEpoch and re-enqueues everything", async () => {
+    const { store, controls } = setup(["a.md", "b.md"]);
+    const result = await controls.rebuild();
+    expect(result.enqueued).toBe(2);
+
+    const epoch = await store.getMeta("rebuildEpoch");
+    expect(typeof epoch).toBe("number");
+    expect((epoch as number) > 0).toBe(true);
+  });
+
+  it("reconcileNow stamps lastReconciledAt", async () => {
+    const { store, controls } = setup(["a.md"]);
+    const before = Date.now();
+    await controls.reconcileNow();
+    const ts = (await store.getMeta("lastReconciledAt")) ?? 0;
+    expect(ts).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/src/services/runner-controls.test.ts
+++ b/src/services/runner-controls.test.ts
@@ -113,11 +113,47 @@ describe("RunnerControls", () => {
     expect((epoch as number) > 0).toBe(true);
   });
 
-  it("reconcileNow stamps lastReconciledAt", async () => {
-    const { store, controls } = setup(["a.md"]);
-    const before = Date.now();
-    await controls.reconcileNow();
-    const ts = (await store.getMeta("lastReconciledAt")) ?? 0;
-    expect(ts).toBeGreaterThanOrEqual(before);
+  it("pause-mid-batch: in-flight job finishes, remainder is re-queued in order", async () => {
+    const queue = new InMemoryJobQueue();
+    const store = new InMemoryIngestionStore();
+    const ran: string[] = [];
+    let resolveSecond: () => void = () => {};
+    const pipeline: IngestionPipeline = {
+      async ingest(path: string): Promise<IngestDecision> {
+        ran.push(path);
+        if (path === "second.md") {
+          await new Promise<void>((r) => { resolveSecond = r; });
+        }
+        return {
+          kind: "skip",
+          state: { path, contentHash: "h", bodyHash: "h", mtime: 0, frontmatter: null },
+        };
+      },
+    };
+    const runner = new IngestionRunner(queue, pipeline, store);
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+    const reconciler = new StubReconciler(queue, []);
+    const controls = new RunnerControls(runner, status, store, reconciler, queue);
+    runner.start();
+
+    queue.enqueue({ kind: "index", path: "first.md" });
+    queue.enqueue({ kind: "index", path: "second.md" });
+    queue.enqueue({ kind: "index", path: "third.md" });
+    queue.enqueue({ kind: "index", path: "fourth.md" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(ran).toEqual(["first.md", "second.md"]);
+
+    await controls.pause();
+    resolveSecond();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Pause halted the loop after second finished; third + fourth stayed queued.
+    expect(ran).toEqual(["first.md", "second.md"]);
+    expect(queue.size()).toBe(2);
+
+    await controls.resume();
+    await runner.drainNow();
+    expect(ran).toEqual(["first.md", "second.md", "third.md", "fourth.md"]);
   });
 });

--- a/src/services/runner-controls.ts
+++ b/src/services/runner-controls.ts
@@ -1,0 +1,85 @@
+import type { IngestionStore, JobQueue, Reconciler } from "../contracts";
+import type { IngestionRunner } from "./ingestion-runner";
+import type { RunnerStatus } from "./runner-status";
+
+/**
+ * User-facing indexer controls (#15c, #15d). Coordinates the runner, the
+ * status observable, and persisted meta state. Single instance owns the
+ * pause flag so the on-disk truth and the in-memory state can never drift.
+ *
+ * Pause persistence: written to `IngestionStore.meta.paused`. On plugin load,
+ * `applyPersistedState()` restores the flag before the runner processes any
+ * jobs.
+ *
+ * Rebuild: bumps `meta.rebuildEpoch`. Subsequent reconciles enqueue every
+ * note (the hash gate makes warm paths free, so unchanged content is a
+ * cheap traversal). A note's `lastEpoch` is stamped after successful ingest;
+ * any path whose `lastEpoch < rebuildEpoch` is treated as stale and gets
+ * re-enqueued. Resumability is automatic: an interrupted rebuild leaves
+ * `lastEpoch` un-bumped on the remaining paths and the next reconcile
+ * picks them up.
+ */
+export class RunnerControls {
+  constructor(
+    private readonly runner: IngestionRunner,
+    private readonly status: RunnerStatus,
+    private readonly store: IngestionStore,
+    private readonly reconciler: Reconciler,
+    private readonly queue: JobQueue,
+  ) {}
+
+  async applyPersistedState(): Promise<void> {
+    const paused = (await this.store.getMeta("paused")) ?? false;
+    this.runner.setPaused(paused);
+    this.status.setPaused(paused);
+  }
+
+  async pause(): Promise<void> {
+    this.runner.setPaused(true);
+    this.status.setPaused(true);
+    await this.store.setMeta("paused", true);
+  }
+
+  async resume(): Promise<void> {
+    this.runner.setPaused(false);
+    this.status.setPaused(false);
+    await this.store.setMeta("paused", false);
+    // Nudge the status — the runner may not emit anything immediately.
+    this.status.recompute();
+  }
+
+  isPaused(): boolean {
+    return this.runner.isPaused();
+  }
+
+  /**
+   * Bump the rebuild epoch and re-enqueue every known note. Resumable: the
+   * epoch is persisted before any work is enqueued, so an interrupted rebuild
+   * picks up where it left off on next start (any path with `lastEpoch <
+   * rebuildEpoch` is still stale).
+   */
+  async rebuild(): Promise<{ enqueued: number }> {
+    const now = Date.now();
+    await this.store.setMeta("rebuildEpoch", now);
+    await this.store.setMeta("lastRebuiltAt", now);
+
+    // Re-running reconcile is the simplest way to enqueue everything: it
+    // walks the vault and pushes an `index` job for every indexable path.
+    // The pipeline's hash gate decides whether each note actually re-chunks.
+    const result = await this.reconciler.reconcile();
+    this.status.recompute();
+    return { enqueued: result.enqueuedIndex };
+  }
+
+  async reconcileNow(): Promise<{ enqueued: number; deleted: number }> {
+    const result = await this.reconciler.reconcile();
+    await this.store.setMeta("lastReconciledAt", Date.now());
+    this.status.recompute();
+    return { enqueued: result.enqueuedIndex, deleted: result.enqueuedDelete };
+  }
+
+  /** Drain helper for tests. */
+  queueSize(): number {
+    return this.queue.size();
+  }
+}

--- a/src/services/runner-controls.ts
+++ b/src/services/runner-controls.ts
@@ -71,13 +71,6 @@ export class RunnerControls {
     return { enqueued: result.enqueuedIndex };
   }
 
-  async reconcileNow(): Promise<{ enqueued: number; deleted: number }> {
-    const result = await this.reconciler.reconcile();
-    await this.store.setMeta("lastReconciledAt", Date.now());
-    this.status.recompute();
-    return { enqueued: result.enqueuedIndex, deleted: result.enqueuedDelete };
-  }
-
   /** Drain helper for tests. */
   queueSize(): number {
     return this.queue.size();

--- a/src/services/runner-controls.ts
+++ b/src/services/runner-controls.ts
@@ -2,6 +2,19 @@ import type { IngestionStore, JobQueue, Reconciler } from "../contracts";
 import type { IngestionRunner } from "./ingestion-runner";
 import type { RunnerStatus } from "./runner-status";
 
+export interface RunnerControlsOptions {
+  /**
+   * Called after a successful rebuild has bumped `meta.rebuildEpoch`. The
+   * pipeline's epoch source (a closure cell in `createServices`) reads
+   * fresh meta and updates itself here. Construction-time injection beats
+   * monkey-patching the method after the fact, which broke for prototype
+   * dispatch and surprised readers.
+   */
+  onRebuild?: () => void | Promise<void>;
+}
+
+const NOOP = (): void => undefined;
+
 /**
  * User-facing indexer controls (#15c, #15d). Coordinates the runner, the
  * status observable, and persisted meta state. Single instance owns the
@@ -20,13 +33,18 @@ import type { RunnerStatus } from "./runner-status";
  * picks them up.
  */
 export class RunnerControls {
+  private readonly onRebuild: () => void | Promise<void>;
+
   constructor(
     private readonly runner: IngestionRunner,
     private readonly status: RunnerStatus,
     private readonly store: IngestionStore,
     private readonly reconciler: Reconciler,
     private readonly queue: JobQueue,
-  ) {}
+    options: RunnerControlsOptions = {},
+  ) {
+    this.onRebuild = options.onRebuild ?? NOOP;
+  }
 
   async applyPersistedState(): Promise<void> {
     const paused = (await this.store.getMeta("paused")) ?? false;
@@ -62,6 +80,10 @@ export class RunnerControls {
     const now = Date.now();
     await this.store.setMeta("rebuildEpoch", now);
     await this.store.setMeta("lastRebuiltAt", now);
+    // Notify any consumer that caches the epoch (e.g. the pipeline closure
+    // in createServices) BEFORE we kick off reconcile, so the first ingest
+    // sees the new epoch and re-stamps stale notes.
+    await this.onRebuild();
 
     // Re-running reconcile is the simplest way to enqueue everything: it
     // walks the vault and pushes an `index` job for every indexable path.

--- a/src/services/runner-status.test.ts
+++ b/src/services/runner-status.test.ts
@@ -3,12 +3,19 @@ import { InMemoryJobQueue } from "./in-memory-job-queue";
 import { RunnerStatus } from "./runner-status";
 import type { RunnerEvent } from "./ingestion-runner";
 
-function fakeRunner() {
+function fakeRunner(queue: { size(): number }) {
   const listeners = new Set<(e: RunnerEvent) => void>();
+  let inFlight = 0;
   return {
     onResult(cb: (e: RunnerEvent) => void) {
       listeners.add(cb);
       return () => listeners.delete(cb);
+    },
+    workSize() {
+      return queue.size() + inFlight;
+    },
+    setInFlight(n: number) {
+      inFlight = n;
     },
     emit(e: RunnerEvent) {
       for (const l of listeners) l(e);
@@ -19,7 +26,7 @@ function fakeRunner() {
 describe("RunnerStatus", () => {
   it("starts idle with no batch", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     const status = new RunnerStatus(queue, runner);
     status.start();
     expect(status.get()).toEqual({ phase: "idle", pending: 0, total: undefined, completed: 0 });
@@ -27,7 +34,7 @@ describe("RunnerStatus", () => {
 
   it("transitions to running on arrival and tracks total via recompute", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     const status = new RunnerStatus(queue, runner);
     status.start();
 
@@ -40,23 +47,34 @@ describe("RunnerStatus", () => {
     expect(status.get()).toMatchObject({ phase: "running", pending: 2, total: 2, completed: 0 });
   });
 
-  it("decrements pending and bumps completed as runner emits events", () => {
+  it("keeps pending accurate while runner has drained jobs in flight", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     const status = new RunnerStatus(queue, runner);
     status.start();
 
     queue.enqueue({ kind: "index", path: "a.md" });
     queue.enqueue({ kind: "index", path: "b.md" });
-    queue.drain(); // simulate runner claiming the batch
-    runner.emit({ kind: "deleted", path: "a.md" });
+    status.recompute();
+    expect(status.get()).toMatchObject({ phase: "running", pending: 2, total: 2 });
 
-    expect(status.get()).toMatchObject({ phase: "idle", pending: 0, total: undefined, completed: 0 });
+    // Simulate runner draining both jobs into its in-flight set.
+    queue.drain();
+    runner.setInFlight(2);
+    runner.emit({ kind: "deleted", path: "a.md" });
+    // After one event fires the runner has completed one job; in-flight drops.
+    runner.setInFlight(1);
+    runner.emit({ kind: "deleted", path: "a.md" });
+    expect(status.get()).toMatchObject({ phase: "running", pending: 1, total: 2, completed: 1 });
+
+    runner.setInFlight(0);
+    runner.emit({ kind: "deleted", path: "b.md" });
+    expect(status.get()).toMatchObject({ phase: "idle", pending: 0, total: undefined });
   });
 
   it("resets batch when queue fully drains, then starts a new one on next arrival", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     const status = new RunnerStatus(queue, runner);
     status.start();
 
@@ -71,7 +89,7 @@ describe("RunnerStatus", () => {
 
   it("notifies subscribers with current snapshot on subscribe and on change", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     const status = new RunnerStatus(queue, runner);
     status.start();
 
@@ -85,7 +103,7 @@ describe("RunnerStatus", () => {
 
   it("setPaused flips phase but keeps pending/total intact", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     const status = new RunnerStatus(queue, runner);
     status.start();
 
@@ -99,7 +117,7 @@ describe("RunnerStatus", () => {
 
   it("setPaused is idempotent", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     const status = new RunnerStatus(queue, runner);
     status.start();
     const cb = vi.fn();
@@ -112,7 +130,7 @@ describe("RunnerStatus", () => {
 
   it("seeds total from preexisting queue size on start (cold reconcile)", () => {
     const queue = new InMemoryJobQueue();
-    const runner = fakeRunner();
+    const runner = fakeRunner(queue);
     queue.enqueue({ kind: "index", path: "a.md" });
     queue.enqueue({ kind: "index", path: "b.md" });
 
@@ -120,5 +138,56 @@ describe("RunnerStatus", () => {
     status.start();
 
     expect(status.get()).toMatchObject({ phase: "running", pending: 2, total: 2 });
+  });
+});
+
+// Integration: real IngestionRunner draining a real queue. Regression for
+// "pill drops to idle after first arrival because runner drained at once".
+import { IngestionRunner } from "./ingestion-runner";
+import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
+import type { IngestDecision, IngestionPipeline } from "../contracts";
+
+class SlowPipeline implements IngestionPipeline {
+  ran: string[] = [];
+  resolve!: () => void;
+  gate = new Promise<void>((r) => { this.resolve = r; });
+  async ingest(path: string): Promise<IngestDecision> {
+    this.ran.push(path);
+    // Block until the test releases us. Lets us observe in-flight state.
+    await this.gate;
+    return {
+      kind: "skip",
+      state: { path, contentHash: "h", bodyHash: "h", mtime: 0, frontmatter: null },
+    };
+  }
+}
+
+describe("RunnerStatus + real IngestionRunner", () => {
+  it("reports pending = total while runner is mid-batch (not zero)", async () => {
+    const queue = new InMemoryJobQueue();
+    const store = new InMemoryIngestionStore();
+    const pipeline = new SlowPipeline();
+    const runner = new IngestionRunner(queue, pipeline, store);
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+    runner.start();
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    queue.enqueue({ kind: "index", path: "b.md" });
+    queue.enqueue({ kind: "index", path: "c.md" });
+    status.recompute();
+
+    // Yield once so the runner's microtask kicks and drain() runs. Pending
+    // must NOT collapse to zero here — that was the bug.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(status.get().pending).toBeGreaterThan(0);
+    expect(status.get().total).toBe(3);
+
+    // Release the pipeline gate so all jobs finish. Stop the runner.
+    pipeline.resolve();
+    await runner.drainNow();
+    expect(status.get()).toMatchObject({ phase: "idle", pending: 0 });
   });
 });

--- a/src/services/runner-status.test.ts
+++ b/src/services/runner-status.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { RunnerStatus } from "./runner-status";
+import type { RunnerEvent } from "./ingestion-runner";
+
+function fakeRunner() {
+  const listeners = new Set<(e: RunnerEvent) => void>();
+  return {
+    onResult(cb: (e: RunnerEvent) => void) {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    emit(e: RunnerEvent) {
+      for (const l of listeners) l(e);
+    },
+  };
+}
+
+describe("RunnerStatus", () => {
+  it("starts idle with no batch", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+    expect(status.get()).toEqual({ phase: "idle", pending: 0, total: undefined, completed: 0 });
+  });
+
+  it("transitions to running on arrival and tracks total via recompute", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    queue.enqueue({ kind: "index", path: "b.md" });
+    // Arrival only fires from-empty; mid-batch enqueues need an explicit
+    // recompute. The bridge does this in production.
+    status.recompute();
+
+    expect(status.get()).toMatchObject({ phase: "running", pending: 2, total: 2, completed: 0 });
+  });
+
+  it("decrements pending and bumps completed as runner emits events", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    queue.enqueue({ kind: "index", path: "b.md" });
+    queue.drain(); // simulate runner claiming the batch
+    runner.emit({ kind: "deleted", path: "a.md" });
+
+    expect(status.get()).toMatchObject({ phase: "idle", pending: 0, total: undefined, completed: 0 });
+  });
+
+  it("resets batch when queue fully drains, then starts a new one on next arrival", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    queue.drain();
+    runner.emit({ kind: "deleted", path: "a.md" });
+    expect(status.get()).toMatchObject({ phase: "idle", total: undefined });
+
+    queue.enqueue({ kind: "index", path: "x.md" });
+    expect(status.get()).toMatchObject({ phase: "running", pending: 1, total: 1 });
+  });
+
+  it("notifies subscribers with current snapshot on subscribe and on change", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+
+    const cb = vi.fn();
+    status.subscribe(cb);
+    expect(cb).toHaveBeenCalledTimes(1); // initial snapshot
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    expect(cb).toHaveBeenLastCalledWith(expect.objectContaining({ phase: "running", pending: 1 }));
+  });
+
+  it("setPaused flips phase but keeps pending/total intact", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+
+    queue.enqueue({ kind: "index", path: "a.md" });
+    status.setPaused(true);
+    expect(status.get()).toMatchObject({ phase: "paused", pending: 1, total: 1 });
+
+    status.setPaused(false);
+    expect(status.get()).toMatchObject({ phase: "running", pending: 1 });
+  });
+
+  it("setPaused is idempotent", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+    const cb = vi.fn();
+    status.subscribe(cb);
+    cb.mockClear();
+
+    status.setPaused(false); // already not paused
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("seeds total from preexisting queue size on start (cold reconcile)", () => {
+    const queue = new InMemoryJobQueue();
+    const runner = fakeRunner();
+    queue.enqueue({ kind: "index", path: "a.md" });
+    queue.enqueue({ kind: "index", path: "b.md" });
+
+    const status = new RunnerStatus(queue, runner);
+    status.start();
+
+    expect(status.get()).toMatchObject({ phase: "running", pending: 2, total: 2 });
+  });
+});

--- a/src/services/runner-status.ts
+++ b/src/services/runner-status.ts
@@ -1,6 +1,15 @@
 import type { JobQueue } from "../contracts";
 import type { IngestionRunner } from "./ingestion-runner";
 
+/**
+ * Subset of IngestionRunner that RunnerStatus actually depends on. Tests
+ * pass a plain stub matching this shape; production passes the runner.
+ */
+export interface RunnerStatusSource {
+  onResult(cb: (e: unknown) => void): () => void;
+  workSize(): number;
+}
+
 export type IndexerPhase = "idle" | "running" | "paused";
 
 export interface RunnerStatusSnapshot {
@@ -47,7 +56,7 @@ export class RunnerStatus {
 
   constructor(
     private readonly queue: JobQueue,
-    private readonly runner: Pick<IngestionRunner, "onResult">,
+    private readonly runner: Pick<IngestionRunner, "onResult" | "workSize">,
   ) {}
 
   start(): void {
@@ -74,7 +83,11 @@ export class RunnerStatus {
    * for mid-batch arrivals that `onArrival` would miss.
    */
   recompute(): void {
-    const pending = this.queue.size();
+    // Queue size + in-flight is the true pending count. Reading queue.size()
+    // alone would underreport during runner draining, since drain() empties
+    // the queue at the start of each batch even though jobs are still in
+    // flight inside the for-loop.
+    const pending = this.runner.workSize();
     if (pending === 0) {
       this.high = 0;
       this.publish({

--- a/src/services/runner-status.ts
+++ b/src/services/runner-status.ts
@@ -1,0 +1,127 @@
+import type { JobQueue } from "../contracts";
+import type { IngestionRunner } from "./ingestion-runner";
+
+export type IndexerPhase = "idle" | "running" | "paused";
+
+export interface RunnerStatusSnapshot {
+  phase: IndexerPhase;
+  pending: number;
+  /**
+   * Total jobs observed in the current cold-start batch (high-water mark).
+   * Resets when the queue fully drains. `undefined` means the queue is idle.
+   */
+  total: number | undefined;
+  /** Jobs completed in the current batch (`total - pending`). */
+  completed: number;
+}
+
+const INITIAL: RunnerStatusSnapshot = {
+  phase: "idle",
+  pending: 0,
+  total: undefined,
+  completed: 0,
+};
+
+/**
+ * Aggregates indexing progress for the chat-header pill (#15b) and settings
+ * panel (#15f).
+ *
+ * Strategy: `queue.size()` is the source of truth for pending. We track a
+ * batch high-water mark (`high`) that resets to 0 whenever pending hits 0.
+ * Recomputes are triggered on:
+ *   - queue arrival (from-empty)
+ *   - runner result event (per job processed)
+ *   - explicit `recompute()` calls (used by the bridge / ingest writer when
+ *     they enqueue mid-batch — the queue's `onArrival` only fires from empty,
+ *     so callers must poke us when they grow a non-empty queue)
+ *
+ * Pause is purely a display flag; the controls service (#15c) flips it.
+ */
+export class RunnerStatus {
+  private snapshot: RunnerStatusSnapshot = { ...INITIAL };
+  private high = 0;
+  private paused = false;
+  private listeners = new Set<(s: RunnerStatusSnapshot) => void>();
+  private offRunner: (() => void) | null = null;
+  private offQueue: (() => void) | null = null;
+
+  constructor(
+    private readonly queue: JobQueue,
+    private readonly runner: Pick<IngestionRunner, "onResult">,
+  ) {}
+
+  start(): void {
+    if (this.offRunner) return;
+    this.offQueue = this.queue.onArrival(() => this.recompute());
+    this.offRunner = this.runner.onResult(() => this.recompute());
+    this.recompute();
+  }
+
+  stop(): void {
+    this.offRunner?.();
+    this.offRunner = null;
+    this.offQueue?.();
+    this.offQueue = null;
+  }
+
+  get(): RunnerStatusSnapshot {
+    return this.snapshot;
+  }
+
+  /**
+   * Recompute the snapshot from current queue size. Idempotent — safe to call
+   * after any enqueue / dequeue. Bridge and orchestrators call this directly
+   * for mid-batch arrivals that `onArrival` would miss.
+   */
+  recompute(): void {
+    const pending = this.queue.size();
+    if (pending === 0) {
+      this.high = 0;
+      this.publish({
+        phase: this.paused ? "paused" : "idle",
+        pending: 0,
+        total: undefined,
+        completed: 0,
+      });
+      return;
+    }
+    if (pending > this.high) this.high = pending;
+    this.publish({
+      phase: this.paused ? "paused" : "running",
+      pending,
+      total: this.high,
+      completed: this.high - pending,
+    });
+  }
+
+  setPaused(paused: boolean): void {
+    if (this.paused === paused) return;
+    this.paused = paused;
+    this.recompute();
+  }
+
+  subscribe(cb: (s: RunnerStatusSnapshot) => void): () => void {
+    this.listeners.add(cb);
+    cb(this.snapshot);
+    return () => this.listeners.delete(cb);
+  }
+
+  private publish(next: RunnerStatusSnapshot): void {
+    if (
+      this.snapshot.phase === next.phase &&
+      this.snapshot.pending === next.pending &&
+      this.snapshot.total === next.total &&
+      this.snapshot.completed === next.completed
+    ) {
+      return;
+    }
+    this.snapshot = next;
+    for (const l of this.listeners) {
+      try {
+        l(next);
+      } catch {
+        // listener errors must not break the loop
+      }
+    }
+  }
+}

--- a/src/services/scheduled-reconciler.test.ts
+++ b/src/services/scheduled-reconciler.test.ts
@@ -26,7 +26,7 @@ function setup(now: number, files: Record<string, string> = {}) {
   const store = new InMemoryIngestionStore();
   const queue = new InMemoryJobQueue();
   const reconciler = new VaultReconciler(vault, store, queue, new DefaultPathFilter());
-  const setTimer = vi.fn(() => "TIMER" as unknown);
+  const setTimer = vi.fn((_cb: () => void, _ms: number): unknown => "TIMER");
   const clearTimer = vi.fn();
   const sched = new ScheduledReconciler({
     vault,
@@ -87,6 +87,51 @@ describe("ScheduledReconciler", () => {
 
     // vault unused-warn silencer
     expect(vault).toBeDefined();
+  });
+
+  it("when the timer fires, it runs reconciliation and reschedules", async () => {
+    const now = 100 * WEEK_MS;
+    const { store, sched, setTimer } = setup(now, { "a.md": "alpha" });
+    await store.setMeta("lastReconciledAt", now - 1000);
+
+    await sched.start();
+    expect(setTimer).toHaveBeenCalledTimes(1);
+    // Pull the scheduled callback and invoke it manually.
+    const cb = setTimer.mock.calls[0]![0]!;
+    cb();
+    // Allow the runNow + setMeta chain to settle.
+    await new Promise((r) => setTimeout(r, 5));
+    // After firing, lastReconciledAt is the current `now`, and a new timer
+    // is scheduled for the full week.
+    expect(await store.getMeta("lastReconciledAt")).toBe(now);
+    expect(setTimer).toHaveBeenCalledTimes(2);
+    expect(setTimer.mock.calls[1]![1]).toBe(WEEK_MS);
+  });
+
+  it("skips rehash when vault mtime matches stored mtime", async () => {
+    const now = 100 * WEEK_MS;
+    const vault = new MockVaultService({ "a.md": "alpha-clean" });
+    vault.setMtime("a.md", 5000);
+    const store = new InMemoryIngestionStore();
+    const queue = new InMemoryJobQueue();
+    const reconciler = new VaultReconciler(vault, store, queue, new DefaultPathFilter());
+    const sched = new ScheduledReconciler({
+      vault,
+      store,
+      reconciler,
+      now: () => now,
+      setTimer: () => "TIMER" as unknown,
+      clearTimer: () => {},
+    });
+    // Seed prior with a hash that DOESN'T match current bytes — but matching
+    // mtime should make us trust the stored hash and skip the rehash.
+    await store.upsert(
+      { path: "a.md", contentHash: "stale", bodyHash: "stale", mtime: 5000, frontmatter: null },
+      [],
+    );
+
+    const report = await sched.runNow();
+    expect(report.hashChanged).toEqual([]);
   });
 
   it("stop() clears the timer", async () => {

--- a/src/services/scheduled-reconciler.test.ts
+++ b/src/services/scheduled-reconciler.test.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { DefaultPathFilter } from "./path-filter";
+import { VaultReconciler } from "./vault-reconciler";
+import { ScheduledReconciler } from "./scheduled-reconciler";
+import type { NoteState } from "../contracts";
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+function makeNoteState(path: string, content: string): NoteState {
+  const hash = createHash("sha256").update(content, "utf8").digest("hex");
+  return {
+    path,
+    contentHash: hash,
+    bodyHash: hash,
+    mtime: 0,
+    frontmatter: null,
+  };
+}
+
+function setup(now: number, files: Record<string, string> = {}) {
+  const vault = new MockVaultService(files);
+  const store = new InMemoryIngestionStore();
+  const queue = new InMemoryJobQueue();
+  const reconciler = new VaultReconciler(vault, store, queue, new DefaultPathFilter());
+  const setTimer = vi.fn(() => "TIMER" as unknown);
+  const clearTimer = vi.fn();
+  const sched = new ScheduledReconciler({
+    vault,
+    store,
+    reconciler,
+    now: () => now,
+    setTimer,
+    clearTimer,
+  });
+  return { vault, store, queue, sched, setTimer, clearTimer };
+}
+
+describe("ScheduledReconciler", () => {
+  it("runs immediately when overdue and schedules next week", async () => {
+    const now = 100 * WEEK_MS;
+    const { store, sched, setTimer } = setup(now, { "a.md": "hello" });
+    await store.setMeta("lastReconciledAt", now - WEEK_MS - 1);
+
+    await sched.start();
+
+    expect(await store.getMeta("lastReconciledAt")).toBe(now);
+    expect(setTimer).toHaveBeenCalledWith(expect.any(Function), WEEK_MS);
+  });
+
+  it("schedules a delta when not yet due", async () => {
+    const now = 100 * WEEK_MS;
+    const { store, sched, setTimer } = setup(now);
+    await store.setMeta("lastReconciledAt", now - 1000);
+
+    await sched.start();
+
+    // Should not have run (lastReconciledAt unchanged).
+    expect(await store.getMeta("lastReconciledAt")).toBe(now - 1000);
+    expect(setTimer).toHaveBeenCalledWith(expect.any(Function), WEEK_MS - 1000);
+  });
+
+  it("produces a drift report with adds, removes, and hash changes", async () => {
+    const now = 100 * WEEK_MS;
+    const { vault, store, sched } = setup(now, {
+      "a.md": "alpha",
+      "b.md": "bravo-new",
+      "c.md": "charlie",
+    });
+    // Seed store: a.md known with same hash, b.md known with stale hash,
+    // d.md known but no longer in vault.
+    await store.upsert(makeNoteState("a.md", "alpha"), []);
+    await store.upsert(makeNoteState("b.md", "bravo-old"), []);
+    await store.upsert(makeNoteState("d.md", "delta"), []);
+
+    const report = await sched.runNow();
+
+    expect(report.added).toEqual(["c.md"]);
+    expect(report.removed).toEqual(["d.md"]);
+    expect(report.hashChanged).toEqual(["b.md"]);
+    expect(report.ranAt).toBe(now);
+
+    expect(await store.getMeta("lastDriftReport")).toEqual(report);
+
+    // vault unused-warn silencer
+    expect(vault).toBeDefined();
+  });
+
+  it("stop() clears the timer", async () => {
+    const now = 100 * WEEK_MS;
+    const { sched, clearTimer, store } = setup(now);
+    await store.setMeta("lastReconciledAt", now);
+    await sched.start();
+    sched.stop();
+    expect(clearTimer).toHaveBeenCalled();
+  });
+});

--- a/src/services/scheduled-reconciler.ts
+++ b/src/services/scheduled-reconciler.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import type {
+  DriftReport,
+  IngestionStore,
+  Reconciler,
+  VaultService,
+} from "../contracts";
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface ScheduledReconcilerDeps {
+  vault: VaultService;
+  store: IngestionStore;
+  reconciler: Reconciler;
+  /** Override for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Override for tests. Defaults to `setTimeout`. */
+  setTimer?: (cb: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+}
+
+/**
+ * Wraps the existing one-shot Reconciler in a weekly schedule (#15e).
+ *
+ * - On `start()`, reads `meta.lastReconciledAt`. If overdue (>7d), runs
+ *   immediately. Otherwise schedules a timer for the remaining delta.
+ * - `runNow()` is the user-triggered "Reconcile now" path. It walks the
+ *   vault, hashes every file, compares against `notes.contentHash`, and
+ *   produces a `DriftReport` with adds/removes/changes. The hash gate in
+ *   the pipeline already deduplicates the actual reprocessing; the report
+ *   is purely diagnostic.
+ *
+ * The drift report is informational — divergence does not auto-enqueue
+ * jobs (that would silently un-pause work). Surfacing the report to the
+ * user is the settings panel's job.
+ */
+export class ScheduledReconciler {
+  private timer: unknown = null;
+  private now: () => number;
+  private setTimer: (cb: () => void, ms: number) => unknown;
+  private clearTimer: (handle: unknown) => void;
+
+  constructor(private readonly deps: ScheduledReconcilerDeps) {
+    this.now = deps.now ?? (() => Date.now());
+    this.setTimer = deps.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimer =
+      deps.clearTimer ??
+      ((handle) => {
+        if (handle) clearTimeout(handle as ReturnType<typeof setTimeout>);
+      });
+  }
+
+  async start(): Promise<void> {
+    const last = (await this.deps.store.getMeta("lastReconciledAt")) ?? 0;
+    const elapsed = this.now() - last;
+    if (elapsed >= WEEK_MS) {
+      await this.runNow();
+      this.scheduleNext(WEEK_MS);
+    } else {
+      this.scheduleNext(WEEK_MS - elapsed);
+    }
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Run reconciliation now. Walks the vault, recomputes content hashes,
+   * compares to the store, writes a `DriftReport`, and triggers a regular
+   * `Reconciler.reconcile()` to enqueue catch-up jobs for genuine adds /
+   * removes (the hash gate handles changes).
+   */
+  async runNow(): Promise<DriftReport> {
+    const ranAt = this.now();
+    const files = await this.deps.vault.listMarkdownFiles();
+    const livePaths = new Set(files.map((f) => f.path));
+    const knownPaths = new Set(await this.deps.store.list());
+
+    const added: string[] = [];
+    const removed: string[] = [];
+    const hashChanged: string[] = [];
+
+    for (const path of livePaths) {
+      if (!knownPaths.has(path)) {
+        added.push(path);
+        continue;
+      }
+      const prior = await this.deps.store.get(path);
+      if (!prior) continue;
+      const raw = await this.deps.vault.read(path);
+      const hash = sha256(raw);
+      if (hash !== prior.contentHash) hashChanged.push(path);
+    }
+
+    for (const path of knownPaths) {
+      if (!livePaths.has(path)) removed.push(path);
+    }
+
+    const report: DriftReport = {
+      ranAt,
+      added: added.sort(),
+      removed: removed.sort(),
+      hashChanged: hashChanged.sort(),
+    };
+
+    await this.deps.store.setMeta("lastDriftReport", report);
+    await this.deps.store.setMeta("lastReconciledAt", ranAt);
+
+    // Re-run reconcile so additions/removals get enqueued. Hash-changed
+    // paths will be re-enqueued too, and the pipeline's hash gate decides
+    // whether to actually re-chunk.
+    await this.deps.reconciler.reconcile();
+
+    return report;
+  }
+
+  private scheduleNext(ms: number): void {
+    if (this.timer !== null) this.clearTimer(this.timer);
+    this.timer = this.setTimer(() => {
+      void this.runNow().then(() => this.scheduleNext(WEEK_MS));
+    }, ms);
+  }
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}

--- a/src/services/scheduled-reconciler.ts
+++ b/src/services/scheduled-reconciler.ts
@@ -91,6 +91,12 @@ export class ScheduledReconciler {
       }
       const prior = await this.deps.store.get(path);
       if (!prior) continue;
+      // Fast path: if mtime matches, skip the read+hash. On a 5k-vault this
+      // turns minutes of work into a no-op for clean drift checks. Falls
+      // through to the slow path when mtime differs OR is unavailable
+      // (mtime===0 in the mock means "not set").
+      const stat = await this.deps.vault.stat(path).catch(() => null);
+      if (stat && stat.mtime > 0 && stat.mtime === prior.mtime) continue;
       const raw = await this.deps.vault.read(path);
       const hash = sha256(raw);
       if (hash !== prior.contentHash) hashChanged.push(path);

--- a/src/services/util.ts
+++ b/src/services/util.ts
@@ -1,0 +1,4 @@
+/** Deduplicate while preserving first-seen order. */
+export function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,8 +6,17 @@ export interface GemmeraSettings {
    * (or in code for tests). Intended for developers and CI, not end users.
    */
   llmBackend: "ollama" | "mock";
+  /** Folder for new ingest notes. Default `Inbox/`. */
+  inboxFolder: string;
+  /** Cosine score above which a similar note is treated as a near-duplicate. */
+  dedupThreshold: number;
+  /** When true, every save passes through the preview modal. */
+  alwaysPreview: boolean;
 }
 
 export const DEFAULT_SETTINGS: GemmeraSettings = {
   llmBackend: "ollama",
+  inboxFolder: "Inbox/",
+  dedupThreshold: 0.85,
+  alwaysPreview: true,
 };

--- a/src/ui/indexing-pill.ts
+++ b/src/ui/indexing-pill.ts
@@ -1,0 +1,60 @@
+import type { RunnerStatus, RunnerStatusSnapshot } from "../services/runner-status";
+import { formatPill } from "./pill-format";
+
+/**
+ * Chat-header pill showing indexing progress (#15b). Subscribes to
+ * RunnerStatus and re-renders on every snapshot. Auto-hides on idle and
+ * for tiny vaults to avoid flicker.
+ *
+ * The pill is mounted by the chat view (`view.ts`) and unmounted on close.
+ */
+export class IndexingPill {
+  private el: HTMLElement | null = null;
+  private off: (() => void) | null = null;
+  private onPauseToggle: (() => void) | null = null;
+
+  constructor(private readonly status: RunnerStatus) {}
+
+  mount(parent: HTMLElement, onPauseToggle?: () => void): void {
+    if (this.el) return;
+    this.onPauseToggle = onPauseToggle ?? null;
+    const pill = parent.createEl("div", { cls: "gemmera-indexing-pill" });
+    pill.style.display = "none";
+    this.el = pill;
+    this.off = this.status.subscribe((snap) => this.render(snap));
+  }
+
+  unmount(): void {
+    this.off?.();
+    this.off = null;
+    this.el?.remove();
+    this.el = null;
+  }
+
+  private render(snap: RunnerStatusSnapshot): void {
+    if (!this.el) return;
+    const view = formatPill(snap);
+    if (!view.visible) {
+      this.el.style.display = "none";
+      return;
+    }
+    this.el.style.display = "";
+    this.el.empty();
+    this.el.removeClass("gemmera-indexing-pill--running");
+    this.el.removeClass("gemmera-indexing-pill--paused");
+    this.el.addClass(`gemmera-indexing-pill--${view.variant}`);
+
+    this.el.createEl("span", {
+      cls: "gemmera-indexing-pill__text",
+      text: view.text,
+    });
+
+    if (this.onPauseToggle) {
+      const btn = this.el.createEl("button", {
+        cls: "gemmera-indexing-pill__btn",
+        text: snap.phase === "paused" ? "Resume" : "Pause",
+      });
+      btn.addEventListener("click", () => this.onPauseToggle?.());
+    }
+  }
+}

--- a/src/ui/ingest-preview-modal.ts
+++ b/src/ui/ingest-preview-modal.ts
@@ -1,0 +1,104 @@
+import { Modal, type App } from "obsidian";
+import type {
+  IngestPreview,
+  PreviewDecision,
+} from "../services/ingest-orchestrator";
+
+/**
+ * Preview gate for the ingest tool loop (#13). Three flavors share one
+ * modal subclass:
+ *   - `save`  : new note. Buttons: Save, Edit title/tags, Cancel.
+ *   - `append`: append-to-existing. Buttons: Append, Cancel.
+ *   - `dedup` : near-duplicate found. Buttons: Append, Save anyway, Cancel.
+ *
+ * The modal resolves a single Promise the orchestrator awaits. Resolving
+ * happens in the click handlers; closing without a click resolves to
+ * cancel so a stray Esc never strands the orchestrator.
+ */
+export function openIngestPreview(
+  app: App,
+  preview: IngestPreview,
+): Promise<PreviewDecision> {
+  return new Promise((resolve) => {
+    const modal = new IngestPreviewModal(app, preview, (decision) => {
+      modal.close();
+      resolve(decision);
+    });
+    modal.open();
+  });
+}
+
+class IngestPreviewModal extends Modal {
+  private resolved = false;
+  constructor(
+    app: App,
+    private readonly preview: IngestPreview,
+    private readonly onDecide: (d: PreviewDecision) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this as unknown as { contentEl: HTMLElement };
+    contentEl.empty();
+
+    const title = this.preview.kind === "dedup"
+      ? "Near-duplicate found"
+      : this.preview.kind === "append"
+        ? "Append to existing note"
+        : "Save new note";
+    contentEl.createEl("h2", { text: title });
+
+    if (this.preview.kind === "dedup" && this.preview.strategy.kind === "dedup_ask") {
+      const sim = Math.round(this.preview.strategy.similarity * 100);
+      contentEl.createEl("p", {
+        text: `${this.preview.strategy.target} (${sim}% match). Append to it, save as a new note anyway, or cancel.`,
+      });
+    } else if (this.preview.kind === "append" && this.preview.strategy.kind === "append") {
+      contentEl.createEl("p", {
+        text: `Will append under today's heading in ${this.preview.strategy.target}.`,
+      });
+    } else {
+      const folder = "Inbox/";
+      contentEl.createEl("p", {
+        text: `Will save as a new note in ${folder} with title: ${this.preview.spec.title}`,
+      });
+    }
+
+    contentEl.createEl("h3", { text: "Title" });
+    contentEl.createEl("p", { text: this.preview.spec.title });
+    if (this.preview.spec.tags.length > 0) {
+      contentEl.createEl("h3", { text: "Tags" });
+      contentEl.createEl("p", { text: this.preview.spec.tags.join(", ") });
+    }
+    contentEl.createEl("h3", { text: "Body" });
+    const bodyPre = contentEl.createEl("pre");
+    bodyPre.setText(this.preview.spec.body_markdown.slice(0, 1200));
+
+    const actions = contentEl.createEl("div", { cls: "gemmera-ingest-actions" });
+    if (this.preview.kind === "dedup") {
+      this.addBtn(actions, "Append", () => this.onDecide({ action: "dedup_choice", choice: "append" }));
+      this.addBtn(actions, "Save anyway", () => this.onDecide({ action: "dedup_choice", choice: "save_anyway" }));
+    } else if (this.preview.kind === "append") {
+      this.addBtn(actions, "Append", () => this.onDecide({ action: "confirm" }));
+    } else {
+      this.addBtn(actions, "Save", () => this.onDecide({ action: "confirm" }));
+    }
+    this.addBtn(actions, "Cancel", () => this.onDecide({ action: "cancel" }));
+  }
+
+  onClose(): void {
+    if (!this.resolved) {
+      this.resolved = true;
+      this.onDecide({ action: "cancel" });
+    }
+  }
+
+  private addBtn(parent: HTMLElement, text: string, cb: () => void): void {
+    const btn = parent.createEl("button", { text, cls: "gemmera-ingest-btn" });
+    btn.addEventListener("click", () => {
+      this.resolved = true;
+      cb();
+    });
+  }
+}

--- a/src/ui/pill-format.test.ts
+++ b/src/ui/pill-format.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatPill } from "./pill-format";
+
+describe("formatPill", () => {
+  it("hides when idle", () => {
+    const v = formatPill({ phase: "idle", pending: 0, total: undefined, completed: 0 });
+    expect(v.visible).toBe(false);
+  });
+
+  it("hides for tiny vaults below threshold", () => {
+    const v = formatPill(
+      { phase: "running", pending: 5, total: 10, completed: 5 },
+      50,
+    );
+    expect(v.visible).toBe(false);
+  });
+
+  it("shows X of Y when running on a non-tiny batch", () => {
+    const v = formatPill(
+      { phase: "running", pending: 200, total: 1000, completed: 800 },
+      50,
+    );
+    expect(v.visible).toBe(true);
+    expect(v.text).toBe("Indexing 800 of 1000");
+    expect(v.variant).toBe("running");
+  });
+
+  it("shows paused state regardless of tiny-vault rule", () => {
+    const v = formatPill(
+      { phase: "paused", pending: 5, total: 10, completed: 5 },
+      50,
+    );
+    expect(v.visible).toBe(true);
+    expect(v.text).toContain("paused");
+    expect(v.variant).toBe("paused");
+  });
+
+  it("shows generic paused text when total is unknown", () => {
+    const v = formatPill({
+      phase: "paused",
+      pending: 0,
+      total: undefined,
+      completed: 0,
+    });
+    expect(v.text).toBe("Indexing paused");
+  });
+});

--- a/src/ui/pill-format.ts
+++ b/src/ui/pill-format.ts
@@ -1,0 +1,50 @@
+import type { RunnerStatusSnapshot } from "../services/runner-status";
+
+export interface PillView {
+  /** Text to render. Empty when the pill should be hidden. */
+  text: string;
+  /** Whether the pill should be visible. */
+  visible: boolean;
+  /** Suggested CSS modifier suffix. */
+  variant: "running" | "paused" | "hidden";
+}
+
+/**
+ * Pure formatter for the indexing pill (#15b). Takes a status snapshot and a
+ * "tiny vault" threshold; returns whether to render and what to display.
+ *
+ * Tiny vaults (total < tinyVaultThreshold) hide the pill entirely — cold
+ * start finishes faster than the eye can register, and a flicker is worse
+ * than no signal.
+ */
+export function formatPill(
+  snapshot: RunnerStatusSnapshot,
+  tinyVaultThreshold = 50,
+): PillView {
+  if (snapshot.phase === "paused") {
+    const total = snapshot.total ?? 0;
+    const completed = snapshot.completed;
+    return {
+      text:
+        total > 0
+          ? `Indexing paused (${completed} / ${total})`
+          : "Indexing paused",
+      visible: true,
+      variant: "paused",
+    };
+  }
+
+  if (snapshot.phase === "idle" || snapshot.total === undefined) {
+    return { text: "", visible: false, variant: "hidden" };
+  }
+
+  if (snapshot.total < tinyVaultThreshold) {
+    return { text: "", visible: false, variant: "hidden" };
+  }
+
+  return {
+    text: `Indexing ${snapshot.completed} of ${snapshot.total}`,
+    visible: true,
+    variant: "running",
+  };
+}

--- a/src/ui/pill-format.ts
+++ b/src/ui/pill-format.ts
@@ -1,5 +1,11 @@
 import type { RunnerStatusSnapshot } from "../services/runner-status";
 
+/**
+ * Vaults below this size hide the pill entirely. Cold start finishes faster
+ * than the eye can register, and a flicker is worse than no signal.
+ */
+export const TINY_VAULT_THRESHOLD = 50;
+
 export interface PillView {
   /** Text to render. Empty when the pill should be hidden. */
   text: string;
@@ -19,7 +25,7 @@ export interface PillView {
  */
 export function formatPill(
   snapshot: RunnerStatusSnapshot,
-  tinyVaultThreshold = 50,
+  tinyVaultThreshold: number = TINY_VAULT_THRESHOLD,
 ): PillView {
   if (snapshot.phase === "paused") {
     const total = snapshot.total ?? 0;

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,0 +1,107 @@
+import { Notice, PluginSettingTab, Setting, type App, type Plugin } from "obsidian";
+import type { DriftReport, IngestionStore } from "../contracts";
+import type { RunnerControls } from "../services/runner-controls";
+import type { ScheduledReconciler } from "../services/scheduled-reconciler";
+
+/**
+ * Plugin settings UI (#15f). Exposes the indexer controls built in #15c–e:
+ * pause toggle, rebuild button (with confirm), reconcile button, last-run
+ * timestamps, and the most recent drift report.
+ *
+ * Re-renders on `display()` — Obsidian calls this when the user opens the
+ * settings tab, which is enough freshness for an ops surface.
+ */
+export class GemmeraSettingsTab extends PluginSettingTab {
+  constructor(
+    app: App,
+    plugin: Plugin,
+    private readonly controls: RunnerControls,
+    private readonly scheduled: ScheduledReconciler,
+    private readonly store: IngestionStore,
+  ) {
+    super(app, plugin);
+  }
+
+  async display(): Promise<void> {
+    const { containerEl } = this as unknown as { containerEl: HTMLElement };
+    containerEl.empty();
+    containerEl.createEl("h2", { text: "Gemmera — Indexer" });
+
+    const paused = this.controls.isPaused();
+    const lastReconciled = (await this.store.getMeta("lastReconciledAt")) ?? 0;
+    const lastRebuilt = (await this.store.getMeta("lastRebuiltAt")) ?? 0;
+    const drift = (await this.store.getMeta("lastDriftReport")) as
+      | DriftReport
+      | null;
+
+    new Setting(containerEl)
+      .setName("Pause indexer")
+      .setDesc(
+        "When paused, no notes are chunked, embedded, or indexed. Pause survives plugin reloads.",
+      )
+      .addToggle((toggle: { setValue: (v: boolean) => unknown; onChange: (cb: (v: boolean) => void) => unknown }) => {
+        toggle.setValue(paused);
+        toggle.onChange(async (value: boolean) => {
+          if (value) await this.controls.pause();
+          else await this.controls.resume();
+          new Notice(value ? "Gemmera: indexer paused" : "Gemmera: indexer resumed");
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Rebuild index")
+      .setDesc(
+        "Re-process every note. Idempotent and resumable — safe to interrupt. Disabled while paused.",
+      )
+      .addButton((btn: { setButtonText: (t: string) => unknown; setDisabled: (d: boolean) => unknown; onClick: (cb: () => void) => unknown }) => {
+        btn.setButtonText("Rebuild");
+        btn.setDisabled(paused);
+        btn.onClick(async () => {
+          const ok = window.confirm(
+            "Rebuild the index for every note? This is safe and resumable but may take a while.",
+          );
+          if (!ok) return;
+          const { enqueued } = await this.controls.rebuild();
+          new Notice(`Gemmera: rebuild queued ${enqueued} note(s)`);
+          await this.display();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Reconcile now")
+      .setDesc("Walk the vault, hash every file, and report drift against the index.")
+      .addButton((btn: { setButtonText: (t: string) => unknown; onClick: (cb: () => void) => unknown }) => {
+        btn.setButtonText("Reconcile");
+        btn.onClick(async () => {
+          const report = await this.scheduled.runNow();
+          new Notice(
+            `Gemmera: drift — ${report.added.length} added, ${report.removed.length} removed, ${report.hashChanged.length} changed`,
+          );
+          await this.display();
+        });
+      });
+
+    containerEl.createEl("h3", { text: "Status" });
+    const statusList = containerEl.createEl("ul");
+    statusList.createEl("li", {
+      text: `Last reconciled: ${formatTimestamp(lastReconciled)}`,
+    });
+    statusList.createEl("li", {
+      text: `Last rebuilt: ${formatTimestamp(lastRebuilt)}`,
+    });
+
+    if (drift) {
+      containerEl.createEl("h3", { text: "Last drift report" });
+      const driftList = containerEl.createEl("ul");
+      driftList.createEl("li", { text: `Ran at: ${formatTimestamp(drift.ranAt)}` });
+      driftList.createEl("li", { text: `Added: ${drift.added.length}` });
+      driftList.createEl("li", { text: `Removed: ${drift.removed.length}` });
+      driftList.createEl("li", { text: `Hash changed: ${drift.hashChanged.length}` });
+    }
+  }
+}
+
+function formatTimestamp(ts: number): string {
+  if (!ts) return "never";
+  return new Date(ts).toLocaleString();
+}

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -2,37 +2,68 @@ import { Notice, PluginSettingTab, Setting, type App, type Plugin } from "obsidi
 import type { DriftReport, IngestionStore } from "../contracts";
 import type { RunnerControls } from "../services/runner-controls";
 import type { ScheduledReconciler } from "../services/scheduled-reconciler";
+import type { GemmeraSettings } from "../settings";
+
+interface IndexerStateSnapshot {
+  paused: boolean;
+  lastReconciledAt: number;
+  lastRebuiltAt: number;
+  drift: DriftReport | null;
+}
+
+const EMPTY_SNAPSHOT: IndexerStateSnapshot = {
+  paused: false,
+  lastReconciledAt: 0,
+  lastRebuiltAt: 0,
+  drift: null,
+};
 
 /**
  * Plugin settings UI (#15f). Exposes the indexer controls built in #15c–e:
  * pause toggle, rebuild button (with confirm), reconcile button, last-run
- * timestamps, and the most recent drift report.
+ * timestamps, and the most recent drift report. Also exposes the ingest
+ * settings (inboxFolder, dedupThreshold, alwaysPreview).
  *
- * Re-renders on `display()` — Obsidian calls this when the user opens the
- * settings tab, which is enough freshness for an ops surface.
+ * Obsidian's `display()` is synchronous, so meta is loaded into a cached
+ * snapshot first. `refresh()` reloads then re-renders; the UI calls it
+ * after any action that mutates persisted state.
  */
 export class GemmeraSettingsTab extends PluginSettingTab {
+  private snapshot: IndexerStateSnapshot = EMPTY_SNAPSHOT;
+
   constructor(
     app: App,
     plugin: Plugin,
     private readonly controls: RunnerControls,
     private readonly scheduled: ScheduledReconciler,
     private readonly store: IngestionStore,
+    private readonly settings: GemmeraSettings,
+    private readonly saveSettings: () => Promise<void>,
   ) {
     super(app, plugin);
   }
 
-  async display(): Promise<void> {
+  async refresh(): Promise<void> {
+    this.snapshot = {
+      paused: this.controls.isPaused(),
+      lastReconciledAt: (await this.store.getMeta("lastReconciledAt")) ?? 0,
+      lastRebuiltAt: (await this.store.getMeta("lastRebuiltAt")) ?? 0,
+      drift: (await this.store.getMeta("lastDriftReport")) ?? null,
+    };
+    this.display();
+  }
+
+  display(): void {
     const { containerEl } = this as unknown as { containerEl: HTMLElement };
     containerEl.empty();
     containerEl.createEl("h2", { text: "Gemmera — Indexer" });
 
-    const paused = this.controls.isPaused();
-    const lastReconciled = (await this.store.getMeta("lastReconciledAt")) ?? 0;
-    const lastRebuilt = (await this.store.getMeta("lastRebuiltAt")) ?? 0;
-    const drift = (await this.store.getMeta("lastDriftReport")) as
-      | DriftReport
-      | null;
+    const { paused, lastReconciled, lastRebuilt, drift } = {
+      paused: this.snapshot.paused,
+      lastReconciled: this.snapshot.lastReconciledAt,
+      lastRebuilt: this.snapshot.lastRebuiltAt,
+      drift: this.snapshot.drift,
+    };
 
     new Setting(containerEl)
       .setName("Pause indexer")
@@ -45,6 +76,7 @@ export class GemmeraSettingsTab extends PluginSettingTab {
           if (value) await this.controls.pause();
           else await this.controls.resume();
           new Notice(value ? "Gemmera: indexer paused" : "Gemmera: indexer resumed");
+          await this.refresh();
         });
       });
 
@@ -63,7 +95,7 @@ export class GemmeraSettingsTab extends PluginSettingTab {
           if (!ok) return;
           const { enqueued } = await this.controls.rebuild();
           new Notice(`Gemmera: rebuild queued ${enqueued} note(s)`);
-          await this.display();
+          await this.refresh();
         });
       });
 
@@ -77,7 +109,7 @@ export class GemmeraSettingsTab extends PluginSettingTab {
           new Notice(
             `Gemmera: drift — ${report.added.length} added, ${report.removed.length} removed, ${report.hashChanged.length} changed`,
           );
-          await this.display();
+          await this.refresh();
         });
       });
 
@@ -98,6 +130,49 @@ export class GemmeraSettingsTab extends PluginSettingTab {
       driftList.createEl("li", { text: `Removed: ${drift.removed.length}` });
       driftList.createEl("li", { text: `Hash changed: ${drift.hashChanged.length}` });
     }
+
+    containerEl.createEl("h2", { text: "Gemmera — Capture" });
+
+    new Setting(containerEl)
+      .setName("Inbox folder")
+      .setDesc("Folder where new notes from the chat capture go. Trailing slash optional.")
+      .addText((text: { setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown; setPlaceholder?: (s: string) => unknown }) => {
+        text.setPlaceholder?.("Inbox/");
+        text.setValue(this.settings.inboxFolder);
+        text.onChange(async (value: string) => {
+          this.settings.inboxFolder = value || "Inbox/";
+          await this.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Dedup threshold")
+      .setDesc(
+        "Cosine score above which a similar note is treated as a near-duplicate (0–1). Default 0.85.",
+      )
+      .addText((text: { setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown; setPlaceholder?: (s: string) => unknown }) => {
+        text.setPlaceholder?.("0.85");
+        text.setValue(String(this.settings.dedupThreshold));
+        text.onChange(async (value: string) => {
+          const parsed = Number(value);
+          if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return;
+          this.settings.dedupThreshold = parsed;
+          await this.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Always preview before save")
+      .setDesc(
+        "When off, high-confidence creates skip the preview modal. Append and dedup-ask always preview.",
+      )
+      .addToggle((toggle: { setValue: (v: boolean) => unknown; onChange: (cb: (v: boolean) => void) => unknown }) => {
+        toggle.setValue(this.settings.alwaysPreview);
+        toggle.onChange(async (value: boolean) => {
+          this.settings.alwaysPreview = value;
+          await this.saveSettings();
+        });
+      });
   }
 }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,12 +1,15 @@
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, Notice, WorkspaceLeaf } from "obsidian";
 import type { ChatMessage, IndexSearchResult } from "./contracts";
 import type { IntentLabel, RecentTurn, RouteDecision } from "./contracts/classifier";
 import type { Services } from "./services";
 import { parseFileOps, handleFileOps } from "./fileops";
 import { classifyTurn } from "./services/classifier-orchestrator";
 import { toDisambiguationRow } from "./services/classifier-events";
+import { runIngest } from "./services/ingest-orchestrator";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
+import { openIngestPreview } from "./ui/ingest-preview-modal";
+import type { GemmeraSettings } from "./settings";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -23,7 +26,11 @@ export class GemmeraChatView extends ItemView {
   private recentTurns: RecentTurn[] = [];
   private pill: IndexingPill | null = null;
 
-  constructor(leaf: WorkspaceLeaf, private readonly services: Services) {
+  constructor(
+    leaf: WorkspaceLeaf,
+    private readonly services: Services,
+    private readonly settings: GemmeraSettings,
+  ) {
     super(leaf);
   }
 
@@ -144,8 +151,59 @@ export class GemmeraChatView extends ItemView {
       return;
     }
 
+    // ── Capture (#13) ─────────────────────────────────────────────────
+    const intent = forcedLabel ?? route?.label ?? "ask";
+    if (intent === "capture") {
+      await this.runCapture(text, turnId);
+      this.recentTurns = [...this.recentTurns.slice(-2), { text, intent: "capture" }];
+      this.setInputDisabled(false);
+      this.inputEl.focus();
+      return;
+    }
+
     // ── Chat ──────────────────────────────────────────────────────────
-    await this.runChat(text, forcedLabel ?? route?.label ?? "ask", turnId);
+    await this.runChat(text, intent, turnId);
+  }
+
+  private async runCapture(text: string, _turnId: string): Promise<void> {
+    this.appendMessage("user", text);
+    try {
+      const outcome = await runIngest(
+        { text },
+        {
+          llm: this.services.llm,
+          promptLoader: this.services.promptLoader,
+          retriever: this.services.retriever,
+          store: this.services.ingestionStore,
+          vault: this.services.vault,
+          writer: this.services.ingestWriter,
+          jobQueue: this.services.jobQueue,
+          preview: (preview) => openIngestPreview(this.app, preview),
+          inboxFolder: this.settings.inboxFolder,
+          dedupThreshold: this.settings.dedupThreshold,
+          alwaysPreview: this.settings.alwaysPreview,
+        },
+      );
+      this.services.runnerStatus.recompute();
+
+      if (outcome.kind === "saved") {
+        const verb = outcome.mode === "append" ? "Appended to" : "Saved to";
+        new Notice(`Gemmera: ${verb} ${outcome.path}`);
+        this.appendMessage("assistant", `${verb} **${outcome.path}**`);
+      } else if (outcome.kind === "cancelled") {
+        this.appendMessage("assistant", "Cancelled.");
+      } else if (outcome.kind === "skipped_existing") {
+        new Notice(`Gemmera: already saved as ${outcome.path}`);
+        this.appendMessage("assistant", `Already in vault: **${outcome.path}**`);
+      } else {
+        this.appendMessage("assistant", `Capture failed: ${outcome.reason}`);
+      }
+    } catch (err) {
+      this.appendMessage(
+        "assistant",
+        `Capture failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+    }
   }
 
   private async runChat(text: string, intent: IntentLabel, turnId: string): Promise<void> {

--- a/src/view.ts
+++ b/src/view.ts
@@ -165,7 +165,7 @@ export class GemmeraChatView extends ItemView {
     await this.runChat(text, intent, turnId);
   }
 
-  private async runCapture(text: string, _turnId: string): Promise<void> {
+  private async runCapture(text: string, turnId: string): Promise<void> {
     this.appendMessage("user", text);
     try {
       const outcome = await runIngest(
@@ -179,6 +179,8 @@ export class GemmeraChatView extends ItemView {
           writer: this.services.ingestWriter,
           jobQueue: this.services.jobQueue,
           preview: (preview) => openIngestPreview(this.app, preview),
+          eventLog: this.services.eventLog,
+          turnId,
           inboxFolder: this.settings.inboxFolder,
           dedupThreshold: this.settings.dedupThreshold,
           alwaysPreview: this.settings.alwaysPreview,
@@ -306,7 +308,15 @@ export class GemmeraChatView extends ItemView {
             cancelled: false,
           }),
         );
-        await this.runChat(resolution.text, chosenLabel, resolution.turnId);
+        if (chosenLabel === "capture") {
+          await this.runCapture(resolution.text, resolution.turnId);
+          this.recentTurns = [
+            ...this.recentTurns.slice(-2),
+            { text: resolution.text, intent: "capture" },
+          ];
+        } else {
+          await this.runChat(resolution.text, chosenLabel, resolution.turnId);
+        }
       }
     }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -6,6 +6,7 @@ import { parseFileOps, handleFileOps } from "./fileops";
 import { classifyTurn } from "./services/classifier-orchestrator";
 import { toDisambiguationRow } from "./services/classifier-events";
 import { DisambiguationChip } from "./disambiguation-chip";
+import { IndexingPill } from "./ui/indexing-pill";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -20,6 +21,7 @@ export class GemmeraChatView extends ItemView {
   private chip = new DisambiguationChip();
   private chipEl: HTMLElement | null = null;
   private recentTurns: RecentTurn[] = [];
+  private pill: IndexingPill | null = null;
 
   constructor(leaf: WorkspaceLeaf, private readonly services: Services) {
     super(leaf);
@@ -42,9 +44,19 @@ export class GemmeraChatView extends ItemView {
     container.empty();
     container.addClass("gemmera-view");
 
-    const statusEl = container.createEl("div", { cls: "gemmera-status" });
+    const headerEl = container.createEl("div", { cls: "gemmera-header" });
+    const statusEl = headerEl.createEl("div", { cls: "gemmera-status" });
     this.checkOllamaStatus(statusEl);
     this.services.llm.pickDefaultModel().then((m) => { this.model = m; }).catch(() => {});
+
+    this.pill = new IndexingPill(this.services.runnerStatus);
+    this.pill.mount(headerEl, async () => {
+      if (this.services.runnerControls.isPaused()) {
+        await this.services.runnerControls.resume();
+      } else {
+        await this.services.runnerControls.pause();
+      }
+    });
 
     this.messagesEl = container.createEl("div", { cls: "gemmera-messages" });
 
@@ -67,7 +79,8 @@ export class GemmeraChatView extends ItemView {
   }
 
   async onClose(): Promise<void> {
-    // cleanup if needed
+    this.pill?.unmount();
+    this.pill = null;
   }
 
   private async checkOllamaStatus(el: HTMLElement): Promise<void> {


### PR DESCRIPTION
Closes #15
Closes #13

## Summary

- **#15 — Ops:** indexer status observable, pause/resume controls (persisted), epoch-based rebuild, weekly drift reconciliation, chat-header pill, settings tab.
- **#13 — Ingest tool loop:** parser → search_similar → decide_strategy → preview → write → update_index, with the near-duplicate branch.
- Self-audit pass: fixed RunnerStatus drain race, exact-hash dedup key, chip "Save" routing, append target drift, event-log emission, plus optimizations.
- Review-feedback fixes from #112 review: replaced rebuild monkey-patch with a typed constructor hook, looser heading match, byte-vs-semantic dedup comment, explicit confirm-on-dedup_ask guard.

## #15 (commit 16efc84)
- RunnerStatus aggregates pending/total/paused via runner.workSize().
- RunnerControls: pause persists in store meta, rebuild bumps a global epoch.
- IngestionRunner.setPaused halts new claims; in-flight finishes.
- HashGatedIngestionPipeline reads the rebuild epoch and re-stamps stale notes.
- ScheduledReconciler produces a DriftReport, runs immediately if overdue.
- IndexingPill widget + GemmeraSettingsTab (pause, rebuild w/ confirm, reconcile-now, drift summary).

## #13 (commit 60a5949)
- IngestWriter: atomic writeNew (cowork frontmatter + dated filename), appendUnderDatedHeading with mtime drift detection.
- parseContent: constrained-JSON LLM call to NoteSpec.
- decideStrategy: exact-hash dedup → threshold dedup_ask → LLM fallback → low-score short-circuit.
- runIngest: UI-agnostic orchestrator; emits one event-log row per phase.
- IngestPreviewModal (save/append/dedup); chat routes capture turns through it including from the disambiguation chip.
- Settings: inboxFolder, dedupThreshold, alwaysPreviewBeforeSave.

## Self-audit fixes (commits 2709e20, 5f6d09c)
- RunnerStatus pending count was wrong during runner draining — fixed via workSize() + decrement before emit.
- Exact-hash dedup compared against chunk contentHash (includes prepended context); switched to bodyHash via new findByBodyHash.
- Chip "Save" routed through runChat — now routes to runCapture.
- Orchestrator emits one event-log entry per phase (issue #13 acceptance).
- applyPersistedState() runs before any service starts.
- Strategy skips LLM when top score < 0.3.
- Drift report skips rehash when vault mtime matches stored mtime (new VaultService.stat()).
- Cleanup: append drift detection (expectedMtime), shared unique() util, exported TINY_VAULT_THRESHOLD, EmptyRetriever warns once.

## Review fixes (commit abfa828)
- RunnerControls: replaced post-construction monkey-patch with an `onRebuild` constructor hook.
- ingest-writer: heading detection no longer requires a trailing newline; added regression test.
- ingest-strategy: comment clarifying findByBodyHash is a byte match, not semantic.
- runIngest: explicit guard for `confirm` on a dedup_ask preview, with test.

## Test plan
- [x] npx vitest run — 491 passing
- [x] npx tsc --noEmit — clean
- [x] npm run build — clean
- [ ] Smoke test in demo-vault (manual, requires desktop Obsidian): cold-start pill, pause persistence, end-to-end capture, rebuild
- [ ] Coordinate with #111 (retrieval stack) — Services.retriever (currently EmptyRetriever stub) is the merge point

## Notes for review
- Merged origin/dev into the branch (commit 5b2de0f) to pick up #109/#110; one settings collision resolved (consolidated alwaysPreview into alwaysPreviewBeforeSave).
- EmptyRetriever is a deliberate stub — replaced by HybridRetriever once #111 lands.
- Settings tab is sync; meta is pre-loaded into a snapshot via refresh().

🤖 Generated with [Claude Code](https://claude.com/claude-code)