### PR TITLE
feat(classifier): golden set, eval runner, regression gate (#85 #86 #87)

### DIFF
--- a/.github/workflows/classifier-regression.yml
+++ b/.github/workflows/classifier-regression.yml
@@ -1,0 +1,37 @@
+name: Classifier regression check
+
+on:
+  pull_request:
+    paths:
+      - "src/contracts/classifier.ts"
+      - "src/services/classifier-*.ts"
+      - "src/services/file-prompt-loader.ts"
+      - "prompts/intent-classifier.md"
+      - "eval/classifier-golden/**"
+      - "eval/runner/classify.ts"
+
+jobs:
+  regression:
+    name: Mock eval — P0 regression gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run classifier eval (mock) and compare to baseline
+        run: npm run eval:classifier:ci
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: classifier-eval-report
+          path: eval/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ __pycache__/
 
 # Worktrees (subagents) — kept out of the main checkout
 /.worktrees/
+
+# Classifier eval timestamped run output
+eval/runs/

--- a/eval/classifier-golden/baseline-mock.json
+++ b/eval/classifier-golden/baseline-mock.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Committed mock-classifier baseline. Regenerate with: npm run eval:classifier:mock -- --save-baseline eval/classifier-golden/baseline-mock.json",
+  "model": "mock",
+  "generatedAt": "2026-05-08T09:19:59.833Z",
+  "totalExamples": 30,
+  "totalAsk": 9,
+  "askCaptureFalsePositives": 0,
+  "askCaptureFpr": 0,
+  "accuracy": 0.8,
+  "capturePrecision": 0.75,
+  "captureRecall": 1
+}

