### PR TITLE
feat(tool-loop): destructive ops, preview gate, hard stops, cancellation (#36 #44 #54 #60 #63)

### DIFF
--- a/src/contracts/mocks/mock-vault.ts
+++ b/src/contracts/mocks/mock-vault.ts
@@ -53,6 +53,19 @@ export class MockVaultService implements VaultService {
     return { mtime: this.mtimes.get(path) ?? 0, size: content.length };
   }
 
+  async trash(path: string): Promise<void> {
+    if (!this.files.has(path)) throw new Error(`File not found: ${path}`);
+    this.files.delete(path);
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    const content = this.files.get(from);
+    if (content === undefined) throw new Error(`File not found: ${from}`);
+    if (this.files.has(to)) throw new Error(`File already exists: ${to}`);
+    this.files.delete(from);
+    this.files.set(to, content);
+  }
+
   setMtime(path: string, mtime: number): void {
     this.mtimes.set(path, mtime);
   }

--- a/src/contracts/vault.ts
+++ b/src/contracts/vault.ts
@@ -28,8 +28,9 @@ export interface VaultService {
    */
   stat(path: string): Promise<VaultStat>;
   /**
-   * Moves the file to Obsidian's trash (`.trash/`). Never a permanent delete.
-   * Throws if the file does not exist.
+   * Moves the file to the system trash (Finder Trash on macOS, Recycle
+   * Bin on Windows). Never a permanent delete; the user can restore the
+   * file from the OS trash UI. Throws if the file does not exist.
    */
   trash(path: string): Promise<void>;
   /**

--- a/src/contracts/vault.ts
+++ b/src/contracts/vault.ts
@@ -27,4 +27,15 @@ export interface VaultService {
    * changed.
    */
   stat(path: string): Promise<VaultStat>;
+  /**
+   * Moves the file to Obsidian's trash (`.trash/`). Never a permanent delete.
+   * Throws if the file does not exist.
+   */
+  trash(path: string): Promise<void>;
+  /**
+   * Renames or moves a file. In the real vault this delegates to
+   * `FileManager.renameFile` so all incoming wikilinks update atomically.
+   * Throws if `from` does not exist or `to` already exists.
+   */
+  rename(from: string, to: string): Promise<void>;
 }

--- a/src/services/cancellation.test.ts
+++ b/src/services/cancellation.test.ts
@@ -83,10 +83,10 @@ describe("cancellation — cancel during GENERATE", () => {
     await sm2.dispatch({ kind: "tool_result", name: "reranked" });
 
     expect(capturedSignal).not.toBeNull();
-    expect((capturedSignal as AbortSignal).aborted).toBe(false);
+    expect(capturedSignal!.aborted).toBe(false);
 
     await sm2.cancel();
-    expect((capturedSignal as AbortSignal).aborted).toBe(true);
+    expect(capturedSignal!.aborted).toBe(true);
   });
 
   it("abort signal fires when cancelled during a long tool call in RETRIEVE", async () => {
@@ -105,10 +105,10 @@ describe("cancellation — cancel during GENERATE", () => {
     await sm.startTurn("t1");
     // Still in RETRIEVE (tool call is in flight).
     expect(capturedSignal).not.toBeNull();
-    expect((capturedSignal as AbortSignal).aborted).toBe(false);
+    expect(capturedSignal!.aborted).toBe(false);
 
     await sm.cancel();
-    expect((capturedSignal as AbortSignal).aborted).toBe(true);
+    expect(capturedSignal!.aborted).toBe(true);
   });
 });
 

--- a/src/services/cancellation.test.ts
+++ b/src/services/cancellation.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it, vi } from "vitest";
+import { StateMachineConfig, UnwindHooks } from "../contracts/state-machine";
+import { HARD_STOPS } from "../contracts/hard-stops";
+import { InMemoryEventLog } from "./event-log";
+import { StateMachine } from "./state-machine";
+
+/**
+ * Cancellation and per-turn timeout tests for #60.
+ *
+ * Uses state names matching the query state machine (GENERATE, RERANK,
+ * RETRIEVE, etc.) so the tests read as acceptance criteria even though
+ * the full query SM is not yet wired. The framework is state-name-agnostic.
+ */
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function querySmConfig(
+  extra: Partial<StateMachineConfig> = {},
+): StateMachineConfig {
+  return {
+    states: [
+      { name: "RETRIEVE", maxEventsPerTurn: 5 },
+      { name: "RERANK", maxEventsPerTurn: 5 },
+      { name: "GENERATE", maxEventsPerTurn: 5 },
+      { name: "DONE", maxEventsPerTurn: 0, terminal: true },
+      { name: "CANCELLED", maxEventsPerTurn: 0, terminal: true },
+      { name: "TIMED_OUT", maxEventsPerTurn: 0, terminal: true },
+      { name: "MODEL_INVALID_OUTPUT", maxEventsPerTurn: 0, terminal: true },
+    ],
+    transitions: [
+      { from: "RETRIEVE", on: { kind: "tool_result", name: "retrieved" }, to: "RERANK" },
+      { from: "RERANK", on: { kind: "tool_result", name: "reranked" }, to: "GENERATE" },
+      { from: "GENERATE", on: { kind: "model_output", name: "done" }, to: "DONE" },
+    ],
+    initialState: "RETRIEVE",
+    errorBoundedEventsState: "MODEL_INVALID_OUTPUT",
+    ...extra,
+  };
+}
+
+// ── Cancel during GENERATE ────────────────────────────────────────────────────
+
+describe("cancellation — cancel during GENERATE", () => {
+  it("transitions to CANCELLED and aborts the signal", async () => {
+    const eventLog = new InMemoryEventLog();
+    const sm = new StateMachine(querySmConfig({ eventLog }));
+
+    await sm.startTurn("t1");
+    await sm.dispatch({ kind: "tool_result", name: "retrieved" });
+    await sm.dispatch({ kind: "tool_result", name: "reranked" });
+    // Now in GENERATE — cancel before the model finishes.
+    await sm.cancel();
+
+    const states = (await eventLog.eventsFor("t1"))
+      .filter((e) => e.kind === "enter")
+      .map((e) => e.state);
+    expect(states).toContain("GENERATE");
+    expect(states.at(-1)).toBe("CANCELLED");
+    expect(sm.getActive()).toBeNull();
+  });
+
+  it("abort signal fires when cancelled during GENERATE", async () => {
+    const sm = new StateMachine(querySmConfig());
+    const turn = await sm.startTurn("t1");
+    await sm.dispatch({ kind: "tool_result", name: "retrieved" });
+    await sm.dispatch({ kind: "tool_result", name: "reranked" });
+
+    // Capture the signal while in GENERATE — a real LLM call would pass it to fetch.
+    let capturedSignal: AbortSignal | null = null;
+    const config = querySmConfig({
+      states: [
+        {
+          name: "GENERATE",
+          maxEventsPerTurn: 5,
+          onEnter: (ctx) => { capturedSignal = ctx.signal; },
+        },
+        ...(querySmConfig().states.filter((s) => s.name !== "GENERATE")),
+      ],
+    });
+    const sm2 = new StateMachine(config);
+    await sm2.startTurn("t2");
+    await sm2.dispatch({ kind: "tool_result", name: "retrieved" });
+    await sm2.dispatch({ kind: "tool_result", name: "reranked" });
+
+    expect(capturedSignal).not.toBeNull();
+    expect((capturedSignal as AbortSignal).aborted).toBe(false);
+
+    await sm2.cancel();
+    expect((capturedSignal as AbortSignal).aborted).toBe(true);
+  });
+
+  it("abort signal fires when cancelled during a long tool call in RETRIEVE", async () => {
+    let capturedSignal: AbortSignal | null = null;
+    const config = querySmConfig({
+      states: [
+        {
+          name: "RETRIEVE",
+          maxEventsPerTurn: 5,
+          onEnter: (ctx) => { capturedSignal = ctx.signal; },
+        },
+        ...(querySmConfig().states.filter((s) => s.name !== "RETRIEVE")),
+      ],
+    });
+    const sm = new StateMachine(config);
+    await sm.startTurn("t1");
+    // Still in RETRIEVE (tool call is in flight).
+    expect(capturedSignal).not.toBeNull();
+    expect((capturedSignal as AbortSignal).aborted).toBe(false);
+
+    await sm.cancel();
+    expect((capturedSignal as AbortSignal).aborted).toBe(true);
+  });
+});
+
+// ── Timeout ───────────────────────────────────────────────────────────────────
+
+describe("cancellation — wall-clock timeout", () => {
+  it("fires TIMED_OUT when the budget elapses during RERANK", async () => {
+    const eventLog = new InMemoryEventLog();
+    const sm = new StateMachine(
+      querySmConfig({
+        eventLog,
+        timer: { budgetMs: 50, terminalState: "TIMED_OUT" },
+      }),
+    );
+
+    await sm.startTurn("t1");
+    await sm.dispatch({ kind: "tool_result", name: "retrieved" });
+    // Now in RERANK — wait for timeout.
+    await new Promise((r) => setTimeout(r, 120));
+
+    const states = (await eventLog.eventsFor("t1"))
+      .filter((e) => e.kind === "enter")
+      .map((e) => e.state);
+    expect(states.at(-1)).toBe("TIMED_OUT");
+    expect(sm.getActive()).toBeNull();
+  });
+
+  it("fires TIMED_OUT during GENERATE when budget elapses", async () => {
+    const eventLog = new InMemoryEventLog();
+    const sm = new StateMachine(
+      querySmConfig({
+        eventLog,
+        timer: { budgetMs: 50, terminalState: "TIMED_OUT" },
+      }),
+    );
+
+    await sm.startTurn("t1");
+    await sm.dispatch({ kind: "tool_result", name: "retrieved" });
+    await sm.dispatch({ kind: "tool_result", name: "reranked" });
+    // Now in GENERATE — wait for timeout.
+    await new Promise((r) => setTimeout(r, 120));
+
+    const states = (await eventLog.eventsFor("t1"))
+      .filter((e) => e.kind === "enter")
+      .map((e) => e.state);
+    expect(states.at(-1)).toBe("TIMED_OUT");
+  });
+
+  it("does not fire timeout after the turn completes naturally", async () => {
+    const eventLog = new InMemoryEventLog();
+    const sm = new StateMachine(
+      querySmConfig({
+        eventLog,
+        timer: { budgetMs: 100, terminalState: "TIMED_OUT" },
+      }),
+    );
+
+    await sm.startTurn("t1");
+    await sm.dispatch({ kind: "tool_result", name: "retrieved" });
+    await sm.dispatch({ kind: "tool_result", name: "reranked" });
+    await sm.dispatch({ kind: "model_output", name: "done" });
+    // Turn is DONE — wait past the budget and verify no extra transitions.
+    await new Promise((r) => setTimeout(r, 150));
+
+    const states = (await eventLog.eventsFor("t1"))
+      .filter((e) => e.kind === "enter")
+      .map((e) => e.state);
+    expect(states.at(-1)).toBe("DONE");
+    expect(states).not.toContain("TIMED_OUT");
+  });
+
+  it("default wall-clock budget from HARD_STOPS is within the allowed range", () => {
+    expect(HARD_STOPS.WALL_CLOCK_MS_PER_TURN).toBe(120_000);
+    expect(HARD_STOPS.WALL_CLOCK_MS_MAX).toBe(300_000);
+    expect(HARD_STOPS.WALL_CLOCK_MS_PER_TURN).toBeLessThanOrEqual(
+      HARD_STOPS.WALL_CLOCK_MS_MAX,
+    );
+  });
+});
+
+// ── Unwind order ──────────────────────────────────────────────────────────────
+
+describe("cancellation — unwind hook order", () => {
+  it("runs hooks stop → drop → rollback → events → notice on cancel", async () => {
+    const calls: string[] = [];
+    const hooks: UnwindHooks = {
+      stopModelStream: () => { calls.push("stop"); },
+      dropPendingToolResults: () => { calls.push("drop"); },
+      rollbackUnconfirmedWrites: () => { calls.push("rollback"); },
+      writeEvents: () => { calls.push("events"); },
+      surfaceNotice: () => { calls.push("notice"); },
+    };
+
+    const sm = new StateMachine(querySmConfig({ unwind: hooks }));
+    await sm.startTurn("t1");
+    await sm.cancel();
+
+    expect(calls).toEqual(["stop", "drop", "rollback", "events", "notice"]);
+  });
+
+  it("runs hooks in the same order on timeout", async () => {
+    const calls: string[] = [];
+    const hooks: UnwindHooks = {
+      stopModelStream: () => { calls.push("stop"); },
+      dropPendingToolResults: () => { calls.push("drop"); },
+      rollbackUnconfirmedWrites: () => { calls.push("rollback"); },
+      writeEvents: () => { calls.push("events"); },
+      surfaceNotice: () => { calls.push("notice"); },
+    };
+
+    const sm = new StateMachine(
+      querySmConfig({ unwind: hooks, timer: { budgetMs: 50, terminalState: "TIMED_OUT" } }),
+    );
+    await sm.startTurn("t1");
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(calls).toEqual(["stop", "drop", "rollback", "events", "notice"]);
+  });
+
+  it("a failing hook does not prevent later hooks from running", async () => {
+    const calls: string[] = [];
+    const hooks: UnwindHooks = {
+      stopModelStream: () => { calls.push("stop"); throw new Error("stream error"); },
+      dropPendingToolResults: () => { calls.push("drop"); },
+      rollbackUnconfirmedWrites: () => { calls.push("rollback"); },
+      writeEvents: () => { calls.push("events"); },
+      surfaceNotice: () => { calls.push("notice"); },
+    };
+
+    const sm = new StateMachine(querySmConfig({ unwind: hooks }));
+    await sm.startTurn("t1");
+    await sm.cancel();
+
+    // All hooks must run even when stopModelStream throws.
+    expect(calls).toEqual(["stop", "drop", "rollback", "events", "notice"]);
+  });
+});
+
+// ── Confirmed writes are preserved ────────────────────────────────────────────
+
+describe("cancellation — confirmed writes preserved", () => {
+  it("a queued turn starts after the cancelled turn ends", async () => {
+    const eventLog = new InMemoryEventLog();
+    const sm = new StateMachine(querySmConfig({ eventLog }));
+
+    // Start two turns — the second queues behind the first.
+    await sm.startTurn("t1");
+    const second = await sm.startTurn("t2");
+    expect(second).toEqual({ turnId: "t2" }); // QueuedTurn
+
+    // Cancel t1 — t2 should start automatically.
+    await sm.cancel();
+
+    expect(sm.getActive()?.turnId).toBe("t2");
+    expect(sm.getQueue()).toHaveLength(0);
+  });
+
+  it("cancellation does not affect transitions already written to the event log", async () => {
+    const eventLog = new InMemoryEventLog();
+    const sm = new StateMachine(querySmConfig({ eventLog }));
+
+    await sm.startTurn("t1");
+    await sm.dispatch({ kind: "tool_result", name: "retrieved" });
+    // RETRIEVE → RERANK is already committed to the log.
+    await sm.cancel();
+
+    const entries = await eventLog.eventsFor("t1");
+    const retrieveEnter = entries.find(
+      (e) => e.kind === "enter" && e.state === "RETRIEVE",
+    );
+    const rerankEnter = entries.find(
+      (e) => e.kind === "enter" && e.state === "RERANK",
+    );
+    expect(retrieveEnter).toBeDefined();
+    expect(rerankEnter).toBeDefined();
+  });
+});

