### PR TITLE
feat: retry policy, turn status, and Ollama runtime lifecycle (#51, #66, #24, #25, #27, #28)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,11 +15,6 @@ export default class GemmeraPlugin extends Plugin {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
     this.statusBarEl = this.addStatusBarItem();
     this.statusBarEl.setText("Cowork: detecting…");
-    this.statusBarEl.onClickEvent(() => {
-      if (this.lifecycle.status === "not_responding") {
-        this.lifecycle.restart().catch((err) => console.error("[gemmera] restart failed", err));
-      }
-    });
     this.lifecycle = new OllamaLifecycle({
       ollamaCmd: this.settings.ollamaPathMode === "manual" && this.settings.ollamaPath
         ? this.settings.ollamaPath
@@ -28,6 +23,11 @@ export default class GemmeraPlugin extends Plugin {
         this.statusBarEl.setText(ollamaStatusLabel(status));
       },
       log: (line) => console.log(line),
+    });
+    this.statusBarEl.onClickEvent(() => {
+      if (this.lifecycle.status === "not_responding") {
+        this.lifecycle.restart().catch((err) => console.error("[gemmera] restart failed", err));
+      }
     });
     // Start Ollama lifecycle in the background — chat is usable if Ollama was already running.
     this.lifecycle.start().catch((err) => console.error("[gemmera] lifecycle start failed", err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, Plugin, WorkspaceLeaf, type StatusBarItem } from "obsidian";
+import { FileSystemAdapter, Plugin, WorkspaceLeaf } from "obsidian";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
 import { OllamaLifecycle, type OllamaStatus } from "./services/ollama-lifecycle";
@@ -9,12 +9,12 @@ export default class GemmeraPlugin extends Plugin {
   private services!: Services;
   settings!: GemmeraSettings;
   private lifecycle!: OllamaLifecycle;
-  private statusBarEl!: StatusBarItem;
+  private statusBarEl!: HTMLElement;
 
   async onload(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
     this.statusBarEl = this.addStatusBarItem();
-    this.statusBarEl.setText("Cowork: detecting…");
+    this.statusBarEl.setText("Gemmera: detecting…");
     this.lifecycle = new OllamaLifecycle({
       ollamaCmd: this.settings.ollamaPathMode === "manual" && this.settings.ollamaPath
         ? this.settings.ollamaPath
@@ -156,11 +156,11 @@ export default class GemmeraPlugin extends Plugin {
 
 function ollamaStatusLabel(status: OllamaStatus): string {
   switch (status) {
-    case "detecting":     return "Cowork: detecting…";
-    case "starting":      return "Cowork: starting…";
-    case "ready":         return "Cowork: ready";
-    case "not_responding": return "Cowork: Ollama not responding — click to restart";
-    case "restarting":    return "Cowork: restarting…";
-    case "not_installed": return "Cowork: Ollama not found";
+    case "detecting":     return "Gemmera: detecting…";
+    case "starting":      return "Gemmera: starting…";
+    case "ready":         return "Gemmera: ready";
+    case "not_responding": return "Gemmera: Ollama not responding — click to restart";
+    case "restarting":    return "Gemmera: restarting…";
+    case "not_installed": return "Gemmera: Ollama not found";
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,36 @@
-import { FileSystemAdapter, Plugin, WorkspaceLeaf } from "obsidian";
+import { FileSystemAdapter, Plugin, WorkspaceLeaf, type StatusBarItem } from "obsidian";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
+import { OllamaLifecycle, type OllamaStatus } from "./services/ollama-lifecycle";
 import { DEFAULT_SETTINGS, GemmeraSettings } from "./settings";
 import { GemmeraSettingsTab } from "./ui/settings-tab";
 
 export default class GemmeraPlugin extends Plugin {
   private services!: Services;
   settings!: GemmeraSettings;
+  private lifecycle!: OllamaLifecycle;
+  private statusBarEl!: StatusBarItem;
 
   async onload(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    this.statusBarEl = this.addStatusBarItem();
+    this.statusBarEl.setText("Cowork: detecting…");
+    this.statusBarEl.onClickEvent(() => {
+      if (this.lifecycle.status === "not_responding") {
+        this.lifecycle.restart().catch((err) => console.error("[gemmera] restart failed", err));
+      }
+    });
+    this.lifecycle = new OllamaLifecycle({
+      ollamaCmd: this.settings.ollamaPathMode === "manual" && this.settings.ollamaPath
+        ? this.settings.ollamaPath
+        : "ollama",
+      onStatusChange: (status: OllamaStatus) => {
+        this.statusBarEl.setText(ollamaStatusLabel(status));
+      },
+      log: (line) => console.log(line),
+    });
+    // Start Ollama lifecycle in the background — chat is usable if Ollama was already running.
+    this.lifecycle.start().catch((err) => console.error("[gemmera] lifecycle start failed", err));
     const pluginDir = (this.app.vault.adapter as FileSystemAdapter).getFullPath(this.manifest.dir ?? ".obsidian/plugins/gemmera");
     this.services = await createServices(this.app, this.settings, pluginDir);
     // Apply persisted pause flag BEFORE any service can claim work — otherwise
@@ -41,6 +62,7 @@ export default class GemmeraPlugin extends Plugin {
       this.services.ingestionStore,
       this.settings,
       () => this.saveData(this.settings),
+      this.lifecycle,
     );
     // Pre-load the snapshot so the first paint of the tab is sync.
     void settingsTab.refresh();
@@ -63,6 +85,7 @@ export default class GemmeraPlugin extends Plugin {
   }
 
   async onunload(): Promise<void> {
+    await this.lifecycle?.stop();
     this.services?.eventBridge.stop();
     this.services?.runnerStatus.stop();
     this.services?.scheduledReconciler.stop();
@@ -128,5 +151,16 @@ export default class GemmeraPlugin extends Plugin {
     if (!leaf) return;
     await leaf.setViewState({ type: VIEW_TYPE, active: true });
     this.app.workspace.revealLeaf(leaf);
+  }
+}
+
+function ollamaStatusLabel(status: OllamaStatus): string {
+  switch (status) {
+    case "detecting":     return "Cowork: detecting…";
+    case "starting":      return "Cowork: starting…";
+    case "ready":         return "Cowork: ready";
+    case "not_responding": return "Cowork: Ollama not responding — click to restart";
+    case "restarting":    return "Cowork: restarting…";
+    case "not_installed": return "Cowork: Ollama not found";
   }
 }

--- a/src/services/ingest-orchestrator.ts
+++ b/src/services/ingest-orchestrator.ts
@@ -16,6 +16,8 @@ import type {
 import { parseContent } from "./ingest-parser";
 import { decideStrategy } from "./ingest-strategy";
 import { IngestWriter } from "./ingest-writer";
+import type { TurnStatusCallback } from "./turn-status";
+import { labelForState } from "./turn-status";
 import { unique } from "./util";
 
 const STATES = {
@@ -66,6 +68,8 @@ export interface IngestOrchestratorDeps {
   eventLog?: EventLog;
   /** Turn id used for event-log entries. Defaults to a fresh uuid. */
   turnId?: string;
+  /** Called synchronously on each state entry so the UI can update its status chip. */
+  onStateChange?: TurnStatusCallback;
   inboxFolder?: string;
   dedupThreshold?: number;
   alwaysPreview?: boolean;
@@ -92,8 +96,9 @@ export async function runIngest(
   deps: IngestOrchestratorDeps,
 ): Promise<IngestOutcome> {
   const turnId = deps.turnId ?? freshTurnId();
-  let prevState = "IDLE";
+  let prevState = "CLASSIFY_INTENT";
   const enter = async (state: string, payload?: Record<string, unknown>) => {
+    deps.onStateChange?.(state, labelForState(state));
     if (!deps.eventLog) return;
     const entry: EventLogEntry = {
       turnId,

--- a/src/services/ollama-lifecycle.test.ts
+++ b/src/services/ollama-lifecycle.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it, vi } from "vitest";
+import { OllamaLifecycle, type ChildProcessHandle, type OllamaLifecycleDeps, type OllamaStatus } from "./ollama-lifecycle";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+interface TestChild extends ChildProcessHandle {
+  triggerExit(code: number | null): void;
+  killSignals: string[];
+}
+
+function makeChild(opts: { exitImmediately?: boolean } = {}): TestChild {
+  const exitListeners: Array<(code: number | null) => void> = [];
+  const killSignals: string[] = [];
+  let exited = false;
+
+  function triggerExit(code: number | null) {
+    if (exited) return;
+    exited = true;
+    for (const l of exitListeners) l(code);
+  }
+
+  if (opts.exitImmediately) {
+    Promise.resolve().then(() => triggerExit(1));
+  }
+
+  return {
+    pid: 99999,
+    kill(signal = "SIGTERM") {
+      killSignals.push(signal);
+    },
+    stdout: { on: () => {} },
+    stderr: { on: () => {} },
+    once(_event: string, cb: (code: number | null) => void) {
+      exitListeners.push(cb);
+    },
+    triggerExit,
+    killSignals,
+  };
+}
+
+function baseDeps(overrides: Partial<OllamaLifecycleDeps> = {}): OllamaLifecycleDeps {
+  return {
+    log: () => {},
+    onStatusChange: () => {},
+    spawnFn: () => makeChild(),
+    healthFn: async () => false,
+    sleepFn: () => Promise.resolve(),
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+    healthCheckIntervalMs: 30_000,
+    startupTimeoutMs: 0,
+    gracefulStopMs: 0,
+    ...overrides,
+  };
+}
+
+// ── start() — already running ─────────────────────────────────────────────────
+
+describe("start() — Ollama already running", () => {
+  it("sets status to ready and does not spawn", async () => {
+    const spawnFn = vi.fn();
+    const statuses: OllamaStatus[] = [];
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => true,
+      spawnFn,
+      onStatusChange: (s) => statuses.push(s),
+    }));
+    await lc.start();
+    expect(lc.status).toBe("ready");
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it("spawnedByPlugin is false when attaching to existing instance", async () => {
+    const lc = new OllamaLifecycle(baseDeps({ healthFn: async () => true }));
+    await lc.start();
+    // Verify by stopping — it should NOT try to kill anything.
+    const child = makeChild();
+    const spawnFn = vi.fn(() => child);
+    // Re-test with a fresh instance that would spawn.
+    const lc2 = new OllamaLifecycle(baseDeps({
+      healthFn: async () => true,
+      spawnFn,
+    }));
+    await lc2.start();
+    await lc2.stop();
+    // No kill signals because we did not spawn.
+    expect(child.killSignals).toHaveLength(0);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it("starts health loop on attach", async () => {
+    let healthTimer: unknown = null;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => true,
+      setIntervalFn: (fn, ms) => { healthTimer = fn; return 1; },
+    }));
+    await lc.start();
+    expect(healthTimer).not.toBeNull();
+  });
+});
+
+// ── start() — spawn path ──────────────────────────────────────────────────────
+
+describe("start() — Ollama not running, spawn", () => {
+  it("sets ready when health comes up after spawn", async () => {
+    const statuses: OltramaStatus[] = [];
+    let healthCalls = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => {
+        healthCalls++;
+        // First call (initial detection) fails, second call (startup poll) succeeds.
+        return healthCalls >= 2;
+      },
+      startupTimeoutMs: 200,
+      onStatusChange: (s) => statuses.push(s as OllamaStatus),
+    }));
+    await lc.start();
+    expect(lc.status).toBe("ready");
+    expect(statuses).toContain("starting");
+    expect(statuses).toContain("ready");
+  });
+
+  it("sets not_responding when health never comes up within timeout", async () => {
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => false, // never healthy
+      startupTimeoutMs: 0,
+    }));
+    await lc.start();
+    expect(lc.status).toBe("not_responding");
+  });
+
+  it("sets spawnedByPlugin=true and calls spawnFn with 'serve'", async () => {
+    const spawnFn = vi.fn(() => makeChild());
+    const lc = new OllamaLifecycle(baseDeps({ spawnFn }));
+    await lc.start();
+    expect(spawnFn).toHaveBeenCalledWith("ollama", ["serve"], expect.any(Object));
+  });
+
+  it("passes OLLAMA_HOST in environment", async () => {
+    let capturedOpts: Record<string, unknown> | null = null;
+    const spawnFn = vi.fn((cmd, args, opts) => { capturedOpts = opts; return makeChild(); });
+    const lc = new OllamaLifecycle(baseDeps({ spawnFn }));
+    await lc.start();
+    expect((capturedOpts?.env as Record<string, string>)?.OLLAMA_HOST).toBe("127.0.0.1:11434");
+  });
+
+  it("sets not_installed when spawn throws ENOENT", async () => {
+    const err = Object.assign(new Error("not found"), { code: "ENOENT" });
+    const lc = new OllamaLifecycle(baseDeps({
+      spawnFn: () => { throw err; },
+    }));
+    await lc.start();
+    expect(lc.status).toBe("not_installed");
+  });
+
+  it("sets not_responding when child exits immediately after spawn", async () => {
+    const child = makeChild({ exitImmediately: true });
+    const statuses: OllamaStatus[] = [];
+    const lc = new OllamaLifecycle(baseDeps({
+      spawnFn: () => child,
+      startupTimeoutMs: 50,
+      onStatusChange: (s) => statuses.push(s),
+    }));
+    await lc.start();
+    expect(statuses).toContain("not_responding");
+  });
+
+  it("logs stdout and stderr lines with [ollama] prefix", async () => {
+    const lines: string[] = [];
+    const child = makeChild();
+    const dataListeners: Record<string, (d: Buffer | string) => void> = {};
+    child.stdout = { on: (evt, cb) => { dataListeners[`out:${evt}`] = cb; } };
+    child.stderr = { on: (evt, cb) => { dataListeners[`err:${evt}`] = cb; } };
+    const lc = new OllamaLifecycle(baseDeps({
+      spawnFn: () => child,
+      log: (l) => lines.push(l),
+    }));
+    await lc.start();
+    dataListeners["out:data"]?.("serving on :11434\n");
+    dataListeners["err:data"]?.("warn: no GPU\n");
+    expect(lines.some((l) => l.includes("[ollama]") && l.includes("serving on :11434"))).toBe(true);
+    expect(lines.some((l) => l.includes("[ollama]") && l.includes("warn: no GPU"))).toBe(true);
+  });
+});
+
+// ── stop() ────────────────────────────────────────────────────────────────────
+
+describe("stop()", () => {
+  it("kills child with SIGTERM when spawnedByPlugin=true", async () => {
+    const child = makeChild();
+    let killCb: (() => void) | null = null;
+    child.once = (_evt, cb: (code: number | null) => void) => {
+      killCb = () => cb(0);
+    };
+    let healthCalls = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      spawnFn: () => child,
+      // First call (initial detection) returns false → triggers spawn.
+      // Second call (startup poll) returns true → comes up.
+      healthFn: async () => { healthCalls++; return healthCalls >= 2; },
+      startupTimeoutMs: 50,
+    }));
+    await lc.start();
+    expect(lc.status).toBe("ready");
+    // Kill and resolve the exit promise.
+    const stopPromise = lc.stop();
+    killCb?.();
+    await stopPromise;
+    expect(child.killSignals).toContain("SIGTERM");
+  });
+
+  it("does NOT kill child when spawnedByPlugin=false (pre-existing Ollama)", async () => {
+    const child = makeChild();
+    const spawnFn = vi.fn(() => child);
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => true, // already running
+      spawnFn,
+    }));
+    await lc.start();
+    await lc.stop();
+    expect(child.killSignals).toHaveLength(0);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it("sends SIGKILL if SIGTERM doesn't resolve within gracefulStopMs", async () => {
+    const child = makeChild(); // never exits on its own
+    child.once = () => {}; // swallow exit listener
+    const lc = new OllamaLifecycle(baseDeps({
+      spawnFn: () => child,
+      startupTimeoutMs: 0,
+      gracefulStopMs: 0,
+    }));
+    await lc.start();
+    await lc.stop();
+    expect(child.killSignals).toContain("SIGKILL");
+  });
+
+  it("stops health loop on stop()", async () => {
+    let cleared = false;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => true,
+      setIntervalFn: () => 1,
+      clearIntervalFn: () => { cleared = true; },
+    }));
+    await lc.start();
+    await lc.stop();
+    expect(cleared).toBe(true);
+  });
+});
+
+// ── Health loop ───────────────────────────────────────────────────────────────
+
+describe("health loop", () => {
+  it("one failure does not flip to not_responding", async () => {
+    let healthTick: (() => Promise<void>) | null = null;
+    let healthCallCount = 0;
+    const statuses: OllamaStatus[] = [];
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => { healthCallCount++; return healthCallCount === 1; }, // initial ok, then fails
+      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+      onStatusChange: (s) => statuses.push(s),
+    }));
+    await lc.start();
+    expect(lc.status).toBe("ready");
+    await healthTick?.();
+    await healthTick?.();
+    expect(lc.status).toBe("ready"); // 2 failures — not yet
+  });
+
+  it("three consecutive failures flip to not_responding", async () => {
+    let healthTick: (() => Promise<void>) | null = null;
+    let healthCallCount = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => { healthCallCount++; return healthCallCount === 1; },
+      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+    }));
+    await lc.start();
+    await healthTick?.();
+    await healthTick?.();
+    await healthTick?.();
+    expect(lc.status).toBe("not_responding");
+  });
+
+  it("recovery after not_responding clears status back to ready", async () => {
+    let healthTick: (() => Promise<void>) | null = null;
+    let healthCallCount = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => {
+        healthCallCount++;
+        // Initial: ok. Ticks 1-3: fail. Tick 4: ok again.
+        if (healthCallCount === 1) return true;
+        if (healthCallCount <= 4) return false;
+        return true;
+      },
+      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+    }));
+    await lc.start();
+    await healthTick?.(); await healthTick?.(); await healthTick?.();
+    expect(lc.status).toBe("not_responding");
+    await healthTick?.();
+    expect(lc.status).toBe("ready");
+  });
+
+  it("skips health check while inFlight", async () => {
+    let healthTick: (() => Promise<void>) | null = null;
+    let healthCalls = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => { healthCalls++; return true; },
+      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+    }));
+    await lc.start();
+    const callsBefore = healthCalls;
+    // Simulate inFlight by triggering a restart that doesn't resolve immediately.
+    // We can't easily test this without more complex setup, so we test the guard
+    // indirectly: stopping sets stopping=true which also skips health checks.
+    lc["stopping"] = true;
+    await healthTick?.();
+    expect(healthCalls).toBe(callsBefore); // no extra call while stopping
+  });
+});
+
+// ── restart() ────────────────────────────────────────────────────────────────
+
+describe("restart()", () => {
+  it("spawns a new process and sets ready on success", async () => {
+    let healthCalls = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => {
+        healthCalls++;
+        return healthCalls !== 2; // initial ok, first restart poll fails once, then ok
+      },
+      startupTimeoutMs: 200,
+    }));
+    await lc.start();
+    await lc.restart();
+    expect(lc.status).toBe("ready");
+  });
+
+  it("concurrent restart calls are no-ops", async () => {
+    const spawnFn = vi.fn(() => makeChild());
+    let healthCalls = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      healthFn: async () => { healthCalls++; return healthCalls === 1; },
+      spawnFn,
+    }));
+    await lc.start();
+    const calls = spawnFn.mock.calls.length;
+    // Fire two restarts concurrently.
+    const [r1, r2] = await Promise.all([lc.restart(), lc.restart()]);
+    // Only one additional spawn should happen.
+    expect(spawnFn.mock.calls.length).toBe(calls + 1);
+  });
+
+  it("kills owned child before restarting", async () => {
+    const child = makeChild();
+    const spawnFn = vi.fn().mockImplementationOnce(() => child).mockImplementation(() => makeChild());
+    let exitCb: ((code: number | null) => void) | null = null;
+    child.once = (_evt, cb: (code: number | null) => void) => { exitCb = cb; };
+
+    let healthCalls = 0;
+    const lc = new OllamaLifecycle(baseDeps({
+      spawnFn,
+      healthFn: async () => { healthCalls++; return healthCalls !== 1; },
+      startupTimeoutMs: 50,
+      gracefulStopMs: 0,
+    }));
+    await lc.start();
+    // Trigger restart; the SIGKILL path fires since gracefulStopMs=0 and no exit fires.
+    await lc.restart();
+    expect(child.killSignals.length).toBeGreaterThan(0);
+  });
+});
+
+// Helper type alias for test body (avoids the typo on line above)
+type OltramaStatus = OllamaStatus;

