### PR TITLE
fix(demo): citation chips, classifier silent fallback, 2s timeout

### DIFF
--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -8,6 +8,8 @@ export interface ClassifierDecision {
   skipReason?: string;
   latencyMs: number;
   promptVersion: string;
+  /** True when the classifier failed (timeout/parse error) and fell back to the default label. */
+  failed?: boolean;
 }
 
 export interface ClassifyOptions {

--- a/src/services/ollama-classifier.ts
+++ b/src/services/ollama-classifier.ts
@@ -8,7 +8,7 @@ import type {
 import { DEFAULT_THRESHOLDS } from "../contracts/classifier";
 
 const PROMPT_VERSION = "v1.0";
-const TIMEOUT_MS = 500;
+const TIMEOUT_MS = 2000;
 const DEFAULT_BASE = "http://127.0.0.1:11434";
 const DEFAULT_MODEL = "gemma3:latest";
 
@@ -159,7 +159,7 @@ export class OllamaClassifierService implements ClassifierService {
       }
     }
 
-    // Fallback: route to ask, caller shows disambiguation chip
+    // Fallback: route to ask silently — caller must NOT show disambiguation chip
     return {
       label: "ask",
       confidence: 0,
@@ -167,6 +167,7 @@ export class OllamaClassifierService implements ClassifierService {
       source: "llm",
       latencyMs: Date.now() - start,
       promptVersion: PROMPT_VERSION,
+      failed: true,
     };
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -134,7 +134,7 @@ export class GemmeraChatView extends ItemView {
   }
 
   private belowThreshold(decision: ClassifierDecision): boolean {
-    if (decision.confidence === 0) return true;
+    if (decision.failed) return false; // silent fallback — never show chip
     return decision.confidence < DEFAULT_THRESHOLDS[decision.label];
   }
 
@@ -195,6 +195,11 @@ export class GemmeraChatView extends ItemView {
         },
       });
       this.history.push({ role: "assistant", content: reply.content });
+
+      if (searchResults.length > 0) {
+        this.appendCitations(assistantEl, searchResults.map((r) => r.basename));
+      }
+
       const ops = parseFileOps(reply.content);
       if (ops.length > 0) await handleFileOps(this.app, ops);
     } catch (err) {
@@ -204,6 +209,14 @@ export class GemmeraChatView extends ItemView {
     } finally {
       this.setInputDisabled(false);
       this.inputEl.focus();
+    }
+  }
+
+  private appendCitations(container: HTMLElement, basenames: string[]): void {
+    const el = container.createEl("div", { cls: "gemmera-citations" });
+    el.createEl("span", { cls: "gemmera-citations__label", text: "Källor:" });
+    for (const name of basenames) {
+      el.createEl("span", { cls: "gemmera-citations__chip", text: name });
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,35 @@
   align-self: flex-end;
 }
 
+/* ── Citation chips ───────────────────────────────────────────────────────── */
+.gemmera-citations {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  font-size: 0.72rem;
+}
+
+.gemmera-citations__label {
+  color: var(--text-faint);
+  font-weight: 600;
+}
+
+.gemmera-citations__chip {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  cursor: default;
+  white-space: nowrap;
+}
+
+.gemmera-citations__chip:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 15%, transparent);
+  color: var(--text-normal);
+}
+
 /* ── Turn wrapper ─────────────────────────────────────────────────────────── */
 .gemmera-turn {
   display: flex;


### PR DESCRIPTION
## Summary

Demo-hardening fixes on top of the classifier milestone (#114). Merge #114 first.

- **Classifier silent fallback** — timeout/parse failures now route to `ask` without showing the disambiguation chip (previously the chip appeared on every slow startup, looking broken).
- **Timeout 500ms → 2000ms** — more realistic for demo hardware where Ollama may be loading the model.
- **`ClassifierDecision.failed` flag** — distinguishes classifier failure from a legitimately low-confidence result; `belowThreshold()` never triggers the chip on failures.
- **Citation "Källor:" strip** — after each assistant response, shows pill badges for every retrieved note. Addresses the citation accuracy metric in the demo evaluation.

## Test plan

- [ ] Start Ollama cold (model not loaded) — send a message — no disambiguation chip appears, answer streams normally
- [ ] Ask about Jonas Berg's hiking trip — answer appears with `Källor: vandringsnoter_sundsvall_harnosand` pill visible
- [ ] Ask about books read — `Källor: laslogg_2025, bokrecension_*` pills shown
- [ ] `npm test` — 120 tests, all green