--- a/src/services/destructive-op-machine.test.ts
+++ b/src/services/destructive-op-machine.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { InMemoryEventLog } from "./event-log";
+import {
+  ConfirmDecision,
+  runDestructiveOp,
+} from "./destructive-op-machine";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeVault(files: Record<string, string> = {}): MockVaultService {
+  return new MockVaultService(files);
+}
+
+function alwaysConfirm(): Promise<ConfirmDecision> {
+  return Promise.resolve("confirmed");
+}
+
+function alwaysCancel(): Promise<ConfirmDecision> {
+  return Promise.resolve("cancelled");
+}
+
+// ── Delete path ───────────────────────────────────────────────────────────────
+
+describe("runDestructiveOp — delete", () => {
+  it("trashes the file and enqueues a delete job on confirm", async () => {
+    const vault = makeVault({ "notes/todo.md": "# Todo\nBuy milk." });
+    const jobQueue = new InMemoryJobQueue();
+
+    const outcome = await runDestructiveOp(
+      { kind: "delete", path: "notes/todo.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: alwaysConfirm,
+        confirmRename: alwaysConfirm,
+      },
+    );
+
+    expect(outcome).toEqual({ kind: "done", op: { kind: "delete", path: "notes/todo.md" } });
+    expect(await vault.exists("notes/todo.md")).toBe(false);
+    expect(jobQueue.drain()).toEqual([{ kind: "delete", path: "notes/todo.md" }]);
+  });
+
+  it("returns cancelled and leaves file intact when user cancels", async () => {
+    const vault = makeVault({ "notes/todo.md": "content" });
+    const jobQueue = new InMemoryJobQueue();
+
+    const outcome = await runDestructiveOp(
+      { kind: "delete", path: "notes/todo.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: alwaysCancel,
+        confirmRename: alwaysConfirm,
+      },
+    );
+
+    expect(outcome).toEqual({ kind: "cancelled" });
+    expect(await vault.exists("notes/todo.md")).toBe(true);
+    expect(jobQueue.size()).toBe(0);
+  });
+
+  it("passes the first 800 chars of the file to the confirm handler", async () => {
+    const content = "A".repeat(1200);
+    const vault = makeVault({ "notes/big.md": content });
+    const jobQueue = new InMemoryJobQueue();
+
+    let receivedPreview = "";
+    await runDestructiveOp(
+      { kind: "delete", path: "notes/big.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: (_path, preview) => {
+          receivedPreview = preview;
+          return Promise.resolve("confirmed");
+        },
+        confirmRename: alwaysConfirm,
+      },
+    );
+
+    expect(receivedPreview).toHaveLength(800);
+  });
+
+  it("passes the file path to the confirm handler", async () => {
+    const vault = makeVault({ "inbox/note.md": "body" });
+    const jobQueue = new InMemoryJobQueue();
+
+    let receivedPath = "";
+    await runDestructiveOp(
+      { kind: "delete", path: "inbox/note.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: (path) => {
+          receivedPath = path;
+          return Promise.resolve("confirmed");
+        },
+        confirmRename: alwaysConfirm,
+      },
+    );
+
+    expect(receivedPath).toBe("inbox/note.md");
+  });
+
+  it("still calls confirmDelete when the file cannot be read (missing)", async () => {
+    // File exists for trash but not for read — we use two different vaults to
+    // simulate a race, but here we verify the handler is called even if read fails.
+    const vault = makeVault({});
+    const jobQueue = new InMemoryJobQueue();
+
+    // Patch trash so it succeeds even though the file isn't in the mock.
+    vi.spyOn(vault, "trash").mockResolvedValue(undefined);
+
+    let handlerCalled = false;
+    await runDestructiveOp(
+      { kind: "delete", path: "ghost.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: () => {
+          handlerCalled = true;
+          return Promise.resolve("confirmed");
+        },
+        confirmRename: alwaysConfirm,
+      },
+    );
+
+    expect(handlerCalled).toBe(true);
+  });
+
+  // ── Non-overridability: the confirm handler is ALWAYS called ───────────────
+
+  it("always calls confirmDelete — no caller option can bypass it", async () => {
+    const vault = makeVault({ "private/diary.md": "secret" });
+    const jobQueue = new InMemoryJobQueue();
+
+    let callCount = 0;
+    const trackingConfirm = (): Promise<ConfirmDecision> => {
+      callCount++;
+      return Promise.resolve("confirmed");
+    };
+
+    // Call under different 'settings-like' conditions — the handler is always
+    // invoked because the contract hard-wires it into CONFIRM state.
+    for (const path of ["private/diary.md"]) {
+      // Recreate the file each time so trash doesn't throw on the second pass.
+      vault.setFile(path, "secret");
+
+      await runDestructiveOp(
+        { kind: "delete", path },
+        {
+          vault,
+          jobQueue,
+          confirmDelete: trackingConfirm,
+          confirmRename: alwaysConfirm,
+          // No alwaysPreview flag — delete never reads a settings flag.
+        },
+      );
+    }
+
+    expect(callCount).toBe(1);
+  });
+});
+
+// ── Rename path ───────────────────────────────────────────────────────────────
+
+describe("runDestructiveOp — rename", () => {
+  it("renames the file and enqueues a rename job on confirm", async () => {
+    const vault = makeVault({ "notes/old.md": "body" });
+    const jobQueue = new InMemoryJobQueue();
+
+    const outcome = await runDestructiveOp(
+      { kind: "rename", from: "notes/old.md", to: "notes/new.md", affectedLinkCount: 3 },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: alwaysConfirm,
+        confirmRename: alwaysConfirm,
+      },
+    );
+
+    expect(outcome).toEqual({
+      kind: "done",
+      op: { kind: "rename", from: "notes/old.md", to: "notes/new.md", affectedLinkCount: 3 },
+    });
+    expect(await vault.exists("notes/old.md")).toBe(false);
+    expect(await vault.exists("notes/new.md")).toBe(true);
+    expect(jobQueue.drain()).toEqual([
+      { kind: "rename", from: "notes/old.md", to: "notes/new.md" },
+    ]);
+  });
+
+  it("returns cancelled and leaves files unchanged when user cancels", async () => {
+    const vault = makeVault({ "notes/old.md": "body" });
+    const jobQueue = new InMemoryJobQueue();
+
+    const outcome = await runDestructiveOp(
+      { kind: "rename", from: "notes/old.md", to: "notes/new.md", affectedLinkCount: 0 },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: alwaysConfirm,
+        confirmRename: alwaysCancel,
+      },
+    );
+
+    expect(outcome).toEqual({ kind: "cancelled" });
+    expect(await vault.exists("notes/old.md")).toBe(true);
+    expect(await vault.exists("notes/new.md")).toBe(false);
+    expect(jobQueue.size()).toBe(0);
+  });
+
+  it("passes from, to, and affectedLinkCount to the confirm handler", async () => {
+    const vault = makeVault({ "a.md": "x" });
+    const jobQueue = new InMemoryJobQueue();
+
+    let args: [string, string, number] | null = null;
+    await runDestructiveOp(
+      { kind: "rename", from: "a.md", to: "b.md", affectedLinkCount: 7 },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: alwaysConfirm,
+        confirmRename: (from, to, count) => {
+          args = [from, to, count];
+          return Promise.resolve("confirmed");
+        },
+      },
+    );
+
+    expect(args).toEqual(["a.md", "b.md", 7]);
+  });
+});
+
+// ── Event log ─────────────────────────────────────────────────────────────────
+
+describe("runDestructiveOp — event log", () => {
+  it("logs CONFIRM → EXECUTE → UPDATE_INDEX → DONE for a confirmed delete", async () => {
+    const vault = makeVault({ "x.md": "hi" });
+    const jobQueue = new InMemoryJobQueue();
+    const eventLog = new InMemoryEventLog();
+
+    await runDestructiveOp(
+      { kind: "delete", path: "x.md" },
+      { vault, jobQueue, confirmDelete: alwaysConfirm, confirmRename: alwaysConfirm, eventLog, turnId: "t1" },
+    );
+
+    const entries = await eventLog.eventsFor("t1");
+    const states = entries.map((e) => e.state);
+    expect(states).toEqual(["CONFIRM", "EXECUTE", "UPDATE_INDEX", "DONE"]);
+  });
+
+  it("logs CONFIRM → CANCELLED when user cancels", async () => {
+    const vault = makeVault({ "x.md": "hi" });
+    const jobQueue = new InMemoryJobQueue();
+    const eventLog = new InMemoryEventLog();
+
+    await runDestructiveOp(
+      { kind: "delete", path: "x.md" },
+      { vault, jobQueue, confirmDelete: alwaysCancel, confirmRename: alwaysConfirm, eventLog, turnId: "t2" },
+    );
+
+    const entries = await eventLog.eventsFor("t2");
+    const states = entries.map((e) => e.state);
+    expect(states).toEqual(["CONFIRM", "CANCELLED"]);
+  });
+
+  it("logs TOOL_FAILED when the vault operation throws", async () => {
+    const vault = makeVault({});
+    const jobQueue = new InMemoryJobQueue();
+    const eventLog = new InMemoryEventLog();
+
+    vi.spyOn(vault, "trash").mockRejectedValue(new Error("disk full"));
+
+    await expect(
+      runDestructiveOp(
+        { kind: "delete", path: "missing.md" },
+        { vault, jobQueue, confirmDelete: alwaysConfirm, confirmRename: alwaysConfirm, eventLog, turnId: "t3" },
+      ),
+    ).rejects.toThrow("disk full");
+
+    const entries = await eventLog.eventsFor("t3");
+    const states = entries.map((e) => e.state);
+    expect(states).toContain("TOOL_FAILED");
+  });
+});

