### PR TITLE
feat(tool-loop): query state machine and ingest SM close-out (#41, #39)

### DIFF
--- a/src/contracts/ingest.ts
+++ b/src/contracts/ingest.ts
@@ -55,11 +55,15 @@ export interface NoteSpec {
  * - `append`: append the body under a dated heading in `target`.
  * - `dedup_ask`: a near or exact duplicate exists; the preview modal asks
  *    the user to append, save anyway, or cancel. `target` is the matched note.
+ * - `split`: the content covers multiple distinct topics. `candidates` are
+ *    the individual NoteSpecs derived from each section. The preview shows
+ *    them as a list; the user confirms each independently or all-at-once.
  */
 export type IngestStrategy =
   | { kind: "create"; related: string[] }
   | { kind: "append"; target: string }
-  | { kind: "dedup_ask"; target: string; similarity: number };
+  | { kind: "dedup_ask"; target: string; similarity: number }
+  | { kind: "split"; candidates: NoteSpec[] };
 
 /** What the user picked in the dedup modal. */
 export type DedupChoice = "append" | "save_anyway" | "cancel";
@@ -73,6 +77,7 @@ export interface IngestInput {
 
 export type IngestOutcome =
   | { kind: "saved"; path: string; mode: "create" | "append"; spec: NoteSpec }
+  | { kind: "split_saved"; paths: string[]; specs: NoteSpec[] }
   | { kind: "skipped_existing"; path: string; reason: "exact_duplicate" }
   | { kind: "cancelled" }
   | { kind: "failed"; reason: string };

--- a/src/services/ingest-orchestrator.test.ts
+++ b/src/services/ingest-orchestrator.test.ts
@@ -398,7 +398,6 @@ describe("runIngest", () => {
       text: "text", headingPath: [], score: 0.5, winningSignal: "semantic",
     };
 
-    const { deps, queue } = setup({ preview: async () => ({ action: "cancel" }) });
     const vault = new MockVaultService();
     const store = new InMemoryIngestionStore();
     const newQueue = new InMemoryJobQueue();

--- a/src/services/ingest-orchestrator.test.ts
+++ b/src/services/ingest-orchestrator.test.ts
@@ -270,6 +270,160 @@ describe("runIngest", () => {
     expect(states).toContain("WRITE");
     expect(states).toContain("UPDATE_INDEX");
     expect(states).toContain("DONE");
+    // First PARSE_CONTENT entry should come from CLASSIFY_INTENT (#39)
+    const parseEntry = entries.find((e) => e.state === "PARSE_CONTENT");
+    expect(parseEntry?.fromState).toBe("CLASSIFY_INTENT");
+  });
+
+  it("PROPOSE_SPLIT: previews all candidates and writes confirmed ones (#39)", async () => {
+    // Build a spec whose body has two level-2 heading sections so
+    // splitSpecByHeadings produces two candidates when the LLM returns "split".
+    const splitBody = "## Topic A\n\nContent about topic A.\n\n## Topic B\n\nContent about topic B.";
+    const splitSpecJson = JSON.stringify({
+      title: "Multi-topic note",
+      type: "concept",
+      tags: [],
+      aliases: [],
+      source: "chat-paste",
+      entities: [],
+      related: [],
+      status: "inbox",
+      summary: "Two topics",
+      key_points: [],
+      body_markdown: splitBody,
+      confidence: "high",
+    });
+    // LLM replies: first call is parseContent, second is decideStrategy (dedup-decider).
+    // We need the strategy to come out as "split". The strategy LLM call (decideStrategy)
+    // is only triggered if hits exist and score is in the LLM range. Use low-score hits
+    // to trigger the LLM path, then have LLM return "split".
+    const splitReply = JSON.stringify({ strategy: "split", reason: "two topics" });
+
+    // StaticLLM always returns the same reply, so we need a sequencing LLM.
+    class TwoReplyLLM implements LLMService {
+      private calls = 0;
+      private readonly replies = [splitSpecJson, splitReply];
+      async chat(_opts: ChatOptions): Promise<LLMResponse> {
+        const r = this.replies[this.calls] ?? this.replies[this.replies.length - 1];
+        this.calls++;
+        return { content: r };
+      }
+      async isReachable(): Promise<LLMReachability> { return "running"; }
+      async listModels() { return []; }
+      async pickDefaultModel() { return "mock"; }
+    }
+
+    // Use a retriever hit with a mid-range score (triggers LLM branch).
+    const midHit: RetrievalHit = {
+      path: "Notes/other.md",
+      title: "other",
+      ord: 0,
+      contentHash: "h1",
+      text: "Some related text",
+      headingPath: [],
+      score: 0.5,
+      winningSignal: "semantic",
+    };
+
+    let receivedKind = "";
+    let receivedCount = 0;
+    const splitHandler: PreviewHandler = async (preview) => {
+      receivedKind = preview.kind;
+      receivedCount = preview.candidates?.length ?? 0;
+      return {
+        action: "split_confirm",
+        confirmed: preview.candidates ?? [],
+      };
+    };
+
+    const vault = new MockVaultService();
+    const store = new InMemoryIngestionStore();
+    const queue = new InMemoryJobQueue();
+    const writer = new IngestWriter(vault);
+    const llm = new TwoReplyLLM();
+
+    const result = await runIngest(
+      { text: "Multi-topic content" },
+      {
+        llm,
+        promptLoader,
+        retriever: new StubRetriever([midHit]),
+        store,
+        vault,
+        writer,
+        jobQueue: queue,
+        preview: splitHandler,
+        inboxFolder: "Inbox/",
+        runId: () => "run-1",
+        model: "test-model",
+        version: "0.0.1",
+      },
+    );
+
+    expect(result.kind).toBe("split_saved");
+    if (result.kind !== "split_saved") return;
+    expect(result.paths).toHaveLength(2);
+    expect(result.specs).toHaveLength(2);
+    expect(receivedKind).toBe("split");
+    expect(receivedCount).toBe(2);
+    expect(queue.size()).toBe(2);
+  });
+
+  it("PROPOSE_SPLIT: cancel in split preview returns cancelled", async () => {
+    const splitBody = "## Section A\n\nA content.\n\n## Section B\n\nB content.";
+    const splitSpecJson = JSON.stringify({
+      title: "Two topics",
+      type: "concept",
+      tags: [], aliases: [], source: "chat-paste", entities: [], related: [],
+      status: "inbox", summary: "split", key_points: [],
+      body_markdown: splitBody, confidence: "high",
+    });
+    const splitReply = JSON.stringify({ strategy: "split", reason: "two topics" });
+
+    class TwoReplyLLM implements LLMService {
+      private calls = 0;
+      private readonly replies = [splitSpecJson, splitReply];
+      async chat(_opts: ChatOptions): Promise<LLMResponse> {
+        const r = this.replies[this.calls] ?? this.replies[this.replies.length - 1];
+        this.calls++;
+        return { content: r };
+      }
+      async isReachable(): Promise<LLMReachability> { return "running"; }
+      async listModels() { return []; }
+      async pickDefaultModel() { return "mock"; }
+    }
+
+    const midHit: RetrievalHit = {
+      path: "Notes/other.md", title: "other", ord: 0, contentHash: "h1",
+      text: "text", headingPath: [], score: 0.5, winningSignal: "semantic",
+    };
+
+    const { deps, queue } = setup({ preview: async () => ({ action: "cancel" }) });
+    const vault = new MockVaultService();
+    const store = new InMemoryIngestionStore();
+    const newQueue = new InMemoryJobQueue();
+    const writer = new IngestWriter(vault);
+
+    const result = await runIngest(
+      { text: "Two topics" },
+      {
+        llm: new TwoReplyLLM(),
+        promptLoader,
+        retriever: new StubRetriever([midHit]),
+        store,
+        vault,
+        writer,
+        jobQueue: newQueue,
+        preview: async () => ({ action: "cancel" }),
+        inboxFolder: "Inbox/",
+        runId: () => "run-1",
+        model: "test-model",
+        version: "0.0.1",
+      },
+    );
+
+    expect(result.kind).toBe("cancelled");
+    expect(newQueue.size()).toBe(0);
   });
 });
 

--- a/src/services/ingest-orchestrator.ts
+++ b/src/services/ingest-orchestrator.ts
@@ -31,17 +31,20 @@ const STATES = {
 } as const;
 
 export interface IngestPreview {
-  /** "save" | "append" | "dedup" — drives which buttons the preview shows. */
-  kind: "save" | "append" | "dedup";
+  /** Drives which buttons the preview shows. */
+  kind: "save" | "append" | "dedup" | "split";
   spec: NoteSpec;
   strategy: IngestStrategy;
+  /** Only set when kind === "split". All split candidates. */
+  candidates?: NoteSpec[];
 }
 
 export type PreviewDecision =
   | { action: "confirm" }
   | { action: "edit"; spec: NoteSpec }
   | { action: "cancel" }
-  | { action: "dedup_choice"; choice: DedupChoice };
+  | { action: "dedup_choice"; choice: DedupChoice }
+  | { action: "split_confirm"; confirmed: NoteSpec[] };
 
 export type PreviewHandler = (
   preview: IngestPreview,
@@ -92,7 +95,9 @@ export async function runIngest(
   deps: IngestOrchestratorDeps,
 ): Promise<IngestOutcome> {
   const turnId = deps.turnId ?? freshTurnId();
-  let prevState = "IDLE";
+  // Classification happens upstream (classifier-orchestrator); ingest picks up
+  // from the state the classifier left on exit.
+  let prevState = "CLASSIFY_INTENT";
   const enter = async (state: string, payload?: Record<string, unknown>) => {
     if (!deps.eventLog) return;
     const entry: EventLogEntry = {
@@ -154,12 +159,52 @@ export async function runIngest(
 
   // ── PREVIEW ──────────────────────────────────────────────────────────
   // Bypass when the user has opted out of always-preview AND the case is
-  // unambiguous: a plain create with high confidence. Append and dedup_ask
-  // always preview — they touch existing notes.
+  // unambiguous: a plain create with high confidence. Append, dedup_ask,
+  // and split always preview — they touch existing notes or write multiple.
   const skipPreview =
     deps.alwaysPreview === false &&
     strategy.kind === "create" &&
     spec.cowork.confidence === "high";
+
+  // ── SPLIT PREVIEW ─────────────────────────────────────────────────────
+  if (strategy.kind === "split") {
+    await enter(STATES.preview, { kind: "split", count: strategy.candidates.length });
+    const result = await deps.preview({
+      kind: "split",
+      spec: strategy.candidates[0] ?? spec,
+      strategy,
+      candidates: strategy.candidates,
+    });
+    if (result.action === "cancel") {
+      await enter(STATES.cancelled, { from: "split_preview" });
+      return { kind: "cancelled" };
+    }
+    if (result.action !== "split_confirm") {
+      await enter(STATES.failed, { reason: "invalid_split_action" });
+      return { kind: "failed", reason: "invalid_split_action" };
+    }
+    const confirmed = result.confirmed;
+
+    // ── WRITE (split) ──────────────────────────────────────────────────
+    await enter(STATES.write, { kind: "split", count: confirmed.length });
+    const paths: string[] = [];
+    const specs: NoteSpec[] = [];
+    for (const candidate of confirmed) {
+      try {
+        const written = await deps.writer.writeNew(candidate, { folder: deps.inboxFolder });
+        paths.push(written.path);
+        specs.push(candidate);
+        deps.jobQueue.enqueue({ kind: "index", path: written.path });
+      } catch (err) {
+        const reason = `write:${stringifyError(err)}`;
+        await enter(STATES.failed, { reason });
+        return { kind: "failed", reason };
+      }
+    }
+    await enter(STATES.updateIndex, { paths });
+    await enter(STATES.done, { mode: "split", count: paths.length });
+    return { kind: "split_saved", paths, specs };
+  }
 
   if (!skipPreview) {
     await enter(STATES.preview, { kind: previewKindFor(strategy) });
@@ -258,6 +303,7 @@ function freshTurnId(): string {
 function previewKindFor(strategy: IngestStrategy): IngestPreview["kind"] {
   if (strategy.kind === "dedup_ask") return "dedup";
   if (strategy.kind === "append") return "append";
+  if (strategy.kind === "split") return "split";
   return "save";
 }
 

--- a/src/services/ingest-strategy.ts
+++ b/src/services/ingest-strategy.ts
@@ -176,7 +176,7 @@ async function consultLlm(
 const STRATEGY_HINT = `
 
 Return ONLY a JSON object with this shape:
-{ "strategy": "new" | "append" | "ask_user", "targetPath"?: string, "reason": string }
+{ "strategy": "new" | "append" | "ask_user" | "split", "targetPath"?: string, "reason": string }
 
 Rules:
 - "new" when the candidate is genuinely distinct from the similar notes.
@@ -184,6 +184,8 @@ Rules:
   candidate would naturally extend it. Provide its path in "targetPath".
 - "ask_user" when there's a near-duplicate but you're not sure whether to
   append or branch off. Provide the closest match in "targetPath".
+- "split" when the candidate clearly covers multiple unrelated topics that
+  should each become their own note (no "targetPath" needed).
 `;
 
 function interpret(
@@ -201,11 +203,38 @@ function interpret(
     const score = hits.find((h) => h.path === target)?.score ?? 0;
     return { kind: "dedup_ask", target, similarity: score };
   }
+  if (strategy === "split") {
+    const candidates = splitSpecByHeadings(spec);
+    if (candidates.length > 1) return { kind: "split", candidates };
+    // Degenerate: no headings to split on — fall through to create.
+  }
   if (strategy === "new") {
     const related = unique([...spec.related, ...hits.slice(0, 3).map((h) => h.path)]);
     return { kind: "create", related };
   }
   return null;
+}
+
+/**
+ * Splits a spec's body_markdown on level-2 headings. Each `## Heading`
+ * becomes a candidate NoteSpec with the heading as title and the section
+ * body as body_markdown. Returns a single-element array (the original spec)
+ * when no level-2 headings are found.
+ */
+function splitSpecByHeadings(spec: NoteSpec): NoteSpec[] {
+  const sections = spec.body_markdown.split(/(?=^## )/m);
+  if (sections.length <= 1) return [spec];
+
+  const candidates: NoteSpec[] = [];
+  for (const section of sections) {
+    const headingMatch = section.match(/^## (.+)\n([\s\S]*)$/);
+    if (!headingMatch) continue;
+    const title = headingMatch[1].trim();
+    const body = headingMatch[2].trim();
+    if (!title || !body) continue;
+    candidates.push({ ...spec, title, body_markdown: body, summary: body.slice(0, 200) });
+  }
+  return candidates.length > 0 ? candidates : [spec];
 }
 
 function sha256(s: string): string {

--- a/src/services/query-orchestrator.test.ts
+++ b/src/services/query-orchestrator.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryEventLog } from "./event-log";
+import { runQuery, type QueryOrchestratorDeps, type QueryInput } from "./query-orchestrator";
+import type {
+  ChatOptions,
+  LLMReachability,
+  LLMResponse,
+  LLMService,
+  PayloadAssembler,
+  PayloadChunk,
+  RetrievalHit,
+  RetrievalPayload,
+  Retriever,
+} from "../contracts";
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+class StubRetriever implements Retriever {
+  constructor(private readonly hits: RetrievalHit[] = []) {}
+  async retrieve(): Promise<RetrievalHit[]> {
+    return this.hits;
+  }
+}
+
+class SequenceLLM implements LLMService {
+  private calls = 0;
+  constructor(private readonly replies: string[]) {}
+  async chat(_opts: ChatOptions): Promise<LLMResponse> {
+    const reply = this.replies[this.calls] ?? this.replies[this.replies.length - 1];
+    this.calls++;
+    return { content: reply };
+  }
+  async isReachable(): Promise<LLMReachability> { return "running"; }
+  async listModels(): Promise<string[]> { return []; }
+  async pickDefaultModel(): Promise<string> { return "test-model"; }
+}
+
+class StubAssembler implements PayloadAssembler {
+  constructor(private readonly chunks: PayloadChunk[]) {}
+  assemble(query: string): RetrievalPayload {
+    return { query, chunks: this.chunks };
+  }
+}
+
+// ── Fixture helpers ───────────────────────────────────────────────────────────
+
+function makeHit(path: string, text: string): RetrievalHit {
+  return {
+    path,
+    title: path.replace(/\.md$/, "").split("/").pop() ?? path,
+    ord: 0,
+    contentHash: `hash-${path}`,
+    text,
+    headingPath: [],
+    score: 1,
+    winningSignal: "semantic",
+  };
+}
+
+function makeChunk(path: string): PayloadChunk {
+  return {
+    path,
+    title: path.replace(/\.md$/, "").split("/").pop() ?? path,
+    headingPath: [],
+    text: `Content of ${path}`,
+    whyMatched: "semantic",
+  };
+}
+
+function validReply(answer: string, citations: string[]): string {
+  return JSON.stringify({ answer, citations });
+}
+
+function setup(opts: {
+  hits?: RetrievalHit[];
+  chunks?: PayloadChunk[];
+  llmReplies?: string[];
+  reranker?: Retriever;
+  withEventLog?: true;
+}): { deps: QueryOrchestratorDeps; eventLog: InMemoryEventLog | undefined } {
+  const hits = opts.hits ?? [makeHit("Notes/a.md", "Some content")];
+  const chunks = opts.chunks ?? [makeChunk("Notes/a.md")];
+  const eventLog = opts.withEventLog ? new InMemoryEventLog() : undefined;
+  const deps: QueryOrchestratorDeps = {
+    retriever: new StubRetriever(hits),
+    assembler: new StubAssembler(chunks),
+    llm: new SequenceLLM(opts.llmReplies ?? [validReply("The answer.", ["Notes/a.md"])]),
+    reranker: opts.reranker,
+    eventLog,
+    turnId: "turn-1",
+    model: "test-model",
+  };
+  return { deps, eventLog };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("runQuery", () => {
+  it("happy path: retrieve, assemble, generate, validate, present", async () => {
+    const { deps } = setup({});
+    const result = await runQuery({ query: "What is Gemmera?" }, deps);
+    expect(result.kind).toBe("answered");
+    if (result.kind !== "answered") return;
+    expect(result.answer).toBe("The answer.");
+    expect(result.citations).toEqual(["Notes/a.md"]);
+  });
+
+  it("returns empty when retriever produces no hits", async () => {
+    const { deps } = setup({ hits: [], llmReplies: ["irrelevant"] });
+    const result = await runQuery({ query: "anything" }, deps);
+    expect(result.kind).toBe("empty");
+  });
+
+  it("citation retry: invalid citation on first try, valid on retry", async () => {
+    const { deps } = setup({
+      llmReplies: [
+        // First GENERATE: cites a path not in the payload
+        validReply("First answer.", ["Notes/a.md", "Notes/ghost.md"]),
+        // RETRY: corrected, only cites valid path
+        validReply("Revised answer.", ["Notes/a.md"]),
+      ],
+    });
+    const result = await runQuery({ query: "query" }, deps);
+    expect(result.kind).toBe("answered");
+    if (result.kind !== "answered") return;
+    expect(result.answer).toBe("Revised answer.");
+    expect(result.citations).toEqual(["Notes/a.md"]);
+  });
+
+  it("citation retry exhausted: invalid on both tries → validation_failed", async () => {
+    const { deps } = setup({
+      llmReplies: [
+        validReply("First answer.", ["Notes/a.md", "Notes/ghost.md"]),
+        validReply("Retry answer.", ["Notes/b.md"]), // b.md also not in payload
+      ],
+    });
+    const result = await runQuery({ query: "query" }, deps);
+    expect(result.kind).toBe("validation_failed");
+  });
+
+  it("GENERATE invalid JSON → failed", async () => {
+    const { deps } = setup({ llmReplies: ["not json at all"] });
+    const result = await runQuery({ query: "query" }, deps);
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return;
+    expect(result.reason).toBe("generate:invalid_json");
+  });
+
+  it("zero citations in response are valid (no cited notes)", async () => {
+    const { deps } = setup({ llmReplies: [validReply("General answer.", [])] });
+    const result = await runQuery({ query: "query" }, deps);
+    expect(result.kind).toBe("answered");
+    if (result.kind !== "answered") return;
+    expect(result.citations).toEqual([]);
+  });
+
+  it("multiple valid citations all pass", async () => {
+    const { deps } = setup({
+      hits: [makeHit("a.md", "text"), makeHit("b.md", "text"), makeHit("c.md", "text")],
+      chunks: [makeChunk("a.md"), makeChunk("b.md"), makeChunk("c.md")],
+      llmReplies: [validReply("Multi-source answer.", ["a.md", "b.md"])],
+    });
+    const result = await runQuery({ query: "query" }, deps);
+    expect(result.kind).toBe("answered");
+    if (result.kind !== "answered") return;
+    expect(result.citations).toEqual(["a.md", "b.md"]);
+  });
+
+  it("reranker is used when provided", async () => {
+    const rerankedHit = makeHit("Reranked/note.md", "Reranked content");
+    const reranker = new StubRetriever([rerankedHit]);
+    const { deps } = setup({
+      reranker,
+      chunks: [makeChunk("Reranked/note.md")],
+      llmReplies: [validReply("Reranked answer.", ["Reranked/note.md"])],
+    });
+    const result = await runQuery({ query: "query" }, deps);
+    expect(result.kind).toBe("answered");
+  });
+
+  it("reranker failure is skipped, raw hits used", async () => {
+    const throwingReranker: Retriever = {
+      async retrieve(): Promise<RetrievalHit[]> {
+        throw new Error("reranker offline");
+      },
+    };
+    const { deps } = setup({
+      reranker: throwingReranker,
+      llmReplies: [validReply("Fallback answer.", ["Notes/a.md"])],
+    });
+    // Should not propagate the reranker error
+    const result = await runQuery({ query: "query" }, deps);
+    expect(result.kind).toBe("answered");
+  });
+
+  it("event log records state sequence for happy path", async () => {
+    const { deps, eventLog } = setup({ withEventLog: true });
+    await runQuery({ query: "query" }, deps);
+    const events = await eventLog!.eventsFor("turn-1");
+    const states = events.filter((e) => e.kind === "enter").map((e) => e.state);
+    expect(states).toEqual([
+      "PLAN_RETRIEVAL",
+      "RETRIEVE",
+      "RERANK",
+      "ASSEMBLE_CONTEXT",
+      "GENERATE",
+      "VALIDATE_CITATIONS",
+      "PRESENT",
+      "DONE",
+    ]);
+  });
+
+  it("event log records citation retry path", async () => {
+    const { deps, eventLog } = setup({
+      withEventLog: true,
+      llmReplies: [
+        validReply("First.", ["Notes/a.md", "Notes/ghost.md"]),
+        validReply("Revised.", ["Notes/a.md"]),
+      ],
+    });
+    await runQuery({ query: "query" }, deps);
+    const events = await eventLog!.eventsFor("turn-1");
+    const states = events.filter((e) => e.kind === "enter").map((e) => e.state);
+    expect(states).toContain("VALIDATE_CITATIONS");
+    expect(states).toContain("RETRY_WITH_CONSTRAINED_CITATIONS");
+    expect(states[states.length - 1]).toBe("DONE");
+  });
+
+  it("event log records VALIDATION_FAILED when retry also fails", async () => {
+    const { deps, eventLog } = setup({
+      withEventLog: true,
+      llmReplies: [
+        validReply("First.", ["Notes/ghost.md"]),
+        validReply("Retry.", ["Notes/ghost2.md"]),
+      ],
+    });
+    await runQuery({ query: "query" }, deps);
+    const events = await eventLog!.eventsFor("turn-1");
+    const states = events.filter((e) => e.kind === "enter").map((e) => e.state);
+    expect(states).toContain("RETRY_WITH_CONSTRAINED_CITATIONS");
+    expect(states[states.length - 1]).toBe("VALIDATION_FAILED");
+  });
+
+  it("empty retrieval event log goes PLAN_RETRIEVAL → RETRIEVE → PRESENT → DONE", async () => {
+    const { deps, eventLog } = setup({ hits: [], withEventLog: true });
+    await runQuery({ query: "query" }, deps);
+    const events = await eventLog!.eventsFor("turn-1");
+    const states = events.filter((e) => e.kind === "enter").map((e) => e.state);
+    expect(states).toEqual(["PLAN_RETRIEVAL", "RETRIEVE", "PRESENT", "DONE"]);
+  });
+});

--- a/src/services/query-orchestrator.ts
+++ b/src/services/query-orchestrator.ts
@@ -68,7 +68,9 @@ export async function runQuery(
   deps: QueryOrchestratorDeps,
 ): Promise<QueryOutcome> {
   const turnId = deps.turnId ?? crypto.randomUUID();
-  let prevState = "IDLE";
+  // Classification happens upstream (classifier-orchestrator); query picks up
+  // from the state the classifier left on exit.
+  let prevState = "CLASSIFY_INTENT";
   const enter = async (state: string, payload?: Record<string, unknown>) => {
     if (!deps.eventLog) return;
     const entry: EventLogEntry = {

--- a/src/services/query-orchestrator.ts
+++ b/src/services/query-orchestrator.ts
@@ -1,0 +1,263 @@
+import type {
+  EventLog,
+  EventLogEntry,
+  LLMService,
+  PayloadAssembler,
+  RetrievalHit,
+  RetrievalPayload,
+  Retriever,
+} from "../contracts";
+
+const STATES = {
+  planRetrieval: "PLAN_RETRIEVAL",
+  retrieve: "RETRIEVE",
+  rerank: "RERANK",
+  assembleContext: "ASSEMBLE_CONTEXT",
+  generate: "GENERATE",
+  validateCitations: "VALIDATE_CITATIONS",
+  retryConstrainedCitations: "RETRY_WITH_CONSTRAINED_CITATIONS",
+  present: "PRESENT",
+  done: "DONE",
+  failed: "TOOL_FAILED",
+  validationFailed: "VALIDATION_FAILED",
+} as const;
+
+const TOP_K_RETRIEVE = 30;
+const TOP_K_RERANK = 8;
+
+export interface QueryInput {
+  query: string;
+}
+
+export type QueryOutcome =
+  | { kind: "answered"; answer: string; citations: string[] }
+  | { kind: "empty" }
+  | { kind: "failed"; reason: string }
+  | { kind: "validation_failed"; answer: string };
+
+export interface QueryOrchestratorDeps {
+  retriever: Retriever;
+  assembler: PayloadAssembler;
+  llm: LLMService;
+  /**
+   * Optional second-pass reranker. When omitted, raw retriever hits pass
+   * directly to the assembler. On failure, skipped per tool-loop.md retry policy.
+   */
+  reranker?: Retriever;
+  eventLog?: EventLog;
+  turnId?: string;
+  model?: string;
+  signal?: AbortSignal;
+}
+
+interface LLMQueryResponse {
+  answer: string;
+  citations: string[];
+}
+
+/**
+ * Drives the query tool loop (#41): plan → retrieve → rerank →
+ * assemble_context → generate → validate_citations → present.
+ *
+ * Citation validation checks every cited path is in the assembled payload.
+ * Invalid citations trigger one retry with the allowed paths listed
+ * explicitly. A second failure exits to VALIDATION_FAILED.
+ */
+export async function runQuery(
+  input: QueryInput,
+  deps: QueryOrchestratorDeps,
+): Promise<QueryOutcome> {
+  const turnId = deps.turnId ?? crypto.randomUUID();
+  let prevState = "IDLE";
+  const enter = async (state: string, payload?: Record<string, unknown>) => {
+    if (!deps.eventLog) return;
+    const entry: EventLogEntry = {
+      turnId,
+      kind: "enter",
+      state,
+      fromState: prevState,
+      timestamp: Date.now(),
+      triggeringEvent: payload
+        ? { kind: "tool_result", name: state, payload }
+        : null,
+    };
+    await deps.eventLog.write(entry);
+    prevState = state;
+  };
+
+  // ── PLAN_RETRIEVAL ────────────────────────────────────────────────────
+  // Simple queries skip planning and go to RETRIEVE with sensible defaults.
+  await enter(STATES.planRetrieval);
+  const { query } = input;
+
+  // ── RETRIEVE ──────────────────────────────────────────────────────────
+  await enter(STATES.retrieve);
+  let hits: RetrievalHit[];
+  try {
+    hits = await deps.retriever.retrieve(query, { topK: TOP_K_RETRIEVE });
+  } catch (err) {
+    const reason = `retrieve:${stringifyError(err)}`;
+    await enter(STATES.failed, { reason });
+    return { kind: "failed", reason };
+  }
+
+  if (hits.length === 0) {
+    await enter(STATES.present, { empty: true });
+    await enter(STATES.done, { empty: true });
+    return { kind: "empty" };
+  }
+
+  // ── RERANK ────────────────────────────────────────────────────────────
+  await enter(STATES.rerank);
+  if (deps.reranker) {
+    try {
+      hits = await deps.reranker.retrieve(query, { topK: TOP_K_RERANK });
+    } catch {
+      // Reranker failure: 0 retries, skip and use raw hits per tool-loop.md.
+    }
+  }
+
+  // ── ASSEMBLE_CONTEXT ──────────────────────────────────────────────────
+  await enter(STATES.assembleContext);
+  const payload = deps.assembler.assemble(query, hits);
+  const validPaths = new Set(payload.chunks.map((c) => c.path));
+
+  // ── GENERATE ──────────────────────────────────────────────────────────
+  await enter(STATES.generate);
+  const model = deps.model ?? (await deps.llm.pickDefaultModel());
+  const systemPrompt = buildSystemPrompt();
+  const userMessage = buildUserMessage(query, payload);
+
+  let llmRaw: string;
+  try {
+    const response = await deps.llm.chat({
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userMessage },
+      ],
+      model,
+      format: "json",
+      signal: deps.signal,
+    });
+    llmRaw = response.content;
+  } catch (err) {
+    const reason = `generate:${stringifyError(err)}`;
+    await enter(STATES.failed, { reason });
+    return { kind: "failed", reason };
+  }
+
+  let parsed = parseQueryResponse(llmRaw);
+  if (!parsed) {
+    const reason = "generate:invalid_json";
+    await enter(STATES.failed, { reason });
+    return { kind: "failed", reason };
+  }
+
+  // ── VALIDATE_CITATIONS ────────────────────────────────────────────────
+  await enter(STATES.validateCitations, { citationCount: parsed.citations.length });
+  const invalid = parsed.citations.filter((p) => !validPaths.has(p));
+
+  if (invalid.length > 0) {
+    // ── RETRY_WITH_CONSTRAINED_CITATIONS ─────────────────────────────
+    const allowed = [...validPaths];
+    await enter(STATES.retryConstrainedCitations, { invalid, allowed });
+
+    const retryMessage = buildRetryMessage(allowed);
+    let retryRaw: string;
+    try {
+      const retryResponse = await deps.llm.chat({
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userMessage },
+          { role: "assistant", content: llmRaw },
+          { role: "user", content: retryMessage },
+        ],
+        model,
+        format: "json",
+        signal: deps.signal,
+      });
+      retryRaw = retryResponse.content;
+    } catch (err) {
+      const reason = `retry:${stringifyError(err)}`;
+      await enter(STATES.failed, { reason });
+      return { kind: "failed", reason };
+    }
+
+    const retryParsed = parseQueryResponse(retryRaw);
+    if (!retryParsed) {
+      await enter(STATES.validationFailed, { reason: "retry:invalid_json" });
+      return { kind: "validation_failed", answer: parsed.answer };
+    }
+
+    const stillInvalid = retryParsed.citations.filter((p) => !validPaths.has(p));
+    if (stillInvalid.length > 0) {
+      await enter(STATES.validationFailed, { stillInvalid });
+      return { kind: "validation_failed", answer: retryParsed.answer };
+    }
+
+    parsed = retryParsed;
+  }
+
+  // ── PRESENT ───────────────────────────────────────────────────────────
+  await enter(STATES.present, { citationCount: parsed.citations.length });
+  await enter(STATES.done);
+  return { kind: "answered", answer: parsed.answer, citations: parsed.citations };
+}
+
+function buildSystemPrompt(): string {
+  return [
+    "You are a knowledgeable assistant with access to the user's personal vault of notes.",
+    "Answer the user's question using only the provided note excerpts.",
+    "Cite every note you draw from using its exact vault path.",
+    "",
+    "Respond with JSON matching exactly this schema:",
+    '{ "answer": "<your answer>", "citations": ["path/to/note.md", ...] }',
+    "",
+    "Rules:",
+    "- Only cite paths that appear in the provided excerpts.",
+    "- If no excerpts are relevant, set citations to [].",
+    "- Do not invent or guess paths.",
+  ].join("\n");
+}
+
+function buildUserMessage(query: string, payload: RetrievalPayload): string {
+  const excerpts = payload.chunks
+    .map((c) => `[${c.path}] ${c.title}\n${c.text}`)
+    .join("\n\n---\n\n");
+  return `Question: ${query}\n\nNote excerpts:\n${excerpts}`;
+}
+
+function buildRetryMessage(allowedPaths: string[]): string {
+  return [
+    "Your previous response cited paths that are not in the provided excerpts.",
+    "Only cite from these paths:",
+    ...allowedPaths.map((p) => `  - ${p}`),
+    "",
+    'Revise your answer and citations. Return: { "answer": "...", "citations": [...] }',
+  ].join("\n");
+}
+
+function parseQueryResponse(raw: string): LLMQueryResponse | null {
+  try {
+    const obj = JSON.parse(raw) as unknown;
+    if (
+      typeof obj === "object" &&
+      obj !== null &&
+      typeof (obj as Record<string, unknown>).answer === "string" &&
+      Array.isArray((obj as Record<string, unknown>).citations) &&
+      ((obj as Record<string, unknown>).citations as unknown[]).every(
+        (c) => typeof c === "string",
+      )
+    ) {
+      return obj as LLMQueryResponse;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/view.ts
+++ b/src/view.ts
@@ -193,6 +193,10 @@ export class GemmeraChatView extends ItemView {
         const verb = outcome.mode === "append" ? "Appended to" : "Saved to";
         new Notice(`Gemmera: ${verb} ${outcome.path}`);
         this.appendMessage("assistant", `${verb} **${outcome.path}**`);
+      } else if (outcome.kind === "split_saved") {
+        new Notice(`Gemmera: saved ${outcome.paths.length} notes`);
+        const list = outcome.paths.map((p) => `- **${p}**`).join("\n");
+        this.appendMessage("assistant", `Saved ${outcome.paths.length} notes:\n${list}`);
       } else if (outcome.kind === "cancelled") {
         this.appendMessage("assistant", "Cancelled.");
       } else if (outcome.kind === "skipped_existing") {


### PR DESCRIPTION
## Summary

- **#41 Query state machine** (`runQuery`): implements `PLAN_RETRIEVAL → RETRIEVE → RERANK → ASSEMBLE_CONTEXT → GENERATE → VALIDATE_CITATIONS → PRESENT → DONE`. Citation validation checks every cited path is in the assembled retrieval payload; invalid citations trigger one constrained retry before `VALIDATION_FAILED`. Reranker failures are silently skipped per `tool-loop.md` retry policy.
- **#39 Ingest SM close-out**: adds `PROPOSE_SPLIT` branch — the LLM can now return `"split"` strategy, body is split on level-2 headings into individual `NoteSpec` candidates, and the preview handler confirms which to write. Fixes `prevState` init from `"IDLE"` to `"CLASSIFY_INTENT"` so the event log correctly reflects `PARSE_CONTENT` entering from `CLASSIFY_INTENT`.

## Test plan

- [ ] `npx vitest run src/services/query-orchestrator.test.ts` — 13 tests: happy path, empty retrieval, citation retry success, citation retry exhausted, invalid JSON, zero citations, multiple citations, reranker used, reranker failure fallback, event log state sequences
- [ ] `npx vitest run src/services/ingest-orchestrator.test.ts` — 13 tests including new: PROPOSE_SPLIT happy path (2 candidates written, 2 jobs queued), PROPOSE_SPLIT cancel, CLASSIFY_INTENT fromState assertion
- [ ] `npx vitest run` — all 518 tests pass, zero regressions

Closes #41
Closes #39