--- a/eval/classifier-golden/examples.json
+++ b/eval/classifier-golden/examples.json
@@ -1,0 +1,343 @@
+[
+  {
+    "id": "c001",
+    "input": {
+      "messageText": "Spara detta som en mötesanteckning om Q2-planering",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Explicit save instruction with content type and purpose"
+  },
+  {
+    "id": "c002",
+    "input": {
+      "messageText": "Lägg till det här i min läslogg",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Explicit add-to-vault instruction with named destination"
+  },
+  {
+    "id": "c003",
+    "input": {
+      "messageText": "Kan du skapa en ny anteckning om min löpning idag? 10 km på 52 minuter, personbästa.",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Create-note request with concrete data to save"
+  },
+  {
+    "id": "c004",
+    "input": {
+      "messageText": "Arkivera det här mejlet som en anteckning i projektet",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Archive/save framing, Swedish"
+  },
+  {
+    "id": "c005",
+    "input": {
+      "messageText": "",
+      "attachmentKinds": ["pdf"],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Attachment-only with no text — skip path routes to capture"
+  },
+  {
+    "id": "c006",
+    "input": {
+      "messageText": "Notera att jag träffade Erik idag vid kaffeautomaten. Han funderar på att byta jobb.",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Note-taking / journaling framing"
+  },
+  {
+    "id": "c007",
+    "input": {
+      "messageText": "Skriv ner det här om bokhylleprojektet: fix för list-kommandot är klar, sortering funkar nu.",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Write-down instruction with project context and specific content"
+  },
+  {
+    "id": "c008",
+    "input": {
+      "messageText": "spara det istället",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad vet jag om bokhylleprojektet?", "label": "ask" },
+        { "userText": "berätta mer", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "capture",
+    "notes": "Follow-up capture after two ask turns — 'save that instead'"
+  },
+  {
+    "id": "a001",
+    "input": {
+      "messageText": "Vad vet jag om bokhylleprojektet?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Direct vault query, Swedish"
+  },
+  {
+    "id": "a002",
+    "input": {
+      "messageText": "Vad har jag skrivit om min pappa?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Personal vault recall query"
+  },
+  {
+    "id": "a003",
+    "input": {
+      "messageText": "Berätta om min vandring i Sundsvall",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Recall / retrieve from vault"
+  },
+  {
+    "id": "a004",
+    "input": {
+      "messageText": "Vilka böcker har jag läst i år?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "List query over vault content"
+  },
+  {
+    "id": "a005",
+    "input": {
+      "messageText": "? Vad tänkte jag om The Dispossessed?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Leading ? — skip path routes to ask"
+  },
+  {
+    "id": "a006",
+    "input": {
+      "messageText": "Vad handlar det öppna dokumentet om?",
+      "attachmentKinds": [],
+      "activeFileName": "dagbok_2026-03-02",
+      "activeFileTitle": "2 mars 2026",
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Query with active-file context — asking about currently open note"
+  },
+  {
+    "id": "a007",
+    "input": {
+      "messageText": "mer detaljer om det",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad har jag skrivit om min pappa?", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "ask",
+    "notes": "Follow-up ask using prior-turn context — 'more detail'"
+  },
+  {
+    "id": "a008",
+    "input": {
+      "messageText": "What did I write about my father?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "English vault query — same intent as a004 but different language"
+  },
+  {
+    "id": "m001",
+    "input": {
+      "messageText": "Spara dessa mötesanteckningar och berätta vad vi beslutade förra veckan",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Explicit save + recall in one message"
+  },
+  {
+    "id": "m002",
+    "input": {
+      "messageText": "Lägg till det här och sök sedan efter relaterade anteckningar om projektet",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Save + search request chained"
+  },
+  {
+    "id": "m003",
+    "input": {
+      "messageText": "Arkivera detta och sammanfatta sedan vad jag vet om migrationsuppdraget",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Archive + summarize existing knowledge"
+  },
+  {
+    "id": "m004",
+    "input": {
+      "messageText": "Save this meeting note and also show me what I know about David",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "English mixed — explicit save + retrieve"
+  },
+  {
+    "id": "m005",
+    "input": {
+      "messageText": "Notera det här och hitta sedan liknande anteckningar i vaulten",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Note + find-similar pattern"
+  },
+  {
+    "id": "m006",
+    "input": {
+      "messageText": "Lägg in detta i min läslogg och ge mig en översikt av allt jag har om Le Guin",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Add to log + retrieve existing — named author makes retrieval half clear"
+  },
+  {
+    "id": "x001",
+    "input": {
+      "messageText": "Hur använder jag Gemmera?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Classic how-to-use-the-app question"
+  },
+  {
+    "id": "x002",
+    "input": {
+      "messageText": "Vad kan du göra?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Capability question about the assistant"
+  },
+  {
+    "id": "x003",
+    "input": {
+      "messageText": "Hur raderar jag en anteckning?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Feature/UI question about the app"
+  },
+  {
+    "id": "x004",
+    "input": {
+      "messageText": "Vad är skillnaden mellan att spara och att fråga?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Conceptual question about the app's two modes"
+  },
+  {
+    "id": "x005",
+    "input": {
+      "messageText": "Hur fungerar sökningen i min vault?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Feature question about retrieval mechanism"
+  },
+  {
+    "id": "e001",
+    "input": {
+      "messageText": "Kan du hjälpa mig?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Ambiguous: could be meta or ask — best label is meta since there is no vault query"
+  },
+  {
+    "id": "e002",
+    "input": {
+      "messageText": "det där",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad vet jag om bokhylleprojektet?", "label": "ask" },
+        { "userText": "mer detaljer", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "ask",
+    "notes": "Minimal follow-up referencing prior ask — classifier must use recentTurns context"
+  },
+  {
+    "id": "e003",
+    "input": {
+      "messageText": "spara det",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad tänkte jag om The Dispossessed?", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "capture",
+    "notes": "Ambiguous short follow-up — 'save it' after an ask turn; prior turn context resolves to capture"
+  }
+]

--- a/eval/classifier-golden/loader.ts
+++ b/eval/classifier-golden/loader.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  AttachmentKind,
+  IntentLabel,
+} from "../../src/contracts/classifier";
+import type { ClassifyTurnInput } from "../../src/services/classifier-orchestrator";
+
+export interface GoldenExample {
+  id: string;
+  input: {
+    messageText: string;
+    attachmentKinds?: AttachmentKind[];
+    activeFileName?: string | null;
+    activeFileTitle?: string | null;
+    recentTurns?: Array<{ userText: string; label: IntentLabel }>;
+    ctrlEnter?: boolean;
+  };
+  expectedLabel: IntentLabel;
+  notes?: string;
+}
+
+export function loadGoldenSet(): GoldenExample[] {
+  const raw = readFileSync(join(__dirname, "examples.json"), "utf-8");
+  return JSON.parse(raw) as GoldenExample[];
+}
+
+export function toClassifyTurnInput(ex: GoldenExample): ClassifyTurnInput {
+  const kinds = ex.input.attachmentKinds ?? [];
+  return {
+    messageText: ex.input.messageText,
+    attachments: kinds.map((kind, i) => ({
+      kind,
+      filename: `attachment-${i}.${kind}`,
+    })),
+    activeFile:
+      ex.input.activeFileName
+        ? {
+            filename: ex.input.activeFileName,
+            title: ex.input.activeFileTitle ?? ex.input.activeFileName,
+          }
+        : null,
+    recentTurns: (ex.input.recentTurns ?? []).map((t) => ({
+      text: t.userText,
+      intent: t.label,
+    })),
+    ctrlEnter: ex.input.ctrlEnter,
+  };
+}

--- a/eval/runner/classify.ts
+++ b/eval/runner/classify.ts
@@ -1,0 +1,403 @@
+#!/usr/bin/env tsx
+/**
+ * Classifier eval runner — drives dev's `classifyTurn` orchestrator
+ * against the hand-labeled golden set, emits a confusion matrix +
+ * per-class P/R/F1 + P50/P95 latency, and (optionally) gates against
+ * a committed baseline JSON.
+ *
+ * Modes:
+ *   --mock              In-process scripted LLM, no network.  Used in CI.
+ *   (default)           Real `OllamaLLMService` against a live daemon.
+ *   --model=<tag>       Override the chat-model tag (live mode only).
+ *   --compare <path>    Compare against a baseline JSON; non-zero exit
+ *                       on a P0 regression (rise in ask→capture FPR).
+ *   --save-baseline <p> Write the run's headline metrics to <path>.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type {
+  ClassifierEventWriter,
+  ClassifierDecisionRow,
+  ClassifierDisambiguationRow,
+  IntentLabel,
+} from "../../src/contracts/classifier";
+import type {
+  ChatOptions,
+  LLMReachability,
+  LLMResponse,
+  LLMService,
+} from "../../src/contracts/llm";
+import { FilePromptLoader } from "../../src/services/file-prompt-loader";
+import { OllamaLLMService } from "../../src/services/ollama-llm";
+import { classifyTurn } from "../../src/services/classifier-orchestrator";
+import { loadGoldenSet, toClassifyTurnInput } from "../classifier-golden/loader";
+
+const LABELS: IntentLabel[] = ["capture", "ask", "mixed", "meta"];
+
+// ─── CLI args ─────────────────────────────────────────────────────────
+
+const useMock = process.argv.includes("--mock");
+const modelArg = process.argv.find((a) => a.startsWith("--model="))?.split("=")[1];
+const model = modelArg ?? "gemma4:e4b";
+
+function flagValue(flag: string): string | undefined {
+  const eq = process.argv.find((a) => a.startsWith(`${flag}=`))?.split("=")[1];
+  if (eq) return eq;
+  const idx = process.argv.indexOf(flag);
+  return idx >= 0 ? process.argv[idx + 1] : undefined;
+}
+
+const compareArg = flagValue("--compare");
+const saveBaselineArg = flagValue("--save-baseline");
+
+// ─── Mock LLM ─────────────────────────────────────────────────────────
+
+/**
+ * Tiny scripted `LLMService` used by `--mock`.  Inspects the user message
+ * the orchestrator hands to `chat()` and emits a fixed JSON classifier
+ * payload.  The orchestrator rejects unparseable / out-of-taxonomy
+ * outputs, so we always emit valid JSON.
+ *
+ * The keyword routing here mirrors the heuristic the previous PR
+ * shipped as `MockClassifierService`; the difference is that this mock
+ * goes through the *real* orchestrator pipeline (skip router → LLM →
+ * retries → thresholds → events), giving CI real-pipeline coverage.
+ */
+class ScriptedClassifierLLM implements LLMService {
+  async isReachable(): Promise<LLMReachability> {
+    return "running";
+  }
+  async listModels(): Promise<string[]> {
+    return ["mock:latest"];
+  }
+  async pickDefaultModel(): Promise<string> {
+    return "mock:latest";
+  }
+
+  async chat(opts: ChatOptions): Promise<LLMResponse> {
+    const lastUser = [...opts.messages].reverse().find((m) => m.role === "user");
+    const promptBody = lastUser?.content ?? "";
+
+    // The classifier prompt template is mostly few-shot prose. The actual
+    // turn-under-classification is everything after the "## Current input"
+    // header up to the next blank-blank gap; pattern-matching across the
+    // whole prompt body would always trip on the few-shot keywords.
+    const text = extractCurrentInput(promptBody);
+
+    let label: IntentLabel = "ask";
+    let confidence = 0.78;
+    let rationale = "Default: treating as a question.";
+
+    const isMixed =
+      /\b(spara|save|lagra|anteckna|notera|skriv ner|arkivera)\b.*\b(och|and)\b.*\b(berätta|tell|find|hitta|sök|search|sammanfatta|summari[sz]e|relaterade|related)\b/i.test(
+        text,
+      ) ||
+      /\b(berätta|tell|find|hitta|sök|search)\b.*\b(och|and)\b.*\b(spara|save|lagra)\b/i.test(text);
+
+    if (isMixed) {
+      label = "mixed";
+      confidence = 0.82;
+      rationale = "Save-and-retrieve in one message.";
+    } else if (
+      /\b(hur (gör|fungerar|använder|byter|ändrar)|hjälp|vad kan du|vilka kommandon|inställning(ar)?|how (do|can) i|what can you|help|settings?|configure)\b/i.test(
+        text,
+      )
+    ) {
+      label = "meta";
+      confidence = 0.88;
+      rationale = "Question about the app itself.";
+    } else if (
+      /\b(spara|save|lagra|anteckna|notera|skriv ner|arkivera|lägg till|skapa.*anteckning|create.*note|store|capture)\b/i.test(
+        text,
+      )
+    ) {
+      label = "capture";
+      confidence = 0.9;
+      rationale = "Explicit save / capture keyword.";
+    } else if (
+      /\b(vad|hur|när|var|vem|varför|berätta|sök|hitta|visa|recap|what|how|when|where|who|why|tell me|find|show|recall|search|list)\b/i.test(
+        text,
+      ) ||
+      /\?$/.test(text)
+    ) {
+      label = "ask";
+      confidence = 0.82;
+      rationale = "Question or retrieval phrasing.";
+    }
+
+    return { content: JSON.stringify({ label, confidence, rationale }) };
+  }
+}
+
+function extractCurrentInput(promptBody: string): string {
+  const marker = "## Current input";
+  const i = promptBody.indexOf(marker);
+  const rest = i >= 0 ? promptBody.slice(i + marker.length) : promptBody;
+  const m = rest.match(/Message:\s*([\s\S]*?)(?:\n\s*\n|$)/);
+  return (m?.[1] ?? rest).trim();
+}
+
+// ─── No-op event writer ───────────────────────────────────────────────
+
+class NoopEventWriter implements ClassifierEventWriter {
+  async writeDecision(_row: ClassifierDecisionRow): Promise<void> {}
+  async writeDisambiguation(_row: ClassifierDisambiguationRow): Promise<void> {}
+}
+
+// ─── Result row ───────────────────────────────────────────────────────
+
+interface Result {
+  id: string;
+  expected: IntentLabel;
+  actual: IntentLabel;
+  confidence: number;
+  latencyMs: number;
+  passed: boolean;
+  notes?: string;
+  rationale: string;
+  source: string;
+  needsDisambiguation: boolean;
+  fallback: boolean;
+}
+
+// ─── Runner ───────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const llm: LLMService = useMock ? new ScriptedClassifierLLM() : new OllamaLLMService();
+  const promptLoader = new FilePromptLoader(resolve(__dirname, "..", "..", "prompts"));
+  const eventWriter = new NoopEventWriter();
+
+  const examples = loadGoldenSet();
+  console.log(
+    `\nClassifier eval — ${examples.length} examples, model: ${useMock ? "mock" : model}\n`,
+  );
+
+  const results: Result[] = [];
+
+  for (const ex of examples) {
+    process.stdout.write(`  ${ex.id} … `);
+    const input = toClassifyTurnInput(ex);
+    const route = await classifyTurn(
+      input,
+      { llm, promptLoader, eventWriter },
+      `eval-${ex.id}`,
+    );
+
+    // Empty-message / null-label decisions count as a fail against the
+    // expected label; the golden set has no empty-message cases today,
+    // but encode the behaviour defensively.
+    const actual: IntentLabel = route.label ?? "ask";
+    const passed = route.label === ex.expectedLabel;
+
+    const out = route.decision.output;
+    results.push({
+      id: ex.id,
+      expected: ex.expectedLabel,
+      actual,
+      confidence: out?.confidence ?? (route.decision.source === "skip" ? 1 : 0),
+      latencyMs: route.decision.latencyMs,
+      passed,
+      notes: ex.notes,
+      rationale: out?.rationale ?? route.decision.skipReason ?? "(no rationale)",
+      source: route.decision.source,
+      needsDisambiguation: route.needsDisambiguation,
+      fallback: route.decision.fallbackReason !== null,
+    });
+    console.log(passed ? `✓ ${actual}` : `✗ got ${actual}, expected ${ex.expectedLabel}`);
+  }
+
+  report(results);
+}
+
+// ─── Metrics + report ─────────────────────────────────────────────────
+
+function report(results: Result[]): void {
+  const total = results.length;
+  const passedCount = results.filter((r) => r.passed).length;
+
+  // confusion[predicted][expected]
+  const confusion: Record<IntentLabel, Record<IntentLabel, number>> = {
+    capture: { capture: 0, ask: 0, mixed: 0, meta: 0 },
+    ask:     { capture: 0, ask: 0, mixed: 0, meta: 0 },
+    mixed:   { capture: 0, ask: 0, mixed: 0, meta: 0 },
+    meta:    { capture: 0, ask: 0, mixed: 0, meta: 0 },
+  };
+  for (const r of results) confusion[r.actual][r.expected]++;
+
+  const precision = (label: IntentLabel): number => {
+    const tp = confusion[label][label];
+    const denom = LABELS.reduce((s, l) => s + confusion[label][l], 0);
+    return denom === 0 ? 0 : tp / denom;
+  };
+  const recall = (label: IntentLabel): number => {
+    const tp = confusion[label][label];
+    const denom = LABELS.reduce((s, l) => s + confusion[l][label], 0);
+    return denom === 0 ? 0 : tp / denom;
+  };
+  const f1 = (label: IntentLabel): number => {
+    const p = precision(label);
+    const r = recall(label);
+    return p + r === 0 ? 0 : (2 * p * r) / (p + r);
+  };
+
+  const latencies = results.map((r) => r.latencyMs).sort((a, b) => a - b);
+  const percentile = (p: number): number => {
+    const idx = Math.ceil((p / 100) * latencies.length) - 1;
+    return latencies[Math.max(0, idx)];
+  };
+
+  const pct = (n: number): string => `${Math.round(n * 100)}%`;
+
+  const failures = results.filter((r) => !r.passed);
+  const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const outDir = join(__dirname, "..", "runs", ts);
+  mkdirSync(outDir, { recursive: true });
+
+  const md: string[] = [
+    `# Classifier Eval — ${new Date().toISOString()}`,
+    "",
+    `**Model:** ${useMock ? "mock" : model}  `,
+    `**Examples:** ${total}  `,
+    `**Passed:** ${passedCount} / ${total} (${pct(passedCount / total)})`,
+    "",
+    "## Confusion matrix",
+    "",
+    "Rows = predicted, columns = expected.",
+    "",
+    `|           | ${LABELS.map((l) => l.padEnd(7)).join(" | ")} |`,
+    `|-----------|${LABELS.map(() => "---------").join("|")}|`,
+    ...LABELS.map(
+      (actual) =>
+        `| ${actual.padEnd(9)} | ${LABELS.map((expected) =>
+          String(confusion[actual][expected]).padEnd(7),
+        ).join(" | ")} |`,
+    ),
+    "",
+    "## Per-class metrics",
+    "",
+    "| Class   | Precision | Recall | F1   |",
+    "|---------|-----------|--------|------|",
+    ...LABELS.map(
+      (l) =>
+        `| ${l.padEnd(7)} | ${pct(precision(l)).padEnd(9)} | ${pct(recall(l)).padEnd(6)} | ${pct(f1(l)).padEnd(4)} |`,
+    ),
+    "",
+    "## Latency",
+    "",
+    `- P50: ${percentile(50)}ms`,
+    `- P95: ${percentile(95)}ms`,
+    `- Min: ${latencies[0]}ms`,
+    `- Max: ${latencies[latencies.length - 1]}ms`,
+  ];
+
+  if (failures.length > 0) {
+    md.push("", "## Failures", "");
+    for (const r of failures) {
+      md.push(
+        `**${r.id}** — expected \`${r.expected}\`, got \`${r.actual}\` (${pct(r.confidence)})  `,
+        `> ${r.rationale}`,
+        r.notes ? `> *${r.notes}*` : "",
+        "",
+      );
+    }
+  }
+
+  const totalAsk = results.filter((r) => r.expected === "ask").length;
+  const askCaptureFalsePositives = confusion["capture"]["ask"];
+  const askCaptureFpr = totalAsk === 0 ? 0 : askCaptureFalsePositives / totalAsk;
+
+  const json = {
+    timestamp: new Date().toISOString(),
+    model: useMock ? "mock" : model,
+    total,
+    passed: passedCount,
+    accuracy: passedCount / total,
+    confusion,
+    perClass: Object.fromEntries(
+      LABELS.map((l) => [l, { precision: precision(l), recall: recall(l), f1: f1(l) }]),
+    ),
+    latency: {
+      p50: percentile(50),
+      p95: percentile(95),
+      min: latencies[0],
+      max: latencies[latencies.length - 1],
+    },
+    derived: { totalAsk, askCaptureFalsePositives, askCaptureFpr },
+    failures: failures.map((r) => ({
+      id: r.id,
+      expected: r.expected,
+      actual: r.actual,
+      confidence: r.confidence,
+      rationale: r.rationale,
+      notes: r.notes,
+    })),
+    results,
+  };
+
+  writeFileSync(join(outDir, "report.md"), md.join("\n"));
+  writeFileSync(join(outDir, "report.json"), JSON.stringify(json, null, 2));
+
+  if (saveBaselineArg) {
+    const baseline = {
+      _comment:
+        "Committed mock-classifier baseline. Regenerate with: npm run eval:classifier:mock -- --save-baseline eval/classifier-golden/baseline-mock.json",
+      model: useMock ? "mock" : model,
+      generatedAt: new Date().toISOString(),
+      totalExamples: total,
+      totalAsk,
+      askCaptureFalsePositives,
+      askCaptureFpr,
+      accuracy: passedCount / total,
+      capturePrecision: precision("capture"),
+      captureRecall: recall("capture"),
+    };
+    writeFileSync(resolve(saveBaselineArg), JSON.stringify(baseline, null, 2));
+    console.log(`\nBaseline saved → ${saveBaselineArg}`);
+  }
+
+  console.log(`\nResults → ${outDir}/`);
+  console.log(`Accuracy: ${passedCount}/${total} (${pct(passedCount / total)})`);
+  console.log(`P50: ${percentile(50)}ms  P95: ${percentile(95)}ms`);
+  if (failures.length > 0) {
+    console.log(`\nFailures (${failures.length}):`);
+    for (const r of failures) {
+      console.log(
+        `  ${r.id}: expected ${r.expected}, got ${r.actual} — "${r.notes ?? r.rationale}"`,
+      );
+    }
+  }
+
+  if (compareArg) {
+    const baseline = JSON.parse(readFileSync(resolve(compareArg), "utf-8")) as {
+      askCaptureFpr: number;
+      accuracy: number;
+    };
+
+    let p0 = false;
+    if (askCaptureFpr > baseline.askCaptureFpr) {
+      console.error(
+        `\n[P0 REGRESSION] ask→capture false-positive rate rose: ${pct(baseline.askCaptureFpr)} → ${pct(askCaptureFpr)}`,
+      );
+      p0 = true;
+    }
+
+    const accuracyDrop = baseline.accuracy - passedCount / total;
+    if (accuracyDrop > 0.05) {
+      console.warn(
+        `\n[P1 REGRESSION] Overall accuracy dropped ${pct(accuracyDrop)} vs baseline (${pct(baseline.accuracy)} → ${pct(passedCount / total)})`,
+      );
+    }
+
+    if (!p0) {
+      console.log("\n✓ No P0 regressions detected.");
+    } else {
+      process.exit(1);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "builtin-modules": "4.0.0",
         "esbuild": "0.24.2",
         "obsidian": "latest",
+        "tsx": "^4.19.2",
         "typescript": "5.6.3",
         "vitest": "^2.1.9"
       }
@@ -396,6 +397,23 @@
       "optional": true,
       "os": [
         "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
       ],
       "engines": {
         "node": ">=18"
@@ -1201,6 +1219,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1337,6 +1368,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
@@ -1463,6 +1504,493 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "node esbuild.config.mjs",
     "build": "node esbuild.config.mjs production",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "eval:classifier": "tsx eval/runner/classify.ts",
+    "eval:classifier:mock": "tsx eval/runner/classify.ts --mock",
+    "eval:classifier:ci": "tsx eval/runner/classify.ts --mock --compare eval/classifier-golden/baseline-mock.json"
   },
   "dependencies": {
     "ajv": "^8.20.0"
@@ -17,6 +20,7 @@
     "builtin-modules": "4.0.0",
     "esbuild": "0.24.2",
     "obsidian": "latest",
+    "tsx": "^4.19.2",
     "typescript": "5.6.3",
     "vitest": "^2.1.9"
   }

--- a/planning/classifier.md
+++ b/planning/classifier.md
@@ -74,14 +74,20 @@ Three fields. No trailing prose. `confidence` is a raw model-reported probabilit
 
 The exact threshold numbers are tuned during build against the classifier golden set. The shape is asymmetric: `capture` requires a higher confidence than `ask` because misclassifying `ask` as `capture` is costlier (a silent note may get written) than the reverse.
 
-Starting points to anchor the eval work, not committed values:
+**Committed values (v1.0, 2026-05-07):**
 
-- `ask` threshold: 0.70.
-- `capture` threshold: 0.85.
-- `mixed` threshold: 0.75.
-- `meta` threshold: 0.70.
+| Label     | Threshold | Rationale |
+|-----------|-----------|-----------|
+| `capture` | 0.85      | Highest threshold — misrouting `ask` as `capture` causes silent writes, which is the costliest error. |
+| `mixed`   | 0.75      | Mid-range — mixed turns that fall below this are safer to route via disambiguation than to guess. |
+| `ask`     | 0.70      | Lower threshold — misrouting `capture` as `ask` is recoverable; user sees the answer and can re-save. |
+| `meta`    | 0.70      | Lower threshold — meta fallback to `ask` is safe; user gets a vault answer instead of help text, low cost. |
 
-Below threshold, the disambiguation chip appears. Committed values land after the first golden-set run during M1.
+These values are encoded in `src/contracts/classifier.ts` (`DEFAULT_CLASSIFIER_THRESHOLDS`) and are guarded by the CI regression check. Update the constant and the baseline together when re-tuning.
+
+**Tuning process:** run `npm run eval:classifier` (requires Ollama) against the 30-example golden set. Adjust thresholds to maintain `capture` > `ask` asymmetry and maximise `capture` precision without sacrificing `ask` recall. Re-generate the mock baseline with `npm run eval:classifier:mock -- --save-baseline eval/classifier-golden/baseline-mock.json` after any golden set or threshold change.
+
+Below threshold, the disambiguation chip appears.
 
 ## Disambiguation UX
 
@@ -133,7 +139,8 @@ A classifier golden set, distinct from the retrieval golden set.
 - **Initial size**: 30 hand-labeled examples covering all four labels and the main edge cases (attachments, follow-ups, ambiguous phrasing, meta questions).
 - **Growth**: to 100+ during beta. The disambiguation chip is a built-in labeled-example factory — every user correction becomes a labeled example.
 - **Metrics**: per-class precision and recall, full confusion matrix, P50 and P95 latency.
-- **Regression policy**: any drop in `ask → capture` precision is a P0 regression. Other regressions are P1.
+- **Regression policy**: any increase in the `ask → capture` false-positive rate (asks misrouted as capture) is a **P0 regression** — the CI gate in `.github/workflows/classifier-regression.yml` fails the build. A drop in overall accuracy of more than 5 percentage points vs the committed baseline is a **P1 regression** — logged as a warning, does not fail CI. All other metric changes are informational.
+- **CI gate**: `npm run eval:classifier:ci` runs the scripted-LLM mock against the golden set through the real `classifyTurn` orchestrator and compares to `eval/classifier-golden/baseline-mock.json`. Triggers on PRs touching `src/contracts/classifier.ts`, any `src/services/classifier-*.ts`, `src/services/file-prompt-loader.ts`, `prompts/intent-classifier.md`, `eval/classifier-golden/**`, or `eval/runner/classify.ts`.
 
 ## Prompt structure
 


### PR DESCRIPTION
## Summary

Scope-bounded revision of the original classifier milestone PR. The runtime classifier service / skip router / threshold gate / disambiguation chip / inspector pieces were superseded by parallel work that landed on dev (#103, #106, #107, #108, #110), so this PR drops them to avoid a contract regression and ships only the eval-side deliverables.

- **#85 — Golden set.** 30 hand-labeled examples in `eval/classifier-golden/examples.json` covering all four labels and every spec edge case (attachment-only, follow-up turns, active-file context, ambiguous phrasing, leading-`?`, recentTurns context).
- **#86 — Eval runner.** `eval/runner/classify.ts` drives dev's real `classifyTurn` orchestrator (skip router → LLM → retries → thresholds → events). Emits confusion matrix, per-class P/R/F1, and P50/P95 latency to `eval/runs/<timestamp>/report.{md,json}`.
- **#87 — Regression gate.** `eval:classifier:ci` runs the scripted-LLM mock against the golden set through the real orchestrator and compares to a committed baseline. P0 fails CI on any rise in ask→capture FPR; P1 warns on >5pp accuracy drop. Workflow at `.github/workflows/classifier-regression.yml`.
- **Committed thresholds** documented in `planning/classifier.md` (capture 0.85 / mixed 0.75 / ask 0.70 / meta 0.70) keyed to dev's `DEFAULT_CLASSIFIER_THRESHOLDS`.

### Baseline

Locked in `eval/classifier-golden/baseline-mock.json`:

| Metric | Value |
|---|---|
| Accuracy | 24 / 30 (80%) |
| Capture precision | 75% |
| Capture recall | 100% |
| ask→capture FPR | 0% |

### What this does NOT include

The previous revision shipped duplicate runtime code under `src/services/{ollama,mock}-classifier.ts` plus a divergent `src/contracts/classifier.ts`. Dev now has the full classifier surface (`classifier-orchestrator`, `classifier-skip-router`, `classifier-thresholds`, `classifier-llm`, `classifier-retries`, `classifier-events`, `classifier-utils`, `classifier-prompt`) plus the disambig chip and dev-mode inspector via separate PRs. Issues #57 and #84 should be closed against those.

## Test plan

- [x] `npm test` — 48 files / 503 tests green
- [x] `npx tsc --noEmit` — clean
- [x] `npm run eval:classifier:mock` — produces report.{md,json}, exits 0
- [x] `npm run eval:classifier:ci` — `✓ No P0 regressions detected`
- [ ] `npm run eval:classifier` (live Ollama) — verifies real-pipeline numbers locally before merge

Closes #85
Closes #86
Closes #87