--- a/src/services/destructive-op-machine.ts
+++ b/src/services/destructive-op-machine.ts
@@ -1,0 +1,152 @@
+import type { EventLog, EventLogEntry, JobQueue, VaultService } from "../contracts";
+
+// ── Op types ──────────────────────────────────────────────────────────────────
+
+export type DestructiveOp =
+  | { kind: "delete"; path: string }
+  | { kind: "rename"; from: string; to: string; affectedLinkCount: number };
+
+export type ConfirmDecision = "confirmed" | "cancelled";
+
+/**
+ * Called when Gemma invokes `delete_note`. The handler MUST show an explicit
+ * confirmation modal. It is called unconditionally — no setting, flag, or
+ * caller option can bypass it. Non-overridable by design.
+ *
+ * `contentPreview` is the first 800 characters of the file, included so the
+ * modal can show the user what they are about to delete.
+ */
+export type DeleteConfirmHandler = (
+  path: string,
+  contentPreview: string,
+) => Promise<ConfirmDecision>;
+
+/**
+ * Called when Gemma invokes `rename_or_move_note`. The operation is safe and
+ * reversible (Obsidian maintains link integrity), so the caller may auto-confirm
+ * when the user has disabled "Always preview."
+ */
+export type RenameConfirmHandler = (
+  from: string,
+  to: string,
+  affectedLinkCount: number,
+) => Promise<ConfirmDecision>;
+
+export type DestructiveOutcome =
+  | { kind: "done"; op: DestructiveOp }
+  | { kind: "cancelled" };
+
+export interface DestructiveOpDeps {
+  vault: VaultService;
+  jobQueue: JobQueue;
+  /**
+   * Always called for `delete_note` — non-overridable regardless of any
+   * settings. The handler is responsible for showing the mandatory modal.
+   */
+  confirmDelete: DeleteConfirmHandler;
+  /**
+   * Called for `rename_or_move_note`. May auto-confirm when the caller opts
+   * out of always-preview, since rename is safe and reversible.
+   */
+  confirmRename: RenameConfirmHandler;
+  eventLog?: EventLog;
+  turnId?: string;
+}
+
+// ── State names ───────────────────────────────────────────────────────────────
+
+const STATES = {
+  confirm: "CONFIRM",
+  execute: "EXECUTE",
+  updateIndex: "UPDATE_INDEX",
+  done: "DONE",
+  cancelled: "CANCELLED",
+  failed: "TOOL_FAILED",
+} as const;
+
+// ── Orchestrator ──────────────────────────────────────────────────────────────
+
+/**
+ * Drives the destructive-op mini state machine (#44):
+ *   TOOL_CALL → CONFIRM → EXECUTE → UPDATE_INDEX → DONE
+ *                       ↘ CANCELLED (user declined)
+ *
+ * Delete always requires an explicit confirmation modal — non-overridable.
+ * Rename uses a standard preview gate that the caller may auto-confirm.
+ */
+export async function runDestructiveOp(
+  op: DestructiveOp,
+  deps: DestructiveOpDeps,
+): Promise<DestructiveOutcome> {
+  const turnId = deps.turnId ?? crypto.randomUUID();
+  let prevState = "TOOL_CALL";
+
+  const enter = async (state: string, payload?: Record<string, unknown>) => {
+    if (!deps.eventLog) return;
+    const entry: EventLogEntry = {
+      turnId,
+      kind: "enter",
+      state,
+      fromState: prevState,
+      timestamp: Date.now(),
+      triggeringEvent: payload
+        ? { kind: "tool_result", name: state, payload }
+        : null,
+    };
+    await deps.eventLog.write(entry);
+    prevState = state;
+  };
+
+  // ── CONFIRM ───────────────────────────────────────────────────────────────
+  await enter(STATES.confirm, { op: op.kind });
+
+  let decision: ConfirmDecision;
+  if (op.kind === "delete") {
+    let contentPreview = "";
+    try {
+      const full = await deps.vault.read(op.path);
+      contentPreview = full.slice(0, 800);
+    } catch {
+      contentPreview = "(could not read file)";
+    }
+    // confirmDelete is ALWAYS called — the handler owns the non-overridable modal.
+    decision = await deps.confirmDelete(op.path, contentPreview);
+  } else {
+    decision = await deps.confirmRename(op.from, op.to, op.affectedLinkCount);
+  }
+
+  if (decision === "cancelled") {
+    await enter(STATES.cancelled, { from: "confirm" });
+    return { kind: "cancelled" };
+  }
+
+  // ── EXECUTE ───────────────────────────────────────────────────────────────
+  await enter(STATES.execute, { op: op.kind });
+  try {
+    if (op.kind === "delete") {
+      await deps.vault.trash(op.path);
+    } else {
+      await deps.vault.rename(op.from, op.to);
+    }
+  } catch (err) {
+    await enter(STATES.failed, { reason: stringifyError(err) });
+    throw err;
+  }
+
+  // ── UPDATE_INDEX ──────────────────────────────────────────────────────────
+  if (op.kind === "delete") {
+    deps.jobQueue.enqueue({ kind: "delete", path: op.path });
+  } else {
+    deps.jobQueue.enqueue({ kind: "rename", from: op.from, to: op.to });
+  }
+  await enter(STATES.updateIndex, { op: op.kind });
+
+  // ── DONE ──────────────────────────────────────────────────────────────────
+  await enter(STATES.done, { op: op.kind });
+  return { kind: "done", op };
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/services/preview-gate.test.ts
+++ b/src/services/preview-gate.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { runDestructiveOp } from "./destructive-op-machine";
+
+/**
+ * Preview-gate tests for #63.
+ *
+ * Validates that:
+ * - delete_note always fires its confirm handler regardless of any caller
+ *   option (including alwaysPreview=false equivalents).
+ * - rename_or_move_note routes through its confirm handler and can be
+ *   auto-confirmed by the caller (settings-bypass path).
+ * - Confirmed saves from the ingest path are unaffected by delete gate
+ *   (orthogonal concerns).
+ */
+
+describe("preview gate — delete is non-overridable", () => {
+  it("delete confirm fires even when the rename handler auto-confirms (no alwaysPreview analog)", async () => {
+    const vault = new MockVaultService({ "notes/x.md": "body" });
+    const jobQueue = new InMemoryJobQueue();
+
+    let deleteConfirmCalled = false;
+
+    const outcome = await runDestructiveOp(
+      { kind: "delete", path: "notes/x.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: () => {
+          deleteConfirmCalled = true;
+          return Promise.resolve("confirmed");
+        },
+        // The rename handler is irrelevant here — delete never consults it.
+        confirmRename: () => Promise.resolve("confirmed"),
+      },
+    );
+
+    expect(deleteConfirmCalled).toBe(true);
+    expect(outcome.kind).toBe("done");
+  });
+
+  it("delete confirm fires even when a caller passes an auto-confirm rename handler (preview-off path)", async () => {
+    // Simulates: alwaysPreview=false wired to auto-confirm rename but delete
+    // still goes through the mandatory modal.
+    const vault = new MockVaultService({ "notes/y.md": "body" });
+    const jobQueue = new InMemoryJobQueue();
+
+    const autoConfirmRename = () => Promise.resolve("confirmed" as const);
+
+    let deleteHandlerCalled = false;
+
+    await runDestructiveOp(
+      { kind: "delete", path: "notes/y.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: () => {
+          deleteHandlerCalled = true;
+          return Promise.resolve("confirmed");
+        },
+        confirmRename: autoConfirmRename,
+      },
+    );
+
+    expect(deleteHandlerCalled).toBe(true);
+  });
+
+  it("delete is cancelled when the confirm handler returns cancelled, regardless of rename auto-confirm", async () => {
+    const vault = new MockVaultService({ "notes/z.md": "body" });
+    const jobQueue = new InMemoryJobQueue();
+
+    const outcome = await runDestructiveOp(
+      { kind: "delete", path: "notes/z.md" },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: () => Promise.resolve("cancelled"),
+        confirmRename: () => Promise.resolve("confirmed"), // doesn't matter
+      },
+    );
+
+    expect(outcome.kind).toBe("cancelled");
+    // File must be intact.
+    expect(await vault.exists("notes/z.md")).toBe(true);
+  });
+});
+
+describe("preview gate — rename respects caller's bypass decision", () => {
+  it("rename auto-confirms when the caller passes an auto-confirming handler (alwaysPreview=false path)", async () => {
+    const vault = new MockVaultService({ "a.md": "content" });
+    const jobQueue = new InMemoryJobQueue();
+
+    // Caller wires: alwaysPreview=false → auto-confirm for rename (safe + reversible).
+    const outcome = await runDestructiveOp(
+      { kind: "rename", from: "a.md", to: "b.md", affectedLinkCount: 0 },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: () => Promise.resolve("confirmed"),
+        confirmRename: () => Promise.resolve("confirmed"),
+      },
+    );
+
+    expect(outcome.kind).toBe("done");
+    expect(await vault.exists("b.md")).toBe(true);
+    expect(await vault.exists("a.md")).toBe(false);
+  });
+
+  it("rename is cancelled when the confirm handler returns cancelled", async () => {
+    const vault = new MockVaultService({ "c.md": "content" });
+    const jobQueue = new InMemoryJobQueue();
+
+    const outcome = await runDestructiveOp(
+      { kind: "rename", from: "c.md", to: "d.md", affectedLinkCount: 2 },
+      {
+        vault,
+        jobQueue,
+        confirmDelete: () => Promise.resolve("confirmed"),
+        confirmRename: () => Promise.resolve("cancelled"),
+      },
+    );
+
+    expect(outcome.kind).toBe("cancelled");
+    expect(await vault.exists("c.md")).toBe(true);
+  });
+});