--- a/src/services/ollama-lifecycle.test.ts
+++ b/src/services/ollama-lifecycle.test.ts
@@ -103,7 +103,7 @@ describe("start() — Ollama already running", () => {
 
 describe("start() — Ollama not running, spawn", () => {
   it("sets ready when health comes up after spawn", async () => {
-    const statuses: OltramaStatus[] = [];
+    const statuses: OllamaStatus[] = [];
     let healthCalls = 0;
     const lc = new OllamaLifecycle(baseDeps({
       healthFn: async () => {
@@ -112,7 +112,7 @@ describe("start() — Ollama not running, spawn", () => {
         return healthCalls >= 2;
       },
       startupTimeoutMs: 200,
-      onStatusChange: (s) => statuses.push(s as OllamaStatus),
+      onStatusChange: (s) => statuses.push(s),
     }));
     await lc.start();
     expect(lc.status).toBe("ready");
@@ -346,7 +346,7 @@ describe("restart()", () => {
     await lc.start();
     const calls = spawnFn.mock.calls.length;
     // Fire two restarts concurrently.
-    const [r1, r2] = await Promise.all([lc.restart(), lc.restart()]);
+    await Promise.all([lc.restart(), lc.restart()]);
     // Only one additional spawn should happen.
     expect(spawnFn.mock.calls.length).toBe(calls + 1);
   });
@@ -371,5 +371,3 @@ describe("restart()", () => {
   });
 });
 
-// Helper type alias for test body (avoids the typo on line above)
-type OltramaStatus = OllamaStatus;

--- a/src/services/ollama-lifecycle.test.ts
+++ b/src/services/ollama-lifecycle.test.ts
@@ -137,11 +137,11 @@ describe("start() — Ollama not running, spawn", () => {
   });
 
   it("passes OLLAMA_HOST in environment", async () => {
-    let capturedOpts: Record<string, unknown> | null = null;
-    const spawnFn = vi.fn((cmd, args, opts) => { capturedOpts = opts; return makeChild(); });
+    const captured: { opts: Record<string, unknown> | null } = { opts: null };
+    const spawnFn = vi.fn((cmd, args, opts) => { captured.opts = opts; return makeChild(); });
     const lc = new OllamaLifecycle(baseDeps({ spawnFn }));
     await lc.start();
-    expect((capturedOpts?.env as Record<string, string>)?.OLLAMA_HOST).toBe("127.0.0.1:11434");
+    expect((captured.opts?.env as Record<string, string>)?.OLLAMA_HOST).toBe("127.0.0.1:11434");
   });
 
   it("sets not_installed when spawn throws ENOENT", async () => {
@@ -188,9 +188,9 @@ describe("start() — Ollama not running, spawn", () => {
 describe("stop()", () => {
   it("kills child with SIGTERM when spawnedByPlugin=true", async () => {
     const child = makeChild();
-    let killCb: (() => void) | null = null;
+    const killCb: { fn: (() => void) | null } = { fn: null };
     child.once = (_evt, cb: (code: number | null) => void) => {
-      killCb = () => cb(0);
+      killCb.fn = () => cb(0);
     };
     let healthCalls = 0;
     const lc = new OllamaLifecycle(baseDeps({
@@ -204,7 +204,7 @@ describe("stop()", () => {
     expect(lc.status).toBe("ready");
     // Kill and resolve the exit promise.
     const stopPromise = lc.stop();
-    killCb?.();
+    killCb.fn?.();
     await stopPromise;
     expect(child.killSignals).toContain("SIGTERM");
   });
@@ -252,37 +252,37 @@ describe("stop()", () => {
 
 describe("health loop", () => {
   it("one failure does not flip to not_responding", async () => {
-    let healthTick: (() => Promise<void>) | null = null;
+    const healthTick: { fn: (() => Promise<void>) | null } = { fn: null };
     let healthCallCount = 0;
     const statuses: OllamaStatus[] = [];
     const lc = new OllamaLifecycle(baseDeps({
       healthFn: async () => { healthCallCount++; return healthCallCount === 1; }, // initial ok, then fails
-      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+      setIntervalFn: (fn) => { healthTick.fn = fn as () => Promise<void>; return 1; },
       onStatusChange: (s) => statuses.push(s),
     }));
     await lc.start();
     expect(lc.status).toBe("ready");
-    await healthTick?.();
-    await healthTick?.();
+    await healthTick.fn?.();
+    await healthTick.fn?.();
     expect(lc.status).toBe("ready"); // 2 failures — not yet
   });
 
   it("three consecutive failures flip to not_responding", async () => {
-    let healthTick: (() => Promise<void>) | null = null;
+    const healthTick: { fn: (() => Promise<void>) | null } = { fn: null };
     let healthCallCount = 0;
     const lc = new OllamaLifecycle(baseDeps({
       healthFn: async () => { healthCallCount++; return healthCallCount === 1; },
-      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+      setIntervalFn: (fn) => { healthTick.fn = fn as () => Promise<void>; return 1; },
     }));
     await lc.start();
-    await healthTick?.();
-    await healthTick?.();
-    await healthTick?.();
+    await healthTick.fn?.();
+    await healthTick.fn?.();
+    await healthTick.fn?.();
     expect(lc.status).toBe("not_responding");
   });
 
   it("recovery after not_responding clears status back to ready", async () => {
-    let healthTick: (() => Promise<void>) | null = null;
+    const healthTick: { fn: (() => Promise<void>) | null } = { fn: null };
     let healthCallCount = 0;
     const lc = new OllamaLifecycle(baseDeps({
       healthFn: async () => {
@@ -292,21 +292,21 @@ describe("health loop", () => {
         if (healthCallCount <= 4) return false;
         return true;
       },
-      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+      setIntervalFn: (fn) => { healthTick.fn = fn as () => Promise<void>; return 1; },
     }));
     await lc.start();
-    await healthTick?.(); await healthTick?.(); await healthTick?.();
+    await healthTick.fn?.(); await healthTick.fn?.(); await healthTick.fn?.();
     expect(lc.status).toBe("not_responding");
-    await healthTick?.();
+    await healthTick.fn?.();
     expect(lc.status).toBe("ready");
   });
 
   it("skips health check while inFlight", async () => {
-    let healthTick: (() => Promise<void>) | null = null;
+    const healthTick: { fn: (() => Promise<void>) | null } = { fn: null };
     let healthCalls = 0;
     const lc = new OllamaLifecycle(baseDeps({
       healthFn: async () => { healthCalls++; return true; },
-      setIntervalFn: (fn) => { healthTick = fn as () => Promise<void>; return 1; },
+      setIntervalFn: (fn) => { healthTick.fn = fn as () => Promise<void>; return 1; },
     }));
     await lc.start();
     const callsBefore = healthCalls;
@@ -314,7 +314,7 @@ describe("health loop", () => {
     // We can't easily test this without more complex setup, so we test the guard
     // indirectly: stopping sets stopping=true which also skips health checks.
     lc["stopping"] = true;
-    await healthTick?.();
+    await healthTick.fn?.();
     expect(healthCalls).toBe(callsBefore); // no extra call while stopping
   });
 });

--- a/src/services/ollama-lifecycle.ts
+++ b/src/services/ollama-lifecycle.ts
@@ -1,0 +1,291 @@
+import { spawn as nodeSpawn } from "node:child_process";
+
+export type OllamaStatus =
+  | "detecting"       // initial state on plugin load
+  | "starting"        // spawn in progress, waiting for /api/tags
+  | "ready"           // /api/tags responding
+  | "not_responding"  // 3+ consecutive health-check failures
+  | "restarting"      // restart attempt in progress
+  | "not_installed";  // Ollama binary not found
+
+export interface ChildProcessHandle {
+  pid?: number;
+  kill(signal?: string): void;
+  stdout: { on(event: "data", cb: (data: Buffer | string) => void): void } | null;
+  stderr: { on(event: "data", cb: (data: Buffer | string) => void): void } | null;
+  once(event: "exit", cb: (code: number | null) => void): void;
+}
+
+export interface OllamaLifecycleDeps {
+  /** Ollama API base. Default: http://127.0.0.1:11434 */
+  baseUrl?: string;
+  /** Path to the Ollama binary. Default: "ollama" (PATH lookup). */
+  ollamaCmd?: string;
+  /** Line-level logger; defaults to console.log. */
+  log?: (line: string) => void;
+  /** Fired on every status transition. */
+  onStatusChange?: (status: OllamaStatus) => void;
+  /** Injectable so tests never actually spawn processes. */
+  spawnFn?: (cmd: string, args: string[], opts: Record<string, unknown>) => ChildProcessHandle;
+  /** Injectable health probe. Returns true when /api/tags responds OK. */
+  healthFn?: (baseUrl: string, signal: AbortSignal) => Promise<boolean>;
+  /** Injectable sleep, used for startup polling and graceful-stop timeout. */
+  sleepFn?: (ms: number) => Promise<void>;
+  /** Injectable setInterval — tests capture the callback to fire health checks manually. */
+  setIntervalFn?: (fn: () => void, ms: number) => unknown;
+  clearIntervalFn?: (id: unknown) => void;
+  /** How often to poll /api/tags while the plugin is loaded. Default: 30 000 ms. */
+  healthCheckIntervalMs?: number;
+  /** How long to wait for Ollama to come up after spawn. Default: 10 000 ms. */
+  startupTimeoutMs?: number;
+  /** How long to wait for SIGTERM before sending SIGKILL. Default: 5 000 ms. */
+  gracefulStopMs?: number;
+}
+
+export class OllamaLifecycle {
+  private readonly baseUrl: string;
+  private readonly ollamaCmd: string;
+  private readonly log: (line: string) => void;
+  private readonly _onStatusChange: (s: OllamaStatus) => void;
+  private readonly spawnFn: NonNullable<OllamaLifecycleDeps["spawnFn"]>;
+  private readonly healthFn: NonNullable<OllamaLifecycleDeps["healthFn"]>;
+  private readonly sleepFn: NonNullable<OllamaLifecycleDeps["sleepFn"]>;
+  private readonly setIntervalFn: NonNullable<OllamaLifecycleDeps["setIntervalFn"]>;
+  private readonly clearIntervalFn: NonNullable<OllamaLifecycleDeps["clearIntervalFn"]>;
+  private readonly healthCheckIntervalMs: number;
+  private readonly startupTimeoutMs: number;
+  private readonly gracefulStopMs: number;
+
+  private child: ChildProcessHandle | null = null;
+  private spawnedByPlugin = false;
+  private consecutiveFailures = 0;
+  private _status: OllamaStatus = "detecting";
+  private healthTimer: unknown = null;
+  private stopping = false;
+  private _inFlight = false;
+
+  constructor(deps: OllamaLifecycleDeps = {}) {
+    this.baseUrl = deps.baseUrl ?? "http://127.0.0.1:11434";
+    this.ollamaCmd = deps.ollamaCmd ?? "ollama";
+    this.log = deps.log ?? ((l) => console.log(l));
+    this._onStatusChange = deps.onStatusChange ?? (() => {});
+    this.spawnFn = deps.spawnFn ?? defaultSpawn;
+    this.healthFn = deps.healthFn ?? defaultHealth;
+    this.sleepFn = deps.sleepFn ?? defaultSleep;
+    this.setIntervalFn = deps.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
+    this.clearIntervalFn = deps.clearIntervalFn ?? ((id) => clearInterval(id as ReturnType<typeof setInterval>));
+    this.healthCheckIntervalMs = deps.healthCheckIntervalMs ?? 30_000;
+    this.startupTimeoutMs = deps.startupTimeoutMs ?? 10_000;
+    this.gracefulStopMs = deps.gracefulStopMs ?? 5_000;
+  }
+
+  get status(): OllamaStatus {
+    return this._status;
+  }
+
+  /** True when a spawn or restart is in progress. UI disables the Restart button. */
+  get inFlight(): boolean {
+    return this._inFlight;
+  }
+
+  /**
+   * Detect and connect to Ollama on plugin load (#24).
+   * - Already running → attach without spawning.
+   * - Not running → spawn and wait up to startupTimeoutMs for /api/tags.
+   */
+  async start(): Promise<void> {
+    this.stopping = false;
+    const alreadyUp = await this.healthFn(this.baseUrl, AbortSignal.timeout(2_000)).catch(() => false);
+    if (alreadyUp) {
+      this.spawnedByPlugin = false;
+      this.setStatus("ready");
+      this.startHealthLoop();
+      return;
+    }
+    this.setStatus("starting");
+    const spawned = await this.doSpawn();
+    if (spawned) this.startHealthLoop();
+  }
+
+  /**
+   * Stop the health-check loop and, if the plugin owns the process, kill it (#25).
+   * Graceful: SIGTERM → 5 s wait → SIGKILL.
+   */
+  async stop(): Promise<void> {
+    this.stopping = true;
+    this.stopHealthLoop();
+    if (this.spawnedByPlugin && this.child) {
+      await this.gracefulKill(this.child);
+      this.child = null;
+    }
+  }
+
+  /**
+   * Restart Ollama. Safe to call from UI — concurrent calls are silently dropped.
+   * Takes ownership of the process regardless of spawnedByPlugin history.
+   */
+  async restart(): Promise<void> {
+    if (this._inFlight) return;
+    this._inFlight = true;
+    try {
+      this.setStatus("restarting");
+      this.stopHealthLoop();
+      if (this.spawnedByPlugin && this.child) {
+        await this.gracefulKill(this.child);
+        this.child = null;
+      }
+      const spawned = await this.doSpawn();
+      if (spawned) this.startHealthLoop();
+    } finally {
+      this._inFlight = false;
+    }
+  }
+
+  private setStatus(s: OllamaStatus): void {
+    this._status = s;
+    this._onStatusChange(s);
+  }
+
+  private async doSpawn(): Promise<boolean> {
+    let childExited = false;
+    let child: ChildProcessHandle;
+
+    try {
+      child = this.spawnFn(this.ollamaCmd, ["serve"], {
+        env: { ...process.env, OLLAMA_HOST: "127.0.0.1:11434" },
+        detached: false,
+        stdio: "pipe",
+      });
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === "ENOENT" || code === "EACCES") {
+        this.setStatus("not_installed");
+      } else {
+        this.log(`[ollama] spawn error: ${String(err)}`);
+        this.setStatus("not_responding");
+      }
+      return false;
+    }
+
+    this.child = child;
+    this.spawnedByPlugin = true;
+
+    child.stdout?.on("data", (chunk) => {
+      for (const line of String(chunk).split("\n")) {
+        if (line.trim()) this.log(`[ollama] ${line}`);
+      }
+    });
+    child.stderr?.on("data", (chunk) => {
+      for (const line of String(chunk).split("\n")) {
+        if (line.trim()) this.log(`[ollama] ${line}`);
+      }
+    });
+    child.once("exit", (code) => {
+      this.log(`[ollama] process exited with code ${code ?? "null"}`);
+      childExited = true;
+      if (this._status === "starting" || this._status === "restarting") {
+        this.setStatus("not_responding");
+      }
+    });
+
+    const up = await this.waitForHealth(this.startupTimeoutMs, () => childExited);
+    if (up) {
+      this.setStatus("ready");
+    } else if (!childExited) {
+      this.setStatus("not_responding");
+    }
+    return true;
+  }
+
+  private async waitForHealth(timeoutMs: number, isExited: () => boolean): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      if (isExited() || this.stopping) return false;
+      try {
+        const ok = await this.healthFn(this.baseUrl, AbortSignal.timeout(1_000));
+        if (ok) return true;
+      } catch { /* keep polling */ }
+      if (Date.now() >= deadline) return false;
+      await this.sleepFn(500);
+    }
+  }
+
+  private startHealthLoop(): void {
+    this.stopHealthLoop();
+    this.consecutiveFailures = 0;
+    this.healthTimer = this.setIntervalFn(async () => {
+      if (this.stopping || this._inFlight) return;
+      try {
+        const ok = await this.healthFn(this.baseUrl, AbortSignal.timeout(5_000));
+        if (ok) {
+          if (this.consecutiveFailures > 0) {
+            this.consecutiveFailures = 0;
+            if (this._status === "not_responding") this.setStatus("ready");
+          }
+        } else {
+          this.recordFailure();
+        }
+      } catch {
+        this.recordFailure();
+      }
+    }, this.healthCheckIntervalMs);
+  }
+
+  private recordFailure(): void {
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= 3 && this._status !== "not_responding") {
+      this.setStatus("not_responding");
+    }
+  }
+
+  private stopHealthLoop(): void {
+    if (this.healthTimer !== null) {
+      this.clearIntervalFn(this.healthTimer);
+      this.healthTimer = null;
+    }
+  }
+
+  private async gracefulKill(child: ChildProcessHandle): Promise<void> {
+    return new Promise((resolve) => {
+      let done = false;
+      child.once("exit", () => {
+        done = true;
+        resolve();
+      });
+      child.kill("SIGTERM");
+      this.sleepFn(this.gracefulStopMs).then(() => {
+        if (!done) {
+          child.kill("SIGKILL");
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+// ── Default implementations (production only) ────────────────────────────────
+
+function defaultSpawn(
+  cmd: string,
+  args: string[],
+  opts: Record<string, unknown>,
+): ChildProcessHandle {
+  return nodeSpawn(cmd, args, {
+    env: opts.env as NodeJS.ProcessEnv,
+    detached: opts.detached as boolean | undefined,
+    stdio: "pipe",
+  }) as unknown as ChildProcessHandle;
+}
+
+async function defaultHealth(baseUrl: string, signal: AbortSignal): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, { signal });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/services/retry-policy.test.ts
+++ b/src/services/retry-policy.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  RetryBudget,
+  withFeedbackRetry,
+  withInfraRetry,
+  withJsonRetry,
+} from "./retry-policy";
+import { HARD_STOPS } from "../contracts";
+
+// ── RetryBudget ───────────────────────────────────────────────────────────────
+
+describe("RetryBudget", () => {
+  it("allows retries up to MAX_RETRIES_PER_TURN", () => {
+    const budget = new RetryBudget();
+    for (let i = 0; i < HARD_STOPS.MAX_RETRIES_PER_TURN; i++) {
+      expect(budget.canRetry()).toBe(true);
+      expect(budget.consume()).toBe(true);
+    }
+    expect(budget.canRetry()).toBe(false);
+    expect(budget.consume()).toBe(false);
+  });
+
+  it("tracks the count of consumed slots", () => {
+    const budget = new RetryBudget();
+    expect(budget.count).toBe(0);
+    budget.consume();
+    expect(budget.count).toBe(1);
+    budget.consume();
+    expect(budget.count).toBe(2);
+  });
+
+  it("supports a custom max", () => {
+    const budget = new RetryBudget(1);
+    expect(budget.consume()).toBe(true);
+    expect(budget.consume()).toBe(false);
+  });
+});
+
+// ── withJsonRetry ─────────────────────────────────────────────────────────────
+
+describe("withJsonRetry — model-output validity (invalid JSON)", () => {
+  it("returns parsed value on first-call success", async () => {
+    const fn = vi.fn().mockResolvedValue('{"ok":true}');
+    const result = await withJsonRetry(fn, JSON.parse, new RetryBudget());
+    expect(result).toEqual({ ok: true, value: { ok: true } });
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("retries once on invalid JSON and succeeds", async () => {
+    const fn = vi.fn()
+      .mockResolvedValueOnce("not json")
+      .mockResolvedValueOnce('{"answer":42}');
+    const budget = new RetryBudget();
+    const result = await withJsonRetry(fn, JSON.parse, budget);
+    expect(result).toEqual({ ok: true, value: { answer: 42 } });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(budget.count).toBe(1);
+  });
+
+  it("returns invalid_json when both calls fail", async () => {
+    const fn = vi.fn().mockResolvedValue("still not json");
+    const result = await withJsonRetry(fn, JSON.parse, new RetryBudget());
+    expect(result).toEqual({ ok: false, reason: "invalid_json" });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns budget_exhausted without retrying when budget is already empty", async () => {
+    const fn = vi.fn().mockResolvedValue("not json");
+    const budget = new RetryBudget(0);
+    const result = await withJsonRetry(fn, JSON.parse, budget);
+    expect(result).toEqual({ ok: false, reason: "budget_exhausted" });
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("budget carries across multiple withJsonRetry calls within a turn", async () => {
+    const budget = new RetryBudget(1);
+    // First call uses the one retry slot.
+    const fn1 = vi.fn()
+      .mockResolvedValueOnce("bad")
+      .mockResolvedValueOnce('{"x":1}');
+    await withJsonRetry(fn1, JSON.parse, budget);
+    expect(budget.count).toBe(1);
+
+    // Second call: budget exhausted, should not retry.
+    const fn2 = vi.fn().mockResolvedValue("bad");
+    const result = await withJsonRetry(fn2, JSON.parse, budget);
+    expect(result).toEqual({ ok: false, reason: "budget_exhausted" });
+    expect(fn2).toHaveBeenCalledOnce();
+  });
+
+  it("uses a custom parse function — returns null to signal failure", async () => {
+    const strictParse = (raw: string): number | null => {
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : null;
+    };
+    const fn = vi.fn()
+      .mockResolvedValueOnce("not a number")
+      .mockResolvedValueOnce("42");
+    const result = await withJsonRetry(fn, strictParse, new RetryBudget());
+    expect(result).toEqual({ ok: true, value: 42 });
+  });
+});
+
+// ── withFeedbackRetry ─────────────────────────────────────────────────────────
+
+describe("withFeedbackRetry — schema-valid-but-rule-violating output", () => {
+  it("returns value on first-call success (no validation error)", async () => {
+    const fn = vi.fn().mockResolvedValue("good");
+    const validate = () => null; // always valid
+    const retryFn = vi.fn();
+    const result = await withFeedbackRetry(fn, validate, retryFn, new RetryBudget());
+    expect(result).toEqual({ ok: true, value: "good" });
+    expect(retryFn).not.toHaveBeenCalled();
+  });
+
+  it("retries with error feedback and succeeds on second call", async () => {
+    const fn = vi.fn().mockResolvedValue("invalid");
+    const validate = (v: string) => (v === "invalid" ? "value must not be 'invalid'" : null);
+    const retryFn = vi.fn().mockResolvedValue("valid");
+    const budget = new RetryBudget();
+    const result = await withFeedbackRetry(fn, validate, retryFn, budget);
+    expect(result).toEqual({ ok: true, value: "valid" });
+    expect(retryFn).toHaveBeenCalledWith("value must not be 'invalid'", undefined);
+    expect(budget.count).toBe(1);
+  });
+
+  it("returns validation_failed when both calls are invalid", async () => {
+    const fn = vi.fn().mockResolvedValue("bad");
+    const validate = () => "still bad";
+    const retryFn = vi.fn().mockResolvedValue("still bad");
+    const result = await withFeedbackRetry(fn, validate, retryFn, new RetryBudget());
+    expect(result).toEqual({ ok: false, reason: "validation_failed", value: "still bad" });
+  });
+
+  it("returns budget_exhausted when budget is empty before first retry", async () => {
+    const fn = vi.fn().mockResolvedValue("bad");
+    const validate = () => "error";
+    const retryFn = vi.fn();
+    const budget = new RetryBudget(0);
+    const result = await withFeedbackRetry(fn, validate, retryFn, budget);
+    expect(result).toEqual({ ok: false, reason: "budget_exhausted", value: "bad" });
+    expect(retryFn).not.toHaveBeenCalled();
+  });
+
+  it("passes signal to both fn and retryFn", async () => {
+    const signal = AbortSignal.timeout(5000);
+    const fn = vi.fn().mockResolvedValue("bad");
+    const validate = () => "error";
+    const retryFn = vi.fn().mockResolvedValue("good");
+    await withFeedbackRetry(fn, validate, retryFn, new RetryBudget(), signal);
+    expect(fn).toHaveBeenCalledWith(signal);
+    expect(retryFn).toHaveBeenCalledWith("error", signal);
+  });
+});
+
+// ── withInfraRetry ────────────────────────────────────────────────────────────
+
+describe("withInfraRetry — transient infrastructure failures", () => {
+  const noSleep = () => Promise.resolve();
+
+  it("returns result on first-call success without retrying", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withInfraRetry(fn, 500, undefined, noSleep);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("retries once after delay and succeeds", async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error("connection refused"))
+      .mockResolvedValueOnce("recovered");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const result = await withInfraRetry(fn, 500, undefined, sleep);
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(500);
+  });
+
+  it("throws on second failure (caller decides: Notice or re-queue)", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("Ollama not running"));
+    await expect(withInfraRetry(fn, 500, undefined, noSleep)).rejects.toThrow(
+      "Ollama not running",
+    );
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("respects delayMs: 250 for embedder, 500 for Ollama", async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await withInfraRetry(fn, 250, undefined, sleep);
+    expect(sleep).toHaveBeenCalledWith(250);
+  });
+
+  it("does NOT consume from RetryBudget (infra retries are transport-level)", async () => {
+    const budget = new RetryBudget();
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error("refused"))
+      .mockResolvedValueOnce("ok");
+    await withInfraRetry(fn, 500, undefined, noSleep);
+    // Budget should be untouched.
+    expect(budget.count).toBe(0);
+    expect(budget.canRetry()).toBe(true);
+  });
+});

--- a/src/services/retry-policy.ts
+++ b/src/services/retry-policy.ts
@@ -1,0 +1,142 @@
+import { HARD_STOPS } from "../contracts";
+
+/**
+ * Tracks the per-turn retry ceiling (#51).
+ *
+ * Model-output retries (invalid JSON, schema violations) and tool-argument
+ * retries all draw from the same pool so pathological prompts cannot exhaust
+ * the turn with retry loops at each state independently.
+ *
+ * Infra retries (Ollama connection refused, embedding failure) are handled by
+ * `withInfraRetry`, which has its own fixed 1-attempt budget and does NOT
+ * consume from this pool — they are transport-level, not model-output events.
+ */
+export class RetryBudget {
+  private used = 0;
+
+  constructor(private readonly max = HARD_STOPS.MAX_RETRIES_PER_TURN) {}
+
+  /** True when at least one retry remains. */
+  canRetry(): boolean {
+    return this.used < this.max;
+  }
+
+  /**
+   * Consume one retry slot. Returns true when the slot was granted,
+   * false when the budget is exhausted and the caller should not retry.
+   */
+  consume(): boolean {
+    if (this.used >= this.max) return false;
+    this.used++;
+    return true;
+  }
+
+  get count(): number {
+    return this.used;
+  }
+}
+
+// ── Model-output validity ──────────────────────────────────────────────────────
+
+export type JsonRetryResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: "invalid_json" | "budget_exhausted" };
+
+/**
+ * Calls `fn` and attempts to parse the result. On parse failure, consumes one
+ * slot from `budget` and retries once. On second failure, or if the budget is
+ * already exhausted, returns an error result rather than throwing.
+ *
+ * Corresponds to: "invalid JSON → 1 retry under format:'json'; on second
+ * failure → MODEL_INVALID_OUTPUT" from tool-loop.md retry policy.
+ */
+export async function withJsonRetry<T>(
+  fn: (signal?: AbortSignal) => Promise<string>,
+  parse: (raw: string) => T | null,
+  budget: RetryBudget,
+  signal?: AbortSignal,
+): Promise<JsonRetryResult<T>> {
+  const raw = await fn(signal);
+  const parsed = tryParse(parse, raw);
+  if (parsed !== null) return { ok: true, value: parsed };
+
+  if (!budget.consume()) return { ok: false, reason: "budget_exhausted" };
+
+  const raw2 = await fn(signal);
+  const parsed2 = tryParse(parse, raw2);
+  if (parsed2 !== null) return { ok: true, value: parsed2 };
+  return { ok: false, reason: "invalid_json" };
+}
+
+function tryParse<T>(parse: (raw: string) => T | null, raw: string): T | null {
+  try {
+    return parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export type FeedbackRetryResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: "validation_failed" | "budget_exhausted"; value: T };
+
+/**
+ * Calls `fn`, validates the result, and on failure retries once with error
+ * feedback via `retryFn`. On second failure, or if the budget is exhausted,
+ * returns the latest value alongside an error result so callers can surface it.
+ *
+ * Corresponds to: "schema-valid-but-rule-violating JSON → 1 retry with
+ * explicit error feedback; second failure → VALIDATION_FAILED".
+ */
+export async function withFeedbackRetry<T>(
+  fn: (signal?: AbortSignal) => Promise<T>,
+  validate: (v: T) => string | null,
+  retryFn: (errorMsg: string, signal?: AbortSignal) => Promise<T>,
+  budget: RetryBudget,
+  signal?: AbortSignal,
+): Promise<FeedbackRetryResult<T>> {
+  const value = await fn(signal);
+  const error = validate(value);
+  if (!error) return { ok: true, value };
+
+  if (!budget.consume()) return { ok: false, reason: "budget_exhausted", value };
+
+  const value2 = await retryFn(error, signal);
+  const error2 = validate(value2);
+  if (!error2) return { ok: true, value: value2 };
+  return { ok: false, reason: "validation_failed", value: value2 };
+}
+
+// ── Transient infra ───────────────────────────────────────────────────────────
+
+/**
+ * Calls `fn` and, on any thrown error, waits `delayMs` then retries once.
+ * Throws on the second failure — callers surface the error as a Notice or
+ * return the job to the queue depending on which component failed.
+ *
+ * Does NOT consume from `RetryBudget` — infra retries are transport-level
+ * events, not model-output retries. Each component has its own fixed budget:
+ *   - Ollama connection refused: 1 retry after 500 ms
+ *   - Embedding call fails: 1 retry after 250 ms
+ *   - Reranker fails: 0 retries (caller skips rerank, never calls this)
+ *
+ * `sleep` is injectable for deterministic tests.
+ */
+export async function withInfraRetry<T>(
+  fn: () => Promise<T>,
+  delayMs: number,
+  signal?: AbortSignal,
+  sleep: (ms: number) => Promise<void> = defaultSleep,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch {
+    if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+    await sleep(delayMs);
+    return fn();
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/services/retry-policy.ts
+++ b/src/services/retry-policy.ts
@@ -14,7 +14,7 @@ import { HARD_STOPS } from "../contracts";
 export class RetryBudget {
   private used = 0;
 
-  constructor(private readonly max = HARD_STOPS.MAX_RETRIES_PER_TURN) {}
+  constructor(private readonly max: number = HARD_STOPS.MAX_RETRIES_PER_TURN) {}
 
   /** True when at least one retry remains. */
   canRetry(): boolean {

--- a/src/services/turn-status.test.ts
+++ b/src/services/turn-status.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  STATE_LABELS,
+  formatInspectorEntries,
+  labelForState,
+} from "./turn-status";
+
+describe("STATE_LABELS", () => {
+  it("covers all ingest states", () => {
+    const ingestStates = [
+      "PARSE_CONTENT",
+      "SEARCH_SIMILAR",
+      "DECIDE_STRATEGY",
+      "PREVIEW",
+      "WRITE",
+      "UPDATE_INDEX",
+    ];
+    for (const s of ingestStates) {
+      expect(STATE_LABELS).toHaveProperty(s);
+      expect(typeof STATE_LABELS[s]).toBe("string");
+    }
+  });
+
+  it("covers all query states", () => {
+    const queryStates = [
+      "PLAN_RETRIEVAL",
+      "RETRIEVE",
+      "RERANK",
+      "ASSEMBLE_CONTEXT",
+      "GENERATE",
+      "VALIDATE_CITATIONS",
+      "RETRY_WITH_CONSTRAINED_CITATIONS",
+      "PRESENT",
+    ];
+    for (const s of queryStates) {
+      expect(STATE_LABELS).toHaveProperty(s);
+      expect(typeof STATE_LABELS[s]).toBe("string");
+    }
+  });
+
+  it("covers shared and terminal states", () => {
+    const shared = ["CLASSIFY_INTENT"];
+    const terminal = [
+      "DONE",
+      "CANCELLED",
+      "TIMED_OUT",
+      "MODEL_INVALID_OUTPUT",
+      "TOOL_FAILED",
+      "VALIDATION_FAILED",
+    ];
+    for (const s of [...shared, ...terminal]) {
+      expect(STATE_LABELS).toHaveProperty(s);
+    }
+  });
+
+  it("all labels are non-empty strings", () => {
+    for (const [state, label] of Object.entries(STATE_LABELS)) {
+      expect(label, `label for ${state} must be non-empty`).not.toBe("");
+    }
+  });
+});
+
+describe("labelForState", () => {
+  it("returns the mapped label for a known state", () => {
+    expect(labelForState("GENERATE")).toBe("Generating answer…");
+    expect(labelForState("DONE")).toBe("Done");
+  });
+
+  it("falls back to the raw state name for unknown states", () => {
+    expect(labelForState("SOME_FUTURE_STATE")).toBe("SOME_FUTURE_STATE");
+    expect(labelForState("")).toBe("");
+  });
+});
+
+describe("formatInspectorEntries", () => {
+  const base = {
+    state: "GENERATE",
+    fromState: "ASSEMBLE_CONTEXT" as string | null,
+    timestamp: 1_700_000_000_000,
+    triggeringEvent: null as { payload?: unknown } | null,
+  };
+
+  it("keeps only enter entries", () => {
+    const entries = [
+      { kind: "enter", ...base },
+      { kind: "exit", ...base },
+      { kind: "enter", ...base, state: "PRESENT" },
+    ];
+    const result = formatInspectorEntries(entries);
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.state !== undefined)).toBe(true);
+  });
+
+  it("maps state to label", () => {
+    const result = formatInspectorEntries([{ kind: "enter", ...base }]);
+    expect(result[0].label).toBe("Generating answer…");
+  });
+
+  it("preserves fromState and timestamp", () => {
+    const result = formatInspectorEntries([{ kind: "enter", ...base }]);
+    expect(result[0].fromState).toBe("ASSEMBLE_CONTEXT");
+    expect(result[0].timestamp).toBe(1_700_000_000_000);
+  });
+
+  it("formats timestamp as ISO string", () => {
+    const result = formatInspectorEntries([{ kind: "enter", ...base }]);
+    expect(result[0].time).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  it("sets payloadPreview to null when no payload", () => {
+    const result = formatInspectorEntries([{ kind: "enter", ...base }]);
+    expect(result[0].payloadPreview).toBeNull();
+  });
+
+  it("sets payloadPreview to null when triggeringEvent is null", () => {
+    const result = formatInspectorEntries([
+      { kind: "enter", ...base, triggeringEvent: null },
+    ]);
+    expect(result[0].payloadPreview).toBeNull();
+  });
+
+  it("serialises small payloads verbatim", () => {
+    const result = formatInspectorEntries([
+      {
+        kind: "enter",
+        ...base,
+        triggeringEvent: { payload: { answer: 42 } },
+      },
+    ]);
+    expect(result[0].payloadPreview).toBe('{"answer":42}');
+  });
+
+  it("truncates large payloads to 120 chars with ellipsis", () => {
+    const big = { x: "a".repeat(200) };
+    const result = formatInspectorEntries([
+      { kind: "enter", ...base, triggeringEvent: { payload: big } },
+    ]);
+    expect(result[0].payloadPreview).toHaveLength(120);
+    expect(result[0].payloadPreview?.endsWith("…")).toBe(true);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(formatInspectorEntries([])).toEqual([]);
+  });
+
+  it("returns empty for input with only exit entries", () => {
+    expect(
+      formatInspectorEntries([{ kind: "exit", ...base }]),
+    ).toEqual([]);
+  });
+});

--- a/src/services/turn-status.ts
+++ b/src/services/turn-status.ts
@@ -1,0 +1,108 @@
+/**
+ * State → human-readable UI label mapping for #66.
+ *
+ * Every named state in the ingest, query, and destructive-op state machines
+ * maps to a short, past-tense-free status string that the chat view renders
+ * as a status chip while the turn is live. Terminal states map to strings
+ * suitable for a final Notice.
+ */
+export const STATE_LABELS: Record<string, string> = {
+  // ── Shared / classifier ───────────────────────────────────────────────
+  CLASSIFY_INTENT: "Thinking…",
+
+  // ── Ingest state machine ──────────────────────────────────────────────
+  PARSE_CONTENT: "Reading your note…",
+  SEARCH_SIMILAR: "Searching for similar notes…",
+  DECIDE_STRATEGY: "Deciding what to do…",
+  PREVIEW: "Ready for review",
+  WRITE: "Saving…",
+  UPDATE_INDEX: "Indexing…",
+
+  // ── Query state machine ───────────────────────────────────────────────
+  PLAN_RETRIEVAL: "Planning search…",
+  RETRIEVE: "Searching notes…",
+  RERANK: "Reranking…",
+  ASSEMBLE_CONTEXT: "Assembling context…",
+  GENERATE: "Generating answer…",
+  VALIDATE_CITATIONS: "Validating citations…",
+  RETRY_WITH_CONSTRAINED_CITATIONS: "Fixing citations…",
+  PRESENT: "Presenting answer…",
+
+  // ── Destructive-op mini state machine ─────────────────────────────────
+  CONFIRM: "Waiting for confirmation…",
+  EXECUTE: "Executing…",
+
+  // ── Terminal states ───────────────────────────────────────────────────
+  DONE: "Done",
+  CANCELLED: "Cancelled",
+  TIMED_OUT: "Timed out",
+  MODEL_INVALID_OUTPUT: "Model returned an unexpected response",
+  TOOL_FAILED: "Tool error",
+  VALIDATION_FAILED: "Validation failed",
+} as const;
+
+/**
+ * Returns the UI label for `state`, falling back to the raw state name
+ * for any state not in the map (e.g. future states added by teammates).
+ */
+export function labelForState(state: string): string {
+  return STATE_LABELS[state] ?? state;
+}
+
+/**
+ * Injected into orchestrator deps so the chat view can update its status
+ * chip in real time as the turn progresses through states.
+ *
+ * Called once per state entry (from → to), matching the event-log entries.
+ * UI implementations must be synchronous and non-blocking — the orchestrator
+ * does not await this callback.
+ */
+export type TurnStatusCallback = (state: string, label: string) => void;
+
+// ── Turn inspector data helpers ────────────────────────────────────────────────
+
+export interface InspectorEntry {
+  state: string;
+  label: string;
+  fromState: string | null;
+  timestamp: number;
+  /** ISO-formatted timestamp for display. */
+  time: string;
+  payloadPreview: string | null;
+}
+
+/**
+ * Converts raw event log entries into a display-ready list for the turn
+ * inspector. Only `enter` entries are shown (exit entries are internal
+ * bookkeeping not meaningful to users).
+ */
+export function formatInspectorEntries(
+  entries: ReadonlyArray<{
+    kind: string;
+    state: string;
+    fromState: string | null;
+    timestamp: number;
+    triggeringEvent: { payload?: unknown } | null;
+  }>,
+): InspectorEntry[] {
+  return entries
+    .filter((e) => e.kind === "enter")
+    .map((e) => ({
+      state: e.state,
+      label: labelForState(e.state),
+      fromState: e.fromState,
+      timestamp: e.timestamp,
+      time: new Date(e.timestamp).toISOString(),
+      payloadPreview: summarisePayload(e.triggeringEvent?.payload),
+    }));
+}
+
+function summarisePayload(payload: unknown): string | null {
+  if (payload === undefined || payload === null) return null;
+  try {
+    const str = JSON.stringify(payload);
+    return str.length > 120 ? str.slice(0, 119) + "…" : str;
+  } catch {
+    return null;
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,18 @@ export interface GemmeraSettings {
 
   /** Cosine score above which a similar note is treated as a near-duplicate. */
   dedupThreshold: number;
+
+  /**
+   * "auto" = find ollama on PATH. "manual" = use ollamaPath.
+   * Wired to Settings → Ollama → path mode (#28).
+   */
+  ollamaPathMode: "auto" | "manual";
+
+  /**
+   * Explicit path to the Ollama binary. Only used when ollamaPathMode = "manual".
+   * Example: "/usr/local/bin/ollama"
+   */
+  ollamaPath: string;
 }
 
 export const DEFAULT_SETTINGS: GemmeraSettings = {
@@ -34,4 +46,6 @@ export const DEFAULT_SETTINGS: GemmeraSettings = {
   alwaysPreviewBeforeSave: true,
   inboxFolder: "Inbox/",
   dedupThreshold: 0.85,
+  ollamaPathMode: "auto",
+  ollamaPath: "",
 };

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,5 +1,6 @@
 import { Notice, PluginSettingTab, Setting, type App, type Plugin } from "obsidian";
 import type { DriftReport, IngestionStore } from "../contracts";
+import type { OllamaLifecycle } from "../services/ollama-lifecycle";
 import type { RunnerControls } from "../services/runner-controls";
 import type { ScheduledReconciler } from "../services/scheduled-reconciler";
 import type { GemmeraSettings } from "../settings";
@@ -39,6 +40,7 @@ export class GemmeraSettingsTab extends PluginSettingTab {
     private readonly store: IngestionStore,
     private readonly settings: GemmeraSettings,
     private readonly saveSettings: () => Promise<void>,
+    private readonly lifecycle?: OllamaLifecycle,
   ) {
     super(app, plugin);
   }
@@ -171,6 +173,55 @@ export class GemmeraSettingsTab extends PluginSettingTab {
         toggle.onChange(async (value: boolean) => {
           this.settings.alwaysPreviewBeforeSave = value;
           await this.saveSettings();
+        });
+      });
+
+    // ── Ollama ────────────────────────────────────────────────────────────────
+    containerEl.createEl("h2", { text: "Gemmera — Ollama" });
+
+    new Setting(containerEl)
+      .setName("Ollama path")
+      .setDesc("auto: find ollama on PATH. manual: provide an explicit path.")
+      .addDropdown((dd: { addOption: (v: string, l: string) => unknown; setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown }) => {
+        dd.addOption("auto", "Auto (PATH lookup)");
+        dd.addOption("manual", "Manual path");
+        dd.setValue(this.settings.ollamaPathMode);
+        dd.onChange(async (value: string) => {
+          this.settings.ollamaPathMode = value as "auto" | "manual";
+          await this.saveSettings();
+          this.display(); // re-render to show/hide path field
+        });
+      });
+
+    if (this.settings.ollamaPathMode === "manual") {
+      new Setting(containerEl)
+        .setName("Ollama binary path")
+        .setDesc("Full path to the ollama binary, e.g. /usr/local/bin/ollama")
+        .addText((text: { setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown; setPlaceholder?: (s: string) => unknown }) => {
+          text.setPlaceholder?.("/usr/local/bin/ollama");
+          text.setValue(this.settings.ollamaPath);
+          text.onChange(async (value: string) => {
+            this.settings.ollamaPath = value;
+            await this.saveSettings();
+          });
+        });
+    }
+
+    // ── Advanced ──────────────────────────────────────────────────────────────
+    containerEl.createEl("h3", { text: "Advanced" });
+
+    new Setting(containerEl)
+      .setName("Restart Ollama")
+      .setDesc("Stop and re-spawn Ollama. Disabled while a restart is already in progress.")
+      .addButton((btn: { setButtonText: (t: string) => unknown; setDisabled: (d: boolean) => unknown; onClick: (cb: () => void) => unknown; setCta?: () => unknown }) => {
+        const inFlight = this.lifecycle?.inFlight ?? false;
+        btn.setButtonText("Restart");
+        btn.setDisabled(inFlight);
+        btn.onClick(async () => {
+          if (!this.lifecycle) return;
+          await this.lifecycle.restart();
+          new Notice("Gemmera: Ollama restarted");
+          await this.refresh();
         });
       });
   }

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -181,7 +181,7 @@ export class GemmeraSettingsTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Ollama path")
-      .setDesc("auto: find ollama on PATH. manual: provide an explicit path.")
+      .setDesc("auto: find ollama on PATH. manual: provide an explicit path. Changes take effect on next Obsidian restart.")
       .addDropdown((dd: { addOption: (v: string, l: string) => unknown; setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown }) => {
         dd.addOption("auto", "Auto (PATH lookup)");
         dd.addOption("manual", "Manual path");

--- a/src/ui/turn-inspector.ts
+++ b/src/ui/turn-inspector.ts
@@ -1,0 +1,79 @@
+import { Modal, type App } from "obsidian";
+import type { InspectorEntry } from "../services/turn-status";
+
+/**
+ * Developer-facing modal that shows every state entered during a turn (#66).
+ *
+ * Open it via `openTurnInspector(app, entries)` after a turn completes.
+ * Only surface this in dev mode — production users should not see raw state
+ * names and timestamps.
+ */
+export function openTurnInspector(app: App, entries: InspectorEntry[]): void {
+  const modal = new TurnInspectorModal(app, entries);
+  modal.open();
+}
+
+class TurnInspectorModal extends Modal {
+  constructor(
+    app: App,
+    private readonly entries: InspectorEntry[],
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    contentEl.createEl("h2", { text: "Turn Inspector" });
+
+    if (this.entries.length === 0) {
+      contentEl.createEl("p", { text: "No state entries recorded for this turn." });
+      return;
+    }
+
+    const table = contentEl.createEl("table");
+    table.style.width = "100%";
+    table.style.borderCollapse = "collapse";
+    table.style.fontSize = "12px";
+
+    const head = table.createEl("thead");
+    const headRow = head.createEl("tr");
+    for (const col of ["State", "Label", "From", "Time", "Payload"]) {
+      const th = headRow.createEl("th", { text: col });
+      th.style.textAlign = "left";
+      th.style.padding = "4px 8px";
+      th.style.borderBottom = "1px solid var(--background-modifier-border)";
+    }
+
+    const body = table.createEl("tbody");
+    for (const entry of this.entries) {
+      const row = body.createEl("tr");
+      row.style.verticalAlign = "top";
+
+      const cells = [
+        entry.state,
+        entry.label,
+        entry.fromState ?? "—",
+        entry.time.replace("T", " ").replace("Z", ""),
+        entry.payloadPreview ?? "",
+      ];
+      for (const text of cells) {
+        const td = row.createEl("td", { text });
+        td.style.padding = "4px 8px";
+        td.style.borderBottom = "1px solid var(--background-modifier-border)";
+        td.style.fontFamily = "var(--font-monospace)";
+        td.style.whiteSpace = "pre-wrap";
+        td.style.wordBreak = "break-all";
+      }
+    }
+
+    const closeBtn = contentEl.createEl("button", { text: "Close" });
+    closeBtn.style.marginTop = "12px";
+    closeBtn.addEventListener("click", () => this.close());
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}


### PR DESCRIPTION
## Summary

- **RetryBudget** — shared per-turn 3-retry ceiling (from `HARD_STOPS.MAX_RETRIES_PER_TURN`) for all model-output retries; infra retries never draw from this pool
- **withJsonRetry** — calls fn, catches thrown/null parse failures, retries once under budget; handles `JSON.parse`-style parsers that throw
- **withFeedbackRetry** — calls fn, validates result, retries once with error message forwarded to model; budget gated
- **withInfraRetry** — transport-level 1-retry with configurable delay and injectable sleep (for deterministic tests); does NOT consume from RetryBudget
- **STATE_LABELS + labelForState** — every state in every SM maps to a readable UI string; unknown states fall back to the raw name
- **TurnStatusCallback** — `(state, label) => void` type injected into orchestrator deps for live status-chip updates
- **formatInspectorEntries** — converts raw EventLog `enter` entries to display-ready `InspectorEntry` objects (ISO time, payload preview truncated at 120 chars)
- **TurnInspectorModal** — dev-mode Obsidian Modal showing the full state timeline for a completed turn
- **IngestOrchestratorDeps.onStateChange** — fires TurnStatusCallback on every `enter()` call so the chat view can update its status chip in real time
- Fix: `prevState` initialised to `"CLASSIFY_INTENT"` (was `"IDLE"`) — the classifier always runs upstream before routing to `runIngest`

## Test plan

- [ ] `npx vitest run` — 538 tests, all green
- [ ] `RetryBudget` tracks count, caps at MAX, custom max
- [ ] `withJsonRetry` success / retry-success / both-fail / budget-exhausted / budget-carries-across-calls / custom-parse paths
- [ ] `withFeedbackRetry` success / retry-with-feedback / both-fail / budget-exhausted / signal forwarding
- [ ] `withInfraRetry` success / retry / both-fail / delay param / does NOT consume from budget
- [ ] `STATE_LABELS` covers all ingest, query, destructive-op, shared, and terminal states
- [ ] `labelForState` falls back to raw name for unknown states
- [ ] `formatInspectorEntries` filters exit entries, maps labels, formats ISO time, truncates payload at 120 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)