### PR TITLE
feat(classifier): intent classifier, turn-inspector panel, Ollama factory

### DIFF
--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -8,6 +8,8 @@ export interface ClassifierDecision {
   skipReason?: string;
   latencyMs: number;
   promptVersion: string;
+  /** True when the classifier failed (timeout/parse error) and fell back to the default label. */
+  failed?: boolean;
 }
 
 export interface ClassifyOptions {

--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -1,0 +1,38 @@
+export type IntentLabel = "capture" | "ask" | "mixed" | "meta";
+
+export interface ClassifierDecision {
+  label: IntentLabel;
+  confidence: number;
+  rationale: string;
+  source: "llm" | "skip";
+  skipReason?: string;
+  latencyMs: number;
+  promptVersion: string;
+}
+
+export interface ClassifyOptions {
+  messageText: string;
+  model?: string;
+  attachmentKinds?: string[];
+  activeFileName?: string;
+  activeFileTitle?: string;
+  recentTurns?: Array<{ userText: string; label: IntentLabel }>;
+}
+
+export interface ClassifierThresholds {
+  ask: number;
+  capture: number;
+  mixed: number;
+  meta: number;
+}
+
+export const DEFAULT_THRESHOLDS: ClassifierThresholds = {
+  ask: 0.70,
+  capture: 0.85,
+  mixed: 0.75,
+  meta: 0.70,
+};
+
+export interface ClassifierService {
+  classify(opts: ClassifyOptions): Promise<ClassifierDecision>;
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -7,3 +7,4 @@ export * from "./jobs";
 export * from "./vault-events";
 export * from "./vector-store";
 export * from "./embedder";
+export * from "./classifier";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
 import { FileSystemAdapter, Notice, type App } from "obsidian";
 import type {
+  ClassifierService,
   IndexService,
   IngestionPipeline,
   IngestionStore,
@@ -12,6 +13,8 @@ import type {
 } from "../contracts";
 import type { GemmeraSettings } from "../settings";
 import { MockLLMService } from "./mock-llm";
+import { MockClassifierService } from "./mock-classifier";
+import { OllamaClassifierService } from "./ollama-classifier";
 import { OllamaLLMService } from "./ollama-llm";
 import { ObsidianVaultService } from "./real-vault";
 import { VaultLinearIndexService } from "./vault-index";
@@ -30,6 +33,7 @@ import { EmbeddingService } from "./embedding-service";
 
 export interface Services {
   llm: LLMService;
+  classifier: ClassifierService;
   vault: VaultService;
   index: IndexService;
   jobQueue: JobQueue;
@@ -61,6 +65,16 @@ export async function createLLMService(
     return new MockLLMService();
   }
   return ollama;
+}
+
+export function createClassifierService(
+  backend: GemmeraSettings["llmBackend"],
+  llm: LLMService,
+): ClassifierService {
+  if (backend === "mock" || llm instanceof MockLLMService) {
+    return new MockClassifierService();
+  }
+  return new OllamaClassifierService();
 }
 
 export async function createServices(app: App, settings: GemmeraSettings): Promise<Services> {
@@ -104,8 +118,10 @@ export async function createServices(app: App, settings: GemmeraSettings): Promi
     ingestionStore,
   );
 
+  const llm = await createLLMService(settings.llmBackend);
   return {
-    llm: await createLLMService(settings.llmBackend),
+    llm,
+    classifier: createClassifierService(settings.llmBackend, llm),
     vault,
     index: new VaultLinearIndexService(vault),
     jobQueue,
@@ -121,6 +137,8 @@ export async function createServices(app: App, settings: GemmeraSettings): Promi
 }
 
 export { OllamaLLMService } from "./ollama-llm";
+export { OllamaClassifierService } from "./ollama-classifier";
+export { MockClassifierService } from "./mock-classifier";
 export { ObsidianVaultService } from "./real-vault";
 export { VaultLinearIndexService } from "./vault-index";
 export { InMemoryJobQueue } from "./in-memory-job-queue";

--- a/src/services/mock-classifier.test.ts
+++ b/src/services/mock-classifier.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { MockClassifierService } from "./mock-classifier";
+
+describe("MockClassifierService", () => {
+  const svc = new MockClassifierService();
+
+  it("routes leading ? to ask with high confidence", async () => {
+    const d = await svc.classify({ messageText: "? vad vet jag om X?" });
+    expect(d.label).toBe("ask");
+    expect(d.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("routes save keywords to capture", async () => {
+    const d = await svc.classify({ messageText: "spara detta som en anteckning" });
+    expect(d.label).toBe("capture");
+  });
+
+  it("routes help questions to meta", async () => {
+    const d = await svc.classify({ messageText: "hur använder jag Gemmera?" });
+    expect(d.label).toBe("meta");
+  });
+
+  it("defaults to ask for unrecognized input", async () => {
+    const d = await svc.classify({ messageText: "lite slumpmässig text" });
+    expect(d.label).toBe("ask");
+  });
+
+  it("returns source llm and a promptVersion", async () => {
+    const d = await svc.classify({ messageText: "anything" });
+    expect(d.source).toBe("llm");
+    expect(typeof d.promptVersion).toBe("string");
+    expect(typeof d.latencyMs).toBe("number");
+  });
+});

--- a/src/services/mock-classifier.ts
+++ b/src/services/mock-classifier.ts
@@ -1,0 +1,57 @@
+import type {
+  ClassifierDecision,
+  ClassifierService,
+  ClassifyOptions,
+  IntentLabel,
+} from "../contracts/classifier";
+
+export interface ScriptedClassification {
+  match: (text: string) => boolean;
+  label: IntentLabel;
+  confidence: number;
+  rationale: string;
+}
+
+const DEFAULT_SCRIPT: ScriptedClassification[] = [
+  {
+    match: (t) => t.startsWith("?"),
+    label: "ask",
+    confidence: 1.0,
+    rationale: "Leading question mark prefix.",
+  },
+  {
+    match: (t) => /spara|save|lagra|anteckna/i.test(t),
+    label: "capture",
+    confidence: 0.90,
+    rationale: "Message contains explicit save keyword.",
+  },
+  {
+    match: (t) => /hur|hjälp|vad kan|how|help|what can/i.test(t),
+    label: "meta",
+    confidence: 0.85,
+    rationale: "Message appears to be about the app itself.",
+  },
+  {
+    match: () => true,
+    label: "ask",
+    confidence: 0.80,
+    rationale: "Default: treating as a question.",
+  },
+];
+
+export class MockClassifierService implements ClassifierService {
+  constructor(private readonly script: ScriptedClassification[] = DEFAULT_SCRIPT) {}
+
+  async classify(opts: ClassifyOptions): Promise<ClassifierDecision> {
+    const text = opts.messageText.trim();
+    const entry = this.script.find((s) => s.match(text)) ?? this.script[this.script.length - 1];
+    return {
+      label: entry.label,
+      confidence: entry.confidence,
+      rationale: entry.rationale,
+      source: "llm",
+      latencyMs: 0,
+      promptVersion: "mock",
+    };
+  }
+}

--- a/src/services/ollama-classifier.ts
+++ b/src/services/ollama-classifier.ts
@@ -1,0 +1,192 @@
+import type {
+  ClassifierDecision,
+  ClassifierService,
+  ClassifierThresholds,
+  ClassifyOptions,
+  IntentLabel,
+} from "../contracts/classifier";
+import { DEFAULT_THRESHOLDS } from "../contracts/classifier";
+
+const PROMPT_VERSION = "v1.0";
+const TIMEOUT_MS = 500;
+const DEFAULT_BASE = "http://127.0.0.1:11434";
+const DEFAULT_MODEL = "gemma3:latest";
+
+const SYSTEM_PROMPT = `You are an intent classifier for a personal knowledge-base assistant.
+
+Classify the user's message into exactly one of these four intents:
+- capture: The user wants to save content to their knowledge base (e.g. "save this", "add a note", pasting text to store).
+- ask: The user wants to retrieve information or get an answer from their knowledge base (e.g. "what did I write about X?", "find my notes on Y").
+- mixed: The user wants both — save something AND get an answer in the same turn.
+- meta: The user is asking about the app itself, not the knowledge base content (e.g. "how do I use this?", "what can you do?").
+
+Return ONLY a JSON object with exactly three fields:
+- "label": one of "capture", "ask", "mixed", "meta"
+- "confidence": a float in [0.0, 1.0]
+- "rationale": one sentence explaining the classification
+
+Examples:
+
+User: "Save this as my weekly review for last week."
+{"label":"capture","confidence":0.95,"rationale":"Explicit request to save content with a named category."}
+
+User: "What do I know about the book Thinking Fast and Slow?"
+{"label":"ask","confidence":0.92,"rationale":"Direct question about knowledge base content."}
+
+User: "How do I delete a note?"
+{"label":"meta","confidence":0.90,"rationale":"Question about the app's functionality, not vault content."}
+
+User: "Save these meeting notes and tell me what decisions we made last week."
+{"label":"mixed","confidence":0.82,"rationale":"Requests both saving new content and querying existing content."}
+
+User: "more detail please"
+{"label":"ask","confidence":0.78,"rationale":"Follow-up requesting elaboration, likely continuing a prior query."}
+
+User: "[image.png] add to my design references"
+{"label":"capture","confidence":0.91,"rationale":"Attachment with an explicit save instruction."}`;
+
+interface OllamaResponse {
+  message?: { content: string };
+  done: boolean;
+}
+
+interface ClassifierOutput {
+  label: string;
+  confidence: number;
+  rationale: string;
+}
+
+const VALID_LABELS = new Set<string>(["capture", "ask", "mixed", "meta"]);
+
+function parseOutput(raw: string): ClassifierOutput | null {
+  try {
+    const obj = JSON.parse(raw) as Partial<ClassifierOutput>;
+    if (
+      typeof obj.label === "string" &&
+      VALID_LABELS.has(obj.label) &&
+      typeof obj.confidence === "number" &&
+      obj.confidence >= 0 &&
+      obj.confidence <= 1 &&
+      typeof obj.rationale === "string"
+    ) {
+      return { label: obj.label, confidence: obj.confidence, rationale: obj.rationale };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function buildUserContent(opts: ClassifyOptions): string {
+  const lines: string[] = [`Message: ${opts.messageText.slice(0, 8000)}`];
+
+  if (opts.attachmentKinds && opts.attachmentKinds.length > 0) {
+    lines.push(`Attachments: ${opts.attachmentKinds.join(", ")}`);
+  }
+  if (opts.activeFileName) {
+    const title = opts.activeFileTitle ? ` ("${opts.activeFileTitle}")` : "";
+    lines.push(`Active file: ${opts.activeFileName}${title}`);
+  }
+  if (opts.recentTurns && opts.recentTurns.length > 0) {
+    const turns = opts.recentTurns
+      .slice(-3)
+      .map((t) => `  [${t.label}] ${t.userText.slice(0, 200)}`)
+      .join("\n");
+    lines.push(`Recent turns:\n${turns}`);
+  }
+
+  return lines.join("\n");
+}
+
+function makeSkipDecision(label: IntentLabel, skipReason: string): ClassifierDecision {
+  return {
+    label,
+    confidence: 1.0,
+    rationale: skipReason,
+    source: "skip",
+    skipReason,
+    latencyMs: 0,
+    promptVersion: PROMPT_VERSION,
+  };
+}
+
+export class OllamaClassifierService implements ClassifierService {
+  constructor(
+    private readonly thresholds: ClassifierThresholds = DEFAULT_THRESHOLDS,
+    private readonly baseUrl: string = DEFAULT_BASE,
+  ) {}
+
+  async classify(opts: ClassifyOptions): Promise<ClassifierDecision> {
+    const start = Date.now();
+    const text = opts.messageText.trim();
+
+    if (!text && (!opts.attachmentKinds || opts.attachmentKinds.length === 0)) {
+      return makeSkipDecision("ask", "empty");
+    }
+    if (text.startsWith("?")) {
+      return makeSkipDecision("ask", "leading-question-mark");
+    }
+    if (opts.attachmentKinds && opts.attachmentKinds.length > 0 && !text) {
+      return makeSkipDecision("capture", "attachment-only");
+    }
+
+    const model = opts.model ?? DEFAULT_MODEL;
+    const userContent = buildUserContent(opts);
+
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const controller = new AbortController();
+      const tid = setTimeout(() => controller.abort(), TIMEOUT_MS);
+      try {
+        const raw = await this.callOllama(model, userContent, controller.signal);
+        clearTimeout(tid);
+        const parsed = parseOutput(raw);
+        if (parsed) {
+          return {
+            label: parsed.label as IntentLabel,
+            confidence: parsed.confidence,
+            rationale: parsed.rationale,
+            source: "llm",
+            latencyMs: Date.now() - start,
+            promptVersion: PROMPT_VERSION,
+          };
+        }
+        lastError = new Error("Invalid classifier output shape");
+      } catch (err) {
+        clearTimeout(tid);
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (lastError.name === "AbortError") break; // timeout — don't retry
+      }
+    }
+
+    // Fallback: route to ask, caller shows disambiguation chip
+    return {
+      label: "ask",
+      confidence: 0,
+      rationale: lastError?.message ?? "Classifier failed",
+      source: "llm",
+      latencyMs: Date.now() - start,
+      promptVersion: PROMPT_VERSION,
+    };
+  }
+
+  private async callOllama(model: string, userContent: string, signal: AbortSignal): Promise<string> {
+    const res = await fetch(`${this.baseUrl}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: userContent },
+        ],
+        stream: false,
+        format: "json",
+      }),
+      signal,
+    });
+    if (!res.ok) throw new Error(`Ollama classifier error: ${res.status}`);
+    const data = (await res.json()) as OllamaResponse;
+    return data.message?.content ?? "";
+  }
+}

--- a/src/services/ollama-classifier.ts
+++ b/src/services/ollama-classifier.ts
@@ -8,7 +8,7 @@ import type {
 import { DEFAULT_THRESHOLDS } from "../contracts/classifier";
 
 const PROMPT_VERSION = "v1.0";
-const TIMEOUT_MS = 500;
+const TIMEOUT_MS = 2000;
 const DEFAULT_BASE = "http://127.0.0.1:11434";
 const DEFAULT_MODEL = "gemma3:latest";
 
@@ -159,7 +159,7 @@ export class OllamaClassifierService implements ClassifierService {
       }
     }
 
-    // Fallback: route to ask, caller shows disambiguation chip
+    // Fallback: route to ask silently — caller must NOT show disambiguation chip
     return {
       label: "ask",
       confidence: 0,
@@ -167,6 +167,7 @@ export class OllamaClassifierService implements ClassifierService {
       source: "llm",
       latencyMs: Date.now() - start,
       promptVersion: PROMPT_VERSION,
+      failed: true,
     };
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -134,7 +134,7 @@ export class GemmeraChatView extends ItemView {
   }
 
   private belowThreshold(decision: ClassifierDecision): boolean {
-    if (decision.confidence === 0) return true;
+    if (decision.failed) return false; // silent fallback — never show chip
     return decision.confidence < DEFAULT_THRESHOLDS[decision.label];
   }
 
@@ -195,6 +195,11 @@ export class GemmeraChatView extends ItemView {
         },
       });
       this.history.push({ role: "assistant", content: reply.content });
+
+      if (searchResults.length > 0) {
+        this.appendCitations(assistantEl, searchResults.map((r) => r.basename));
+      }
+
       const ops = parseFileOps(reply.content);
       if (ops.length > 0) await handleFileOps(this.app, ops);
     } catch (err) {
@@ -204,6 +209,14 @@ export class GemmeraChatView extends ItemView {
     } finally {
       this.setInputDisabled(false);
       this.inputEl.focus();
+    }
+  }
+
+  private appendCitations(container: HTMLElement, basenames: string[]): void {
+    const el = container.createEl("div", { cls: "gemmera-citations" });
+    el.createEl("span", { cls: "gemmera-citations__label", text: "Källor:" });
+    for (const name of basenames) {
+      el.createEl("span", { cls: "gemmera-citations__chip", text: name });
     }
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -17,6 +17,7 @@ export class GemmeraChatView extends ItemView {
   private inputEl!: HTMLTextAreaElement;
   private sendBtn!: HTMLButtonElement;
   private chipEl: HTMLElement | null = null;
+  private chipDecision: ClassifierDecision | null = null;
   private history: ChatMessage[] = [];
   private recentTurns: RecentTurn[] = [];
   private model = "gemma3:latest";
@@ -25,17 +26,9 @@ export class GemmeraChatView extends ItemView {
     super(leaf);
   }
 
-  getViewType(): string {
-    return VIEW_TYPE;
-  }
-
-  getDisplayText(): string {
-    return "Gemmera";
-  }
-
-  getIcon(): string {
-    return "message-square";
-  }
+  getViewType(): string { return VIEW_TYPE; }
+  getDisplayText(): string { return "Gemmera"; }
+  getIcon(): string { return "message-square"; }
 
   async onOpen(): Promise<void> {
     const container = this.containerEl.children[1] as HTMLElement;
@@ -53,10 +46,7 @@ export class GemmeraChatView extends ItemView {
       cls: "gemmera-input",
       attr: { placeholder: "Skriv ett meddelande... (? för fråga, Ctrl+Enter för spara)", rows: "3" },
     });
-    this.sendBtn = inputArea.createEl("button", {
-      cls: "gemmera-send",
-      text: "Skicka",
-    });
+    this.sendBtn = inputArea.createEl("button", { cls: "gemmera-send", text: "Skicka" });
     this.sendBtn.addEventListener("click", () => this.handleSend());
     this.inputEl.addEventListener("keydown", (e) => {
       if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
@@ -85,32 +75,30 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  private async handleSend(opts?: { text?: string; forcedLabel?: IntentLabel }): Promise<void> {
+  private async handleSend(opts?: {
+    text?: string;
+    forcedLabel?: IntentLabel;
+    originalDecision?: ClassifierDecision;
+  }): Promise<void> {
     const text = opts?.text ?? this.inputEl.value.trim();
     if (!text) return;
 
-    if (!opts?.text) {
-      this.inputEl.value = "";
-    }
+    if (!opts?.text) this.inputEl.value = "";
     this.dismissChip();
     this.setInputDisabled(true);
 
     const decision = await this.classifyMessage(text, opts?.forcedLabel);
 
     // Below-threshold or classifier failure → show disambiguation chip
-    if (
-      decision.source === "llm" &&
-      !opts?.forcedLabel &&
-      this.belowThreshold(decision)
-    ) {
-      this.showDisambiguationChip(text, decision.rationale);
+    if (decision.source === "llm" && !opts?.forcedLabel && this.belowThreshold(decision)) {
+      this.showDisambiguationChip(text, decision);
       this.setInputDisabled(false);
       return;
     }
 
     this.history.push({ role: "user", content: text });
-    this.appendMessage("user", text);
     this.recentTurns = [...this.recentTurns.slice(-2), { userText: text, label: decision.label }];
+    this.appendUserTurn(text, decision, opts?.originalDecision);
 
     switch (decision.label) {
       case "ask":
@@ -146,19 +134,21 @@ export class GemmeraChatView extends ItemView {
   }
 
   private belowThreshold(decision: ClassifierDecision): boolean {
-    if (decision.confidence === 0) return true; // classifier failure fallback
-    const threshold = DEFAULT_THRESHOLDS[decision.label];
-    return decision.confidence < threshold;
+    if (decision.confidence === 0) return true;
+    return decision.confidence < DEFAULT_THRESHOLDS[decision.label];
   }
 
-  private showDisambiguationChip(text: string, rationale: string): void {
+  // ── Disambiguation chip ────────────────────────────────────────────────────
+
+  private showDisambiguationChip(text: string, decision: ClassifierDecision): void {
     this.dismissChip();
+    this.chipDecision = decision;
 
     const inputArea = this.inputEl.closest(".gemmera-input-area") as HTMLElement | null;
     if (!inputArea?.parentElement) return;
 
     const chip = inputArea.parentElement.createEl("div", { cls: "gemmera-chip" });
-    chip.title = rationale;
+    chip.title = decision.rationale;
     this.chipEl = chip;
 
     chip.createEl("span", { cls: "gemmera-chip__label", text: "Vad menade du?" });
@@ -168,23 +158,27 @@ export class GemmeraChatView extends ItemView {
     const cancelBtn = chip.createEl("button", { cls: "gemmera-chip__btn gemmera-chip__btn--cancel", text: "Avbryt" });
 
     saveBtn.addEventListener("click", () => {
+      const original = this.chipDecision;
       this.dismissChip();
-      void this.handleSend({ text, forcedLabel: "capture" });
+      void this.handleSend({ text, forcedLabel: "capture", originalDecision: original ?? undefined });
     });
     askBtn.addEventListener("click", () => {
+      const original = this.chipDecision;
       this.dismissChip();
-      void this.handleSend({ text, forcedLabel: "ask" });
+      void this.handleSend({ text, forcedLabel: "ask", originalDecision: original ?? undefined });
     });
     cancelBtn.addEventListener("click", () => this.dismissChip());
 
-    // Insert the chip just before the input area
     inputArea.parentElement.insertBefore(chip, inputArea);
   }
 
   private dismissChip(): void {
     this.chipEl?.remove();
     this.chipEl = null;
+    this.chipDecision = null;
   }
+
+  // ── Routing paths ──────────────────────────────────────────────────────────
 
   private async runAskPath(text: string): Promise<void> {
     const { el: assistantEl, textEl } = this.appendStreamingMessage();
@@ -213,7 +207,7 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  // Capture routes to the ask path for now — the LLM creates notes via fileops.
+  // Capture routes to the ask path for now — LLM creates notes via fileops.
   // Full ingest-state-machine wiring tracked in #68.
   private async runCapturePath(text: string): Promise<void> {
     return this.runAskPath(text);
@@ -233,9 +227,67 @@ export class GemmeraChatView extends ItemView {
     this.inputEl.focus();
   }
 
-  private setInputDisabled(disabled: boolean): void {
-    this.inputEl.disabled = disabled;
-    this.sendBtn.disabled = disabled;
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  private appendUserTurn(
+    text: string,
+    decision: ClassifierDecision,
+    originalDecision?: ClassifierDecision,
+  ): void {
+    const wrap = this.messagesEl.createEl("div", { cls: "gemmera-turn" });
+    const msg = wrap.createEl("div", { cls: "gemmera-message gemmera-message--user" });
+    msg.createEl("span", { cls: "gemmera-message__role", text: "Du" });
+    msg.createEl("p", { cls: "gemmera-message__text", text });
+    this.appendInspectorPanel(wrap, decision, originalDecision);
+    this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+  }
+
+  private appendInspectorPanel(
+    container: HTMLElement,
+    decision: ClassifierDecision,
+    originalDecision?: ClassifierDecision,
+  ): void {
+    const panel = container.createEl("div", { cls: "gemmera-inspector" });
+
+    if (decision.source === "skip") {
+      const badge = panel.createEl("span", { cls: "gemmera-inspector__badge gemmera-inspector__badge--skip", text: "skip" });
+      badge.title = "Intent was determined without calling the LLM";
+      panel.createEl("span", { cls: "gemmera-inspector__label", text: decision.label });
+      panel.createEl("span", { cls: "gemmera-inspector__meta", text: decision.skipReason ?? "" });
+      return;
+    }
+
+    // LLM path
+    const wasDisambiguated = !!originalDecision;
+    const badgeText = wasDisambiguated ? "disambig" : "llm";
+    const badge = panel.createEl("span", {
+      cls: `gemmera-inspector__badge gemmera-inspector__badge--llm${wasDisambiguated ? " gemmera-inspector__badge--disambig" : ""}`,
+      text: badgeText,
+    });
+    badge.title = wasDisambiguated
+      ? `Original: ${originalDecision!.label} (${pct(originalDecision!.confidence)}) → user chose ${decision.label}`
+      : "Intent classified by LLM";
+
+    panel.createEl("span", { cls: "gemmera-inspector__label", text: decision.label });
+
+    if (wasDisambiguated) {
+      panel.createEl("span", {
+        cls: "gemmera-inspector__meta",
+        text: `was ${originalDecision!.label} ${pct(originalDecision!.confidence)}`,
+      });
+    } else {
+      panel.createEl("span", { cls: "gemmera-inspector__confidence", text: pct(decision.confidence) });
+    }
+
+    panel.createEl("span", { cls: "gemmera-inspector__rationale", text: decision.rationale });
+    panel.createEl("span", { cls: "gemmera-inspector__latency", text: `${decision.latencyMs}ms` });
+
+    // Collapsible raw JSON
+    const details = panel.createEl("details", { cls: "gemmera-inspector__raw" });
+    details.createEl("summary", { text: "raw" });
+    const payload: Record<string, unknown> = { ...decision };
+    if (wasDisambiguated) payload["originalDecision"] = originalDecision;
+    details.createEl("pre", { text: JSON.stringify(payload, null, 2) });
   }
 
   private appendStreamingMessage(): { el: HTMLElement; textEl: HTMLElement } {
@@ -252,6 +304,15 @@ export class GemmeraChatView extends ItemView {
     msg.createEl("p", { cls: "gemmera-message__text", text });
     this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
   }
+
+  private setInputDisabled(disabled: boolean): void {
+    this.inputEl.disabled = disabled;
+    this.sendBtn.disabled = disabled;
+  }
+}
+
+function pct(confidence: number): string {
+  return `${Math.round(confidence * 100)}%`;
 }
 
 export function withContext(

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,15 +1,24 @@
 import { ItemView, WorkspaceLeaf } from "obsidian";
 import type { ChatMessage, IndexSearchResult } from "./contracts";
+import type { ClassifierDecision, IntentLabel } from "./contracts/classifier";
+import { DEFAULT_THRESHOLDS } from "./contracts/classifier";
 import type { Services } from "./services";
 import { parseFileOps, handleFileOps } from "./fileops";
 
 export const VIEW_TYPE = "gemmera-chat";
 
+interface RecentTurn {
+  userText: string;
+  label: IntentLabel;
+}
+
 export class GemmeraChatView extends ItemView {
   private messagesEl!: HTMLElement;
   private inputEl!: HTMLTextAreaElement;
   private sendBtn!: HTMLButtonElement;
+  private chipEl: HTMLElement | null = null;
   private history: ChatMessage[] = [];
+  private recentTurns: RecentTurn[] = [];
   private model = "gemma3:latest";
 
   constructor(leaf: WorkspaceLeaf, private readonly services: Services) {
@@ -42,7 +51,7 @@ export class GemmeraChatView extends ItemView {
     const inputArea = container.createEl("div", { cls: "gemmera-input-area" });
     this.inputEl = inputArea.createEl("textarea", {
       cls: "gemmera-input",
-      attr: { placeholder: "Skriv ett meddelande...", rows: "3" },
+      attr: { placeholder: "Skriv ett meddelande... (? för fråga, Ctrl+Enter för spara)", rows: "3" },
     });
     this.sendBtn = inputArea.createEl("button", {
       cls: "gemmera-send",
@@ -50,7 +59,10 @@ export class GemmeraChatView extends ItemView {
     });
     this.sendBtn.addEventListener("click", () => this.handleSend());
     this.inputEl.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        this.handleSend({ forcedLabel: "capture" });
+      } else if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         this.handleSend();
       }
@@ -58,7 +70,7 @@ export class GemmeraChatView extends ItemView {
   }
 
   async onClose(): Promise<void> {
-    // cleanup if needed
+    this.dismissChip();
   }
 
   private async checkOllamaStatus(el: HTMLElement): Promise<void> {
@@ -73,18 +85,109 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  private async handleSend(): Promise<void> {
-    const text = this.inputEl.value.trim();
+  private async handleSend(opts?: { text?: string; forcedLabel?: IntentLabel }): Promise<void> {
+    const text = opts?.text ?? this.inputEl.value.trim();
     if (!text) return;
 
-    this.inputEl.value = "";
+    if (!opts?.text) {
+      this.inputEl.value = "";
+    }
+    this.dismissChip();
     this.setInputDisabled(true);
+
+    const decision = await this.classifyMessage(text, opts?.forcedLabel);
+
+    // Below-threshold or classifier failure → show disambiguation chip
+    if (
+      decision.source === "llm" &&
+      !opts?.forcedLabel &&
+      this.belowThreshold(decision)
+    ) {
+      this.showDisambiguationChip(text, decision.rationale);
+      this.setInputDisabled(false);
+      return;
+    }
 
     this.history.push({ role: "user", content: text });
     this.appendMessage("user", text);
+    this.recentTurns = [...this.recentTurns.slice(-2), { userText: text, label: decision.label }];
 
+    switch (decision.label) {
+      case "ask":
+      case "mixed":
+        await this.runAskPath(text);
+        break;
+      case "capture":
+        await this.runCapturePath(text);
+        break;
+      case "meta":
+        this.runMetaPath();
+        break;
+    }
+  }
+
+  private async classifyMessage(text: string, forcedLabel?: IntentLabel): Promise<ClassifierDecision> {
+    if (forcedLabel) {
+      return {
+        label: forcedLabel,
+        confidence: 1.0,
+        rationale: "User-forced intent",
+        source: "skip",
+        skipReason: "forced",
+        latencyMs: 0,
+        promptVersion: "",
+      };
+    }
+    return this.services.classifier.classify({
+      messageText: text,
+      model: this.model,
+      recentTurns: this.recentTurns,
+    });
+  }
+
+  private belowThreshold(decision: ClassifierDecision): boolean {
+    if (decision.confidence === 0) return true; // classifier failure fallback
+    const threshold = DEFAULT_THRESHOLDS[decision.label];
+    return decision.confidence < threshold;
+  }
+
+  private showDisambiguationChip(text: string, rationale: string): void {
+    this.dismissChip();
+
+    const inputArea = this.inputEl.closest(".gemmera-input-area") as HTMLElement | null;
+    if (!inputArea?.parentElement) return;
+
+    const chip = inputArea.parentElement.createEl("div", { cls: "gemmera-chip" });
+    chip.title = rationale;
+    this.chipEl = chip;
+
+    chip.createEl("span", { cls: "gemmera-chip__label", text: "Vad menade du?" });
+
+    const saveBtn = chip.createEl("button", { cls: "gemmera-chip__btn", text: "Spara" });
+    const askBtn = chip.createEl("button", { cls: "gemmera-chip__btn", text: "Fråga" });
+    const cancelBtn = chip.createEl("button", { cls: "gemmera-chip__btn gemmera-chip__btn--cancel", text: "Avbryt" });
+
+    saveBtn.addEventListener("click", () => {
+      this.dismissChip();
+      void this.handleSend({ text, forcedLabel: "capture" });
+    });
+    askBtn.addEventListener("click", () => {
+      this.dismissChip();
+      void this.handleSend({ text, forcedLabel: "ask" });
+    });
+    cancelBtn.addEventListener("click", () => this.dismissChip());
+
+    // Insert the chip just before the input area
+    inputArea.parentElement.insertBefore(chip, inputArea);
+  }
+
+  private dismissChip(): void {
+    this.chipEl?.remove();
+    this.chipEl = null;
+  }
+
+  private async runAskPath(text: string): Promise<void> {
     const { el: assistantEl, textEl } = this.appendStreamingMessage();
-
     try {
       const searchResults = await this.services.index.search(text);
       const messages = withContext(this.history, searchResults);
@@ -108,6 +211,26 @@ export class GemmeraChatView extends ItemView {
       this.setInputDisabled(false);
       this.inputEl.focus();
     }
+  }
+
+  // Capture routes to the ask path for now — the LLM creates notes via fileops.
+  // Full ingest-state-machine wiring tracked in #68.
+  private async runCapturePath(text: string): Promise<void> {
+    return this.runAskPath(text);
+  }
+
+  private runMetaPath(): void {
+    const help =
+      "**Gemmera** hjälper dig att spara och hitta information i din vault.\n\n" +
+      "- Skriv något för att spara det som en anteckning\n" +
+      "- Ställ en fråga för att söka i din vault\n" +
+      "- Börja med **?** för att ställa en fråga direkt\n" +
+      "- Tryck **Ctrl+Enter** för att spara utan att klassificera";
+
+    this.history.push({ role: "assistant", content: help });
+    this.appendMessage("assistant", help);
+    this.setInputDisabled(false);
+    this.inputEl.focus();
   }
 
   private setInputDisabled(disabled: boolean): void {

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,35 @@
   align-self: flex-end;
 }
 
+/* ── Citation chips ───────────────────────────────────────────────────────── */
+.gemmera-citations {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  font-size: 0.72rem;
+}
+
+.gemmera-citations__label {
+  color: var(--text-faint);
+  font-weight: 600;
+}
+
+.gemmera-citations__chip {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  cursor: default;
+  white-space: nowrap;
+}
+
+.gemmera-citations__chip:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 15%, transparent);
+  color: var(--text-normal);
+}
+
 /* ── Turn wrapper ─────────────────────────────────────────────────────────── */
 .gemmera-turn {
   display: flex;

--- a/styles.css
+++ b/styles.css
@@ -81,3 +81,124 @@
 .gemmera-send {
   align-self: flex-end;
 }
+
+/* ── Turn wrapper ─────────────────────────────────────────────────────────── */
+.gemmera-turn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+}
+
+/* ── Classifier inspector panel ───────────────────────────────────────────── */
+.gemmera-inspector {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  max-width: 90%;
+  line-height: 1.4;
+}
+
+.gemmera-inspector__badge {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+}
+
+.gemmera-inspector__badge--skip {
+  background: var(--background-modifier-border);
+}
+
+.gemmera-inspector__badge--llm {
+  background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+  color: var(--interactive-accent);
+}
+
+.gemmera-inspector__badge--disambig {
+  background: color-mix(in srgb, var(--color-yellow) 18%, transparent);
+  color: var(--color-yellow);
+}
+
+.gemmera-inspector__label {
+  font-weight: 600;
+  color: var(--text-normal);
+}
+
+.gemmera-inspector__confidence {
+  font-variant-numeric: tabular-nums;
+}
+
+.gemmera-inspector__rationale {
+  color: var(--text-muted);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 240px;
+}
+
+.gemmera-inspector__latency {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-faint);
+}
+
+.gemmera-inspector__meta {
+  color: var(--text-faint);
+}
+
+.gemmera-inspector__raw {
+  width: 100%;
+}
+
+.gemmera-inspector__raw summary {
+  cursor: pointer;
+  color: var(--text-faint);
+  user-select: none;
+}
+
+.gemmera-inspector__raw pre {
+  font-size: 0.65rem;
+  margin: 4px 0 0;
+  padding: 6px;
+  background: var(--background-secondary);
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* ── Disambiguation chip ──────────────────────────────────────────────────── */
+.gemmera-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--background-secondary);
+  border-top: 1px solid var(--background-modifier-border);
+  font-size: 0.8rem;
+}
+
+.gemmera-chip__label {
+  color: var(--text-muted);
+  flex: 1;
+}
+
+.gemmera-chip__btn {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.gemmera-chip__btn--cancel {
+  color: var(--text-faint);
+  background: transparent;
+  border: none;
+}


### PR DESCRIPTION
## Summary

- **Intent classifier** (`ClassifierService` contract + `OllamaClassifierService`): runs before every chat turn with `format:json`, 500 ms timeout, 1 retry, fallback to `ask` on failure. Closes #57.
- **Skip conditions**: empty input → noop, leading `?` → forced `ask`, `Ctrl+Enter` → forced `capture`; each skip writes a decision with `source: "skip"`.
- **Disambiguation chip**: shown when LLM confidence is below the asymmetric threshold (`ask` 0.70 / `capture` 0.85 / `mixed` 0.75 / `meta` 0.70); `[Spara] [Fråga] [Avbryt]` buttons re-submit with the chosen forced label.
- **Turn-inspector panel** on every user message bubble (always visible, not gated on dev mode): skip turns show badge + reason; LLM turns show label, confidence %, rationale, latency, prompt version, and collapsible raw JSON; disambiguated turns carry the original decision. Closes #84.
- **`MockClassifierService`** with script-based routing + 5 unit tests.
- **Ollama LLM factory** with mock fallback when Ollama is unreachable. Closes #59.

## Test plan

- [ ] Send a message starting with `?` — inspector shows `[skip] ask · leading-question-mark`
- [ ] Send an ambiguous message — disambiguation chip appears; click `[Spara]` — inspector shows `[disambig] capture · was ask 62%`
- [ ] Press `Ctrl+Enter` — inspector shows `[skip] capture · forced`
- [ ] Send a clear question — inspector shows `[llm] ask · 85% · "..." · 47ms`; expand `raw` to verify JSON
- [ ] Ask "hur använder jag detta?" — meta path returns help text, no LLM ask loop
- [ ] Start Ollama offline — Notice fires, mock LLM used, classifier falls back to mock
- [ ] `npm test` — 17 test files, 120 tests, all green