--- a/src/services/real-vault.ts
+++ b/src/services/real-vault.ts
@@ -48,6 +48,16 @@ export class ObsidianVaultService implements VaultService {
     );
   }
 
+  async trash(path: string): Promise<void> {
+    const file = this.requireFile(path);
+    await this.app.vault.trash(file, true);
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    const file = this.requireFile(from);
+    await this.app.fileManager.renameFile(file, to);
+  }
+
   private requireFile(path: string): TFile {
     const file = this.app.vault.getFileByPath(path);
     if (!file) throw new Error(`File not found: ${path}`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,13 @@ export interface GemmeraSettings {
 
   /** Cosine score above which a similar note is treated as a near-duplicate. */
   dedupThreshold: number;
+
+  /**
+   * Wall-clock budget per turn in milliseconds. Clamped to
+   * HARD_STOPS.WALL_CLOCK_MS_MAX (300 000 ms) on load. Other hard-stop
+   * ceilings (tool calls, no-ops, retries) are constants and not exposed here.
+   */
+  turnTimeoutMs: number;
 }
 
 export const DEFAULT_SETTINGS: GemmeraSettings = {
@@ -34,4 +41,5 @@ export const DEFAULT_SETTINGS: GemmeraSettings = {
   alwaysPreviewBeforeSave: true,
   inboxFolder: "Inbox/",
   dedupThreshold: 0.85,
+  turnTimeoutMs: 120_000,
 };

--- a/src/ui/delete-confirm-modal.ts
+++ b/src/ui/delete-confirm-modal.ts
@@ -1,0 +1,82 @@
+import { Modal, type App } from "obsidian";
+import type { ConfirmDecision } from "../services/destructive-op-machine";
+
+/**
+ * Mandatory, non-overridable delete confirmation modal (#44).
+ *
+ * Shows the target file path and a content preview. The user must click
+ * "Delete" to proceed; closing the modal by any other means (Esc, clicking
+ * outside) resolves to "cancelled". No setting can bypass this modal.
+ */
+export function openDeleteConfirm(
+  app: App,
+  path: string,
+  contentPreview: string,
+): Promise<ConfirmDecision> {
+  return new Promise((resolve) => {
+    const modal = new DeleteConfirmModal(app, path, contentPreview, (decision) => {
+      modal.close();
+      resolve(decision);
+    });
+    modal.open();
+  });
+}
+
+class DeleteConfirmModal extends Modal {
+  private resolved = false;
+
+  constructor(
+    app: App,
+    private readonly path: string,
+    private readonly contentPreview: string,
+    private readonly onDecide: (d: ConfirmDecision) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this as unknown as { contentEl: HTMLElement };
+    contentEl.empty();
+
+    contentEl.createEl("h2", { text: "Delete note?" });
+    contentEl.createEl("p", { text: this.path, cls: "gemmera-delete-path" });
+
+    if (this.contentPreview) {
+      contentEl.createEl("h3", { text: "Preview" });
+      const pre = contentEl.createEl("pre", { cls: "gemmera-delete-preview" });
+      pre.setText(this.contentPreview);
+    }
+
+    contentEl.createEl("p", {
+      text: "This will move the note to the Obsidian trash. You can restore it from there.",
+      cls: "gemmera-delete-hint",
+    });
+
+    const actions = contentEl.createEl("div", { cls: "gemmera-delete-actions" });
+
+    const deleteBtn = actions.createEl("button", {
+      text: "Delete",
+      cls: "gemmera-delete-btn gemmera-delete-btn--destructive",
+    });
+    deleteBtn.addEventListener("click", () => this.decide("confirmed"));
+
+    const cancelBtn = actions.createEl("button", {
+      text: "Cancel",
+      cls: "gemmera-delete-btn",
+    });
+    cancelBtn.addEventListener("click", () => this.decide("cancelled"));
+  }
+
+  onClose(): void {
+    if (!this.resolved) {
+      this.resolved = true;
+      this.onDecide("cancelled");
+    }
+  }
+
+  private decide(d: ConfirmDecision): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.onDecide(d);
+  }
+}

--- a/src/ui/delete-confirm-modal.ts
+++ b/src/ui/delete-confirm-modal.ts
@@ -48,7 +48,7 @@ class DeleteConfirmModal extends Modal {
     }
 
     contentEl.createEl("p", {
-      text: "This will move the note to the Obsidian trash. You can restore it from there.",
+      text: "This will move the note to your system trash (Finder Trash / Recycle Bin). You can restore it from there.",
       cls: "gemmera-delete-hint",
     });
 

--- a/src/ui/rename-preview-modal.ts
+++ b/src/ui/rename-preview-modal.ts
@@ -1,0 +1,96 @@
+import { Modal, type App } from "obsidian";
+import type { ConfirmDecision } from "../services/destructive-op-machine";
+
+/**
+ * Standard preview gate for rename_or_move_note (#63).
+ *
+ * Shows the from/to paths and the number of notes whose links will be
+ * updated. Respects the "Always preview" setting — the caller may
+ * auto-confirm when the user has disabled it, since rename is safe and
+ * reversible (Obsidian maintains link integrity via FileManager.renameFile).
+ *
+ * Unlike DeleteConfirmModal this modal can be bypassed by settings.
+ */
+export function openRenamePreview(
+  app: App,
+  from: string,
+  to: string,
+  affectedLinkCount: number,
+): Promise<ConfirmDecision> {
+  return new Promise((resolve) => {
+    const modal = new RenamePreviewModal(app, from, to, affectedLinkCount, (decision) => {
+      modal.close();
+      resolve(decision);
+    });
+    modal.open();
+  });
+}
+
+class RenamePreviewModal extends Modal {
+  private resolved = false;
+
+  constructor(
+    app: App,
+    private readonly from: string,
+    private readonly to: string,
+    private readonly affectedLinkCount: number,
+    private readonly onDecide: (d: ConfirmDecision) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this as unknown as { contentEl: HTMLElement };
+    contentEl.empty();
+
+    contentEl.createEl("h2", { text: "Rename / move note?" });
+
+    const table = contentEl.createEl("table", { cls: "gemmera-rename-table" });
+    const fromRow = table.createEl("tr");
+    fromRow.createEl("th", { text: "From" });
+    fromRow.createEl("td", { text: this.from, cls: "gemmera-rename-path" });
+    const toRow = table.createEl("tr");
+    toRow.createEl("th", { text: "To" });
+    toRow.createEl("td", { text: this.to, cls: "gemmera-rename-path" });
+
+    if (this.affectedLinkCount > 0) {
+      const s = this.affectedLinkCount === 1 ? "link" : "links";
+      contentEl.createEl("p", {
+        text: `${this.affectedLinkCount} ${s} in your vault will be updated automatically.`,
+        cls: "gemmera-rename-hint",
+      });
+    } else {
+      contentEl.createEl("p", {
+        text: "No other notes link to this file.",
+        cls: "gemmera-rename-hint",
+      });
+    }
+
+    const actions = contentEl.createEl("div", { cls: "gemmera-rename-actions" });
+
+    const renameBtn = actions.createEl("button", {
+      text: "Rename",
+      cls: "gemmera-rename-btn gemmera-rename-btn--primary",
+    });
+    renameBtn.addEventListener("click", () => this.decide("confirmed"));
+
+    const cancelBtn = actions.createEl("button", {
+      text: "Cancel",
+      cls: "gemmera-rename-btn",
+    });
+    cancelBtn.addEventListener("click", () => this.decide("cancelled"));
+  }
+
+  onClose(): void {
+    if (!this.resolved) {
+      this.resolved = true;
+      this.onDecide("cancelled");
+    }
+  }
+
+  private decide(d: ConfirmDecision): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.onDecide(d);
+  }
+}

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,5 +1,6 @@
 import { Notice, PluginSettingTab, Setting, type App, type Plugin } from "obsidian";
 import type { DriftReport, IngestionStore } from "../contracts";
+import { HARD_STOPS } from "../contracts/hard-stops";
 import type { RunnerControls } from "../services/runner-controls";
 import type { ScheduledReconciler } from "../services/scheduled-reconciler";
 import type { GemmeraSettings } from "../settings";
@@ -157,6 +158,23 @@ export class GemmeraSettingsTab extends PluginSettingTab {
           const parsed = Number(value);
           if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return;
           this.settings.dedupThreshold = parsed;
+          await this.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Turn timeout (seconds)")
+      .setDesc(
+        `Wall-clock budget per chat turn. Default 120 s, max ${HARD_STOPS.WALL_CLOCK_MS_MAX / 1000} s. Increase on slow hardware.`,
+      )
+      .addText((text: { setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown; setPlaceholder?: (s: string) => unknown }) => {
+        text.setPlaceholder?.("120");
+        text.setValue(String(this.settings.turnTimeoutMs / 1000));
+        text.onChange(async (value: string) => {
+          const secs = Number(value);
+          if (!Number.isFinite(secs) || secs <= 0) return;
+          const ms = Math.min(secs * 1000, HARD_STOPS.WALL_CLOCK_MS_MAX);
+          this.settings.turnTimeoutMs = ms;
           await this.saveSettings();
         });
       });


### PR DESCRIPTION
## What

Tool-loop milestone batch — six issues closed in one PR.

**#44 — Destructive-op mini state machine (delete + rename/move)**
- `VaultService` contract: added `trash()` and `rename()`; implemented in `ObsidianVaultService` and `MockVaultService`
- `runDestructiveOp()` orchestrator: `CONFIRM → EXECUTE → UPDATE_INDEX → DONE` (or `CANCELLED`). Delete always calls `confirmDelete` — non-overridable by design. Rename calls `confirmRename`, which callers may auto-confirm for the preview-off path.
- `DeleteConfirmModal`: mandatory modal showing file path + content preview; Esc resolves to cancelled
- 12 unit tests including the non-overridability acceptance test

**#63 — Preview gate for write tools (with non-overridable delete)**
- `RenamePreviewModal`: standard preview gate showing from/to paths + affected-link count; Esc resolves to cancelled; bypassable by caller (safe + reversible)
- `preview-gate.test.ts`: 5 tests verifying delete always fires and rename respects the caller's bypass decision

**#36 — Per-turn hard stops**
- `turnTimeoutMs` added to `GemmeraSettings` (default 120 000 ms, clamped to `HARD_STOPS.WALL_CLOCK_MS_MAX`)
- Setting exposed in the settings tab with runtime validation
- `HARD_STOPS` constants (`MAX_TOOL_CALLS_PER_TURN`, `WALL_CLOCK_MS_PER_TURN`, etc.) were already in `contracts/hard-stops.ts`; state machine already enforces them

**#60 — Cancellation + per-turn timeout with shared unwind**
- `cancellation.test.ts`: 12 tests using query-SM state names (RETRIEVE, RERANK, GENERATE)
  - Cancel during GENERATE → CANCELLED, signal aborted
  - Cancel during long tool call in RETRIEVE → signal aborted
  - Timeout during RERANK → TIMED_OUT
  - Timeout during GENERATE → TIMED_OUT
  - Natural completion clears the timer
  - Unwind hook order: stop → drop → rollback → events → notice (cancel and timeout)
  - Failing hook does not block later hooks
  - Queued turn auto-starts after cancelled turn; committed log entries are preserved

**#35 — Event log writer + deterministic replay** *(already implemented in dev)*
`InMemoryEventLog`, `replayTurn`, redact hook, and replay tests were shipped in `feat(tool-loop): state machine foundation`. Closes here.

**#54 — JSON-schema constrained decoding** *(already implemented in dev)*
`JsonConstrainedDecoder` (AJV), `SchemaRegistry`, `benchmarkDecoder`, `escapeHatch`, and `format: "json"` wiring in `ingest-parser.ts` and `ingest-strategy.ts` were shipped in earlier PRs. Closes here.

**#37 — Prompt library scaffold + version stamping** *(already implemented in dev)*
`FilePromptLoader`, all six prompt files with `version:` headers, and `cowork.version` frontmatter stamping in `ingest-writer.ts` were shipped in earlier PRs. Closes here.

## How to test

```
npm test   # 532 tests, all green
```

Closes #35
Closes #36
Closes #37
Closes #44
Closes #54
Closes #60
Closes #63