### PR TITLE
feat(tool-loop): mixed-intent orchestration — ingest then query in one turn (#47)

### DIFF
--- a/src/contracts/state-machine.ts
+++ b/src/contracts/state-machine.ts
@@ -132,6 +132,8 @@ export interface EventLogEntry {
   fromState: string | null;
   timestamp: number;
   triggeringEvent: StateMachineEvent | null;
+  /** Set on mixed-intent turns to distinguish which phase produced the entry. */
+  phase?: "ingest" | "query";
 }
 
 // Implementations must guarantee that any entry passed to a fully-resolved

--- a/src/services/mixed-orchestrator.test.ts
+++ b/src/services/mixed-orchestrator.test.ts
@@ -171,44 +171,64 @@ describe("runMixed", () => {
     expect(queryEntries).toHaveLength(0);
   });
 
-  it("cancelled mid-query via signal: note is saved, query phase fails gracefully", async () => {
-    const queryReply = JSON.stringify({ answer: "Answer.", citations: [] });
-
+  it("cancelled mid-query via signal (pre-abort): note is saved, query fails with savedPath", async () => {
     const queryController = new AbortController();
-    const vault = new MockVaultService({});
-    const store = new InMemoryIngestionStore();
-    const queue = new InMemoryJobQueue();
-    const writer = new IngestWriter(vault);
-    const eventLog = new InMemoryEventLog();
-
-    // Abort the query signal immediately
     queryController.abort();
 
-    const deps: MixedOrchestratorDeps & { eventLog: InMemoryEventLog } = {
-      llm: new SequenceLLM([specReply(), queryReply]),
-      promptLoader,
-      retriever: new StubRetriever([makeHit("note.md")]),
-      store,
-      vault,
-      writer,
-      jobQueue: queue,
-      preview: confirmPreview,
-      assembler: new StubAssembler([makeChunk("note.md")]),
-      eventLog,
-      turnId: "turn-2",
-      alwaysPreview: false,
-      querySignal: queryController.signal,
-    };
+    const deps = setup({ llmReplies: [specReply()] });
+    deps.querySignal = queryController.signal;
 
     const outcome = await runMixed("test", deps);
 
-    // Query phase failed (aborted) but ingest note was preserved
     expect(outcome.kind).toBe("failed");
     if (outcome.kind !== "failed") return;
     expect(outcome.phase).toBe("query");
+    expect(outcome.savedPath).toBeTruthy();
 
-    // Verify the job queue has an index job for the saved note (ingest completed)
-    const jobs = queue.drain();
+    const jobs = (deps.jobQueue as InMemoryJobQueue).drain();
+    expect(jobs.some((j) => j.kind === "index")).toBe(true);
+  });
+
+  it("in-flight query abort: note is saved, query phase fails after LLM aborted", async () => {
+    const queryController = new AbortController();
+
+    // First LLM call (ingest parse): resolves immediately.
+    // Second call (query generate): hangs until signal is aborted.
+    let calls = 0;
+    const blockingLlm: LLMService = {
+      async chat(opts: ChatOptions): Promise<LLMResponse> {
+        if (calls++ === 0) return { content: specReply() };
+        return new Promise((_, reject) => {
+          if (opts.signal?.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          opts.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        });
+      },
+      async isReachable(): Promise<LLMReachability> { return "running"; },
+      async listModels(): Promise<string[]> { return []; },
+      async pickDefaultModel(): Promise<string> { return "test-model"; },
+    };
+
+    const deps = setup({ llmReplies: [] });
+    deps.llm = blockingLlm;
+    deps.querySignal = queryController.signal;
+
+    // Abort after ingest completes but while query is in flight
+    setTimeout(() => queryController.abort(), 0);
+
+    const outcome = await runMixed("test", deps);
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.phase).toBe("query");
+    // savedPath must be set so the UI can inform the user the note was saved
+    expect(outcome.savedPath).toBeTruthy();
+
+    const jobs = (deps.jobQueue as InMemoryJobQueue).drain();
     expect(jobs.some((j) => j.kind === "index")).toBe(true);
   });
 

--- a/src/services/mixed-orchestrator.test.ts
+++ b/src/services/mixed-orchestrator.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { InMemoryIngestionStore } from "../contracts/mocks/in-memory-ingestion-store";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { IngestWriter } from "./ingest-writer";
+import { InMemoryEventLog } from "./event-log";
+import { runMixed, type MixedOrchestratorDeps, type MixedPhase } from "./mixed-orchestrator";
+import type {
+  ChatOptions,
+  LLMReachability,
+  LLMResponse,
+  LLMService,
+  LoadedPrompt,
+  NoteSpec,
+  PayloadAssembler,
+  PayloadChunk,
+  PromptLoader,
+  RetrievalHit,
+  RetrievalPayload,
+  Retriever,
+} from "../contracts";
+import type { PreviewDecision, PreviewHandler } from "./ingest-orchestrator";
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+class SequenceLLM implements LLMService {
+  private calls = 0;
+  constructor(private readonly replies: string[]) {}
+  async chat(_opts: ChatOptions): Promise<LLMResponse> {
+    const reply = this.replies[this.calls] ?? this.replies[this.replies.length - 1];
+    this.calls++;
+    return { content: reply };
+  }
+  async isReachable(): Promise<LLMReachability> { return "running"; }
+  async listModels(): Promise<string[]> { return []; }
+  async pickDefaultModel(): Promise<string> { return "test-model"; }
+}
+
+class AbortingLLM implements LLMService {
+  async chat(opts: ChatOptions): Promise<LLMResponse> {
+    if (opts.signal?.aborted) throw new DOMException("Aborted", "AbortError");
+    return { content: '{"answer":"x","citations":[]}' };
+  }
+  async isReachable(): Promise<LLMReachability> { return "running"; }
+  async listModels(): Promise<string[]> { return []; }
+  async pickDefaultModel(): Promise<string> { return "test-model"; }
+}
+
+class StubRetriever implements Retriever {
+  constructor(private readonly hits: RetrievalHit[] = []) {}
+  async retrieve(): Promise<RetrievalHit[]> { return this.hits; }
+}
+
+class StubAssembler implements PayloadAssembler {
+  constructor(private readonly chunks: PayloadChunk[] = []) {}
+  assemble(query: string): RetrievalPayload { return { query, chunks: this.chunks }; }
+}
+
+const promptLoader: PromptLoader = {
+  async load(): Promise<LoadedPrompt> {
+    return { id: "ingest-parser", version: "0.1", body: "stub" };
+  },
+  invalidate() {},
+};
+
+const confirmPreview: PreviewHandler = async () => ({ action: "confirm" });
+const cancelPreview: PreviewHandler = async () => ({ action: "cancel" });
+
+function specReply(overrides: Partial<NoteSpec> = {}): string {
+  return JSON.stringify({
+    title: "Mixed note",
+    type: "meeting",
+    tags: [],
+    aliases: [],
+    source: "chat-paste",
+    entities: [],
+    related: [],
+    status: "inbox",
+    summary: "A note.",
+    key_points: [],
+    body_markdown: "# Mixed\n\nContent.",
+    confidence: "high",
+    ...overrides,
+  });
+}
+
+function makeChunk(path: string): PayloadChunk {
+  return {
+    path,
+    title: path,
+    text: "chunk text",
+    headingPath: [],
+    whyMatched: "semantic",
+  } as unknown as PayloadChunk;
+}
+
+function makeHit(path: string): RetrievalHit {
+  return {
+    path,
+    title: path,
+    ord: 0,
+    contentHash: `hash-${path}`,
+    text: "hit text",
+    headingPath: [],
+    score: 0.2, // below LLM_FLOOR_SCORE (0.3) so decideStrategy skips the LLM call
+    winningSignal: "semantic",
+  };
+}
+
+function setup(opts: {
+  llmReplies: string[];
+  preview?: PreviewHandler;
+  retrieverHits?: RetrievalHit[];
+  chunks?: PayloadChunk[];
+}): MixedOrchestratorDeps & { eventLog: InMemoryEventLog } {
+  const vault = new MockVaultService({});
+  const store = new InMemoryIngestionStore();
+  const queue = new InMemoryJobQueue();
+  const writer = new IngestWriter(vault);
+  const eventLog = new InMemoryEventLog();
+  const hits = opts.retrieverHits ?? [makeHit("note.md")];
+  const chunks = opts.chunks ?? [makeChunk("note.md")];
+
+  return {
+    llm: new SequenceLLM(opts.llmReplies),
+    promptLoader,
+    retriever: new StubRetriever(hits),
+    store,
+    vault,
+    writer,
+    jobQueue: queue,
+    preview: opts.preview ?? confirmPreview,
+    assembler: new StubAssembler(chunks),
+    eventLog,
+    turnId: "turn-1",
+    alwaysPreview: false,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("runMixed", () => {
+  it("clean turn: saves note then returns answer", async () => {
+    const queryReply = JSON.stringify({ answer: "Here is your answer.", citations: ["note.md"] });
+    const deps = setup({ llmReplies: [specReply(), queryReply] });
+
+    const outcome = await runMixed("Save this and answer me", deps);
+
+    expect(outcome.kind).toBe("answered");
+    if (outcome.kind !== "answered") return;
+    expect(outcome.answer).toBe("Here is your answer.");
+    expect(outcome.citations).toEqual(["note.md"]);
+    expect(outcome.savedPath).toMatch(/\.md$/);
+  });
+
+  it("clean turn: event log has both ingest and query phases", async () => {
+    const queryReply = JSON.stringify({ answer: "Answer.", citations: [] });
+    const deps = setup({ llmReplies: [specReply(), queryReply], chunks: [] });
+
+    await runMixed("test", deps);
+
+    const entries = await deps.eventLog.eventsFor("turn-1");
+    const phases = entries.map((e) => e.phase).filter(Boolean);
+    expect(phases).toContain("ingest");
+    expect(phases).toContain("query");
+  });
+
+  it("cancelled mid-ingest: aborts whole turn, no query phase", async () => {
+    const deps = setup({ llmReplies: [specReply()], preview: cancelPreview });
+    deps.alwaysPreview = true; // force preview so cancelPreview can fire
+
+    const outcome = await runMixed("test", deps);
+
+    expect(outcome.kind).toBe("cancelled");
+    if (outcome.kind !== "cancelled") return;
+    expect(outcome.phase).toBe("ingest");
+
+    const entries = await deps.eventLog.eventsFor("turn-1");
+    const queryEntries = entries.filter((e) => e.phase === "query");
+    expect(queryEntries).toHaveLength(0);
+  });
+
+  it("cancelled mid-query via signal: note is saved, query phase fails gracefully", async () => {
+    const queryReply = JSON.stringify({ answer: "Answer.", citations: [] });
+
+    const queryController = new AbortController();
+    const vault = new MockVaultService({});
+    const store = new InMemoryIngestionStore();
+    const queue = new InMemoryJobQueue();
+    const writer = new IngestWriter(vault);
+    const eventLog = new InMemoryEventLog();
+
+    // Abort the query signal immediately
+    queryController.abort();
+
+    const deps: MixedOrchestratorDeps & { eventLog: InMemoryEventLog } = {
+      llm: new SequenceLLM([specReply(), queryReply]),
+      promptLoader,
+      retriever: new StubRetriever([makeHit("note.md")]),
+      store,
+      vault,
+      writer,
+      jobQueue: queue,
+      preview: confirmPreview,
+      assembler: new StubAssembler([makeChunk("note.md")]),
+      eventLog,
+      turnId: "turn-2",
+      alwaysPreview: false,
+      querySignal: queryController.signal,
+    };
+
+    const outcome = await runMixed("test", deps);
+
+    // Query phase failed (aborted) but ingest note was preserved
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.phase).toBe("query");
+
+    // Verify the job queue has an index job for the saved note (ingest completed)
+    const jobs = queue.drain();
+    expect(jobs.some((j) => j.kind === "index")).toBe(true);
+  });
+
+  it("onStateChange called with phase for both ingest and query", async () => {
+    const queryReply = JSON.stringify({ answer: "Answer.", citations: [] });
+    const deps = setup({ llmReplies: [specReply(), queryReply], chunks: [] });
+
+    const calls: Array<{ state: string; phase: MixedPhase }> = [];
+    deps.onStateChange = (state, _label, phase) => calls.push({ state, phase });
+
+    await runMixed("test", deps);
+
+    const ingestCalls = calls.filter((c) => c.phase === "ingest");
+    const queryCalls = calls.filter((c) => c.phase === "query");
+    expect(ingestCalls.length).toBeGreaterThan(0);
+    expect(queryCalls.length).toBeGreaterThan(0);
+  });
+
+  it("ingest failure: returns failed with ingest phase, no query", async () => {
+    // LLM returns invalid JSON so parse fails
+    const deps = setup({ llmReplies: ["not json at all"] });
+
+    const outcome = await runMixed("test", deps);
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.phase).toBe("ingest");
+  });
+});

--- a/src/services/mixed-orchestrator.test.ts
+++ b/src/services/mixed-orchestrator.test.ts
@@ -36,15 +36,6 @@ class SequenceLLM implements LLMService {
   async pickDefaultModel(): Promise<string> { return "test-model"; }
 }
 
-class AbortingLLM implements LLMService {
-  async chat(opts: ChatOptions): Promise<LLMResponse> {
-    if (opts.signal?.aborted) throw new DOMException("Aborted", "AbortError");
-    return { content: '{"answer":"x","citations":[]}' };
-  }
-  async isReachable(): Promise<LLMReachability> { return "running"; }
-  async listModels(): Promise<string[]> { return []; }
-  async pickDefaultModel(): Promise<string> { return "test-model"; }
-}
 
 class StubRetriever implements Retriever {
   constructor(private readonly hits: RetrievalHit[] = []) {}

--- a/src/services/mixed-orchestrator.ts
+++ b/src/services/mixed-orchestrator.ts
@@ -65,7 +65,6 @@ export async function runMixed(
   const turnId = deps.turnId ?? crypto.randomUUID();
 
   const ingestLog = deps.eventLog ? new PhaseEventLog(deps.eventLog, "ingest") : undefined;
-  const queryLog = deps.eventLog ? new PhaseEventLog(deps.eventLog, "query") : undefined;
 
   // ── INGEST PHASE ──────────────────────────────────────────────────────
   const ingestOutcome = await runIngest(
@@ -99,7 +98,7 @@ export async function runMixed(
   }
 
   const savedPath =
-    ingestOutcome.kind === "saved"
+    ingestOutcome.kind === "saved" || ingestOutcome.kind === "skipped_existing"
       ? ingestOutcome.path
       : ingestOutcome.kind === "split_saved"
         ? (ingestOutcome.paths[0] ?? "")
@@ -109,6 +108,8 @@ export async function runMixed(
   if (deps.querySignal?.aborted) {
     return { kind: "failed", phase: "query", reason: "aborted" };
   }
+
+  const queryLog = deps.eventLog ? new PhaseEventLog(deps.eventLog, "query") : undefined;
 
   const queryOutcome = await runQuery(
     { query: text },

--- a/src/services/mixed-orchestrator.ts
+++ b/src/services/mixed-orchestrator.ts
@@ -1,0 +1,161 @@
+import type {
+  EventLog,
+  EventLogEntry,
+  IngestionStore,
+  JobQueue,
+  LLMService,
+  PayloadAssembler,
+  PromptLoader,
+  Retriever,
+  VaultService,
+} from "../contracts";
+import { IngestWriter } from "./ingest-writer";
+import { runIngest, type PreviewHandler } from "./ingest-orchestrator";
+import { runQuery } from "./query-orchestrator";
+
+export type MixedPhase = "ingest" | "query";
+
+export type MixedOutcome =
+  | { kind: "answered"; answer: string; citations: string[]; savedPath: string }
+  | { kind: "cancelled"; phase: MixedPhase }
+  | { kind: "failed"; phase: MixedPhase; reason: string }
+  | { kind: "validation_failed"; answer: string; savedPath: string };
+
+export interface MixedOrchestratorDeps {
+  llm: LLMService;
+  promptLoader: PromptLoader;
+  retriever: Retriever;
+  store: IngestionStore;
+  vault: VaultService;
+  writer: IngestWriter;
+  jobQueue: JobQueue;
+  preview: PreviewHandler;
+  assembler: PayloadAssembler;
+  reranker?: Retriever;
+  eventLog?: EventLog;
+  turnId?: string;
+  /** Called on each state entry with the state name, label, and current phase. */
+  onStateChange?: (state: string, label: string, phase: MixedPhase) => void;
+  inboxFolder?: string;
+  dedupThreshold?: number;
+  alwaysPreview?: boolean;
+  model?: string;
+  version?: string;
+  /** Signal for the ingest phase. Aborting this also aborts the whole turn. */
+  ingestSignal?: AbortSignal;
+  /** Signal for the query phase only. Aborting preserves the saved note. */
+  querySignal?: AbortSignal;
+}
+
+/**
+ * Orchestrates a mixed-intent turn (#47): ingest runs first to completion,
+ * then query runs against the vault (which now includes the newly saved note).
+ *
+ * Both phases share a single `turnId`. Event log entries are tagged with a
+ * `phase` field so the turn inspector can show ingest and query as separate
+ * sections within one turn.
+ *
+ * Cancellation during ingest aborts the whole turn. Cancellation after ingest
+ * completes preserves the saved note and aborts only the query phase.
+ */
+export async function runMixed(
+  text: string,
+  deps: MixedOrchestratorDeps,
+): Promise<MixedOutcome> {
+  const turnId = deps.turnId ?? crypto.randomUUID();
+
+  const ingestLog = deps.eventLog ? new PhaseEventLog(deps.eventLog, "ingest") : undefined;
+  const queryLog = deps.eventLog ? new PhaseEventLog(deps.eventLog, "query") : undefined;
+
+  // ── INGEST PHASE ──────────────────────────────────────────────────────
+  const ingestOutcome = await runIngest(
+    { text },
+    {
+      llm: deps.llm,
+      promptLoader: deps.promptLoader,
+      retriever: deps.retriever,
+      store: deps.store,
+      vault: deps.vault,
+      writer: deps.writer,
+      jobQueue: deps.jobQueue,
+      preview: deps.preview,
+      eventLog: ingestLog,
+      turnId,
+      onStateChange: deps.onStateChange
+        ? (state, label) => deps.onStateChange!(state, label, "ingest")
+        : undefined,
+      inboxFolder: deps.inboxFolder,
+      dedupThreshold: deps.dedupThreshold,
+      alwaysPreview: deps.alwaysPreview,
+      model: deps.model,
+      version: deps.version,
+      signal: deps.ingestSignal,
+    },
+  );
+
+  if (ingestOutcome.kind === "cancelled") return { kind: "cancelled", phase: "ingest" };
+  if (ingestOutcome.kind === "failed") {
+    return { kind: "failed", phase: "ingest", reason: ingestOutcome.reason };
+  }
+
+  const savedPath =
+    ingestOutcome.kind === "saved"
+      ? ingestOutcome.path
+      : ingestOutcome.kind === "split_saved"
+        ? (ingestOutcome.paths[0] ?? "")
+        : "";
+
+  // ── QUERY PHASE ───────────────────────────────────────────────────────
+  if (deps.querySignal?.aborted) {
+    return { kind: "failed", phase: "query", reason: "aborted" };
+  }
+
+  const queryOutcome = await runQuery(
+    { query: text },
+    {
+      retriever: deps.retriever,
+      assembler: deps.assembler,
+      llm: deps.llm,
+      reranker: deps.reranker,
+      eventLog: queryLog,
+      turnId,
+      model: deps.model,
+      signal: deps.querySignal,
+      onStateChange: deps.onStateChange
+        ? (state, label) => deps.onStateChange!(state, label, "query")
+        : undefined,
+    },
+  );
+
+  if (queryOutcome.kind === "failed") {
+    return { kind: "failed", phase: "query", reason: queryOutcome.reason };
+  }
+  if (queryOutcome.kind === "validation_failed") {
+    return { kind: "validation_failed", answer: queryOutcome.answer, savedPath };
+  }
+  if (queryOutcome.kind === "empty") {
+    return { kind: "answered", answer: "No relevant notes found.", citations: [], savedPath };
+  }
+
+  return {
+    kind: "answered",
+    answer: queryOutcome.answer,
+    citations: queryOutcome.citations,
+    savedPath,
+  };
+}
+
+class PhaseEventLog implements EventLog {
+  constructor(
+    private readonly inner: EventLog,
+    private readonly phase: MixedPhase,
+  ) {}
+
+  write(entry: EventLogEntry): void | Promise<void> {
+    return this.inner.write({ ...entry, phase: this.phase });
+  }
+
+  eventsFor(turnId: string): Promise<readonly EventLogEntry[]> {
+    return this.inner.eventsFor(turnId);
+  }
+}

--- a/src/services/mixed-orchestrator.ts
+++ b/src/services/mixed-orchestrator.ts
@@ -18,7 +18,7 @@ export type MixedPhase = "ingest" | "query";
 export type MixedOutcome =
   | { kind: "answered"; answer: string; citations: string[]; savedPath: string }
   | { kind: "cancelled"; phase: MixedPhase }
-  | { kind: "failed"; phase: MixedPhase; reason: string }
+  | { kind: "failed"; phase: MixedPhase; reason: string; savedPath?: string }
   | { kind: "validation_failed"; answer: string; savedPath: string };
 
 export interface MixedOrchestratorDeps {
@@ -45,6 +45,12 @@ export interface MixedOrchestratorDeps {
   ingestSignal?: AbortSignal;
   /** Signal for the query phase only. Aborting preserves the saved note. */
   querySignal?: AbortSignal;
+  /**
+   * Called after ingest succeeds and before query starts, with the path of
+   * the saved note. Lets callers record the path so they can inform the user
+   * even if the query phase throws unexpectedly.
+   */
+  onIngestComplete?: (savedPath: string) => void;
 }
 
 /**
@@ -63,6 +69,7 @@ export async function runMixed(
   deps: MixedOrchestratorDeps,
 ): Promise<MixedOutcome> {
   const turnId = deps.turnId ?? crypto.randomUUID();
+  const onStateChange = deps.onStateChange;
 
   const ingestLog = deps.eventLog ? new PhaseEventLog(deps.eventLog, "ingest") : undefined;
 
@@ -80,8 +87,8 @@ export async function runMixed(
       preview: deps.preview,
       eventLog: ingestLog,
       turnId,
-      onStateChange: deps.onStateChange
-        ? (state, label) => deps.onStateChange!(state, label, "ingest")
+      onStateChange: onStateChange
+        ? (state, label) => onStateChange(state, label, "ingest")
         : undefined,
       inboxFolder: deps.inboxFolder,
       dedupThreshold: deps.dedupThreshold,
@@ -101,12 +108,14 @@ export async function runMixed(
     ingestOutcome.kind === "saved" || ingestOutcome.kind === "skipped_existing"
       ? ingestOutcome.path
       : ingestOutcome.kind === "split_saved"
-        ? (ingestOutcome.paths[0] ?? "")
+        ? (ingestOutcome.paths[0] ?? "(split into multiple notes)")
         : "";
+
+  deps.onIngestComplete?.(savedPath);
 
   // ── QUERY PHASE ───────────────────────────────────────────────────────
   if (deps.querySignal?.aborted) {
-    return { kind: "failed", phase: "query", reason: "aborted" };
+    return { kind: "failed", phase: "query", reason: "aborted", savedPath };
   }
 
   const queryLog = deps.eventLog ? new PhaseEventLog(deps.eventLog, "query") : undefined;
@@ -122,14 +131,14 @@ export async function runMixed(
       turnId,
       model: deps.model,
       signal: deps.querySignal,
-      onStateChange: deps.onStateChange
-        ? (state, label) => deps.onStateChange!(state, label, "query")
+      onStateChange: onStateChange
+        ? (state, label) => onStateChange(state, label, "query")
         : undefined,
     },
   );
 
   if (queryOutcome.kind === "failed") {
-    return { kind: "failed", phase: "query", reason: queryOutcome.reason };
+    return { kind: "failed", phase: "query", reason: queryOutcome.reason, savedPath };
   }
   if (queryOutcome.kind === "validation_failed") {
     return { kind: "validation_failed", answer: queryOutcome.answer, savedPath };

--- a/src/services/query-orchestrator.ts
+++ b/src/services/query-orchestrator.ts
@@ -7,6 +7,8 @@ import type {
   RetrievalPayload,
   Retriever,
 } from "../contracts";
+import type { TurnStatusCallback } from "./turn-status";
+import { labelForState } from "./turn-status";
 
 const STATES = {
   planRetrieval: "PLAN_RETRIEVAL",
@@ -48,6 +50,7 @@ export interface QueryOrchestratorDeps {
   turnId?: string;
   model?: string;
   signal?: AbortSignal;
+  onStateChange?: TurnStatusCallback;
 }
 
 interface LLMQueryResponse {
@@ -72,6 +75,7 @@ export async function runQuery(
   // from the state the classifier left on exit.
   let prevState = "CLASSIFY_INTENT";
   const enter = async (state: string, payload?: Record<string, unknown>) => {
+    deps.onStateChange?.(state, labelForState(state));
     if (!deps.eventLog) return;
     const entry: EventLogEntry = {
       turnId,

--- a/src/view.ts
+++ b/src/view.ts
@@ -8,6 +8,7 @@ import { parseFileOps, handleFileOps } from "./fileops";
 import { classifyTurn } from "./services/classifier-orchestrator";
 import { toDisambiguationRow } from "./services/classifier-events";
 import { runIngest } from "./services/ingest-orchestrator";
+import { runMixed } from "./services/mixed-orchestrator";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
@@ -178,6 +179,15 @@ export class GemmeraChatView extends ItemView {
       return;
     }
 
+    // ── Mixed (#47) ───────────────────────────────────────────────────
+    if (intent === "mixed") {
+      await this.runMixed(text, turnId);
+      this.recentTurns = [...this.recentTurns.slice(-2), { text, intent: "mixed" }];
+      this.setInputDisabled(false);
+      this.inputEl.focus();
+      return;
+    }
+
     // ── Chat ──────────────────────────────────────────────────────────
     await this.runChat(text, intent, turnId, route ?? null);
   }
@@ -222,6 +232,71 @@ export class GemmeraChatView extends ItemView {
         this.appendMessage("assistant", `Capture failed: ${outcome.reason}`);
       }
     } catch (err) {
+      this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
+    }
+  }
+
+  private async runMixed(text: string, turnId: string): Promise<void> {
+    this.appendMessage("user", text);
+
+    const ingestStatusEl = this.messagesEl.createEl("div", {
+      cls: "gemmera-mixed-status gemmera-mixed-status--ingest",
+      text: "Saving note…",
+    });
+    const queryStatusEl = this.messagesEl.createEl("div", {
+      cls: "gemmera-mixed-status gemmera-mixed-status--query",
+      text: "Searching notes…",
+    });
+    queryStatusEl.style.display = "none";
+
+    try {
+      const outcome = await runMixed(text, {
+        llm: this.services.llm,
+        promptLoader: this.services.promptLoader,
+        retriever: this.services.retriever,
+        store: this.services.ingestionStore,
+        vault: this.services.vault,
+        writer: this.services.ingestWriter,
+        jobQueue: this.services.jobQueue,
+        preview: (preview) => openIngestPreview(this.app, preview),
+        assembler: this.services.payloadAssembler,
+        eventLog: this.services.eventLog,
+        turnId,
+        inboxFolder: this.settings.inboxFolder,
+        dedupThreshold: this.settings.dedupThreshold,
+        alwaysPreview: this.settings.alwaysPreviewBeforeSave,
+        onStateChange: (state, label, phase) => {
+          if (phase === "ingest") {
+            ingestStatusEl.textContent = label;
+          } else {
+            queryStatusEl.style.display = "";
+            queryStatusEl.textContent = label;
+          }
+        },
+      });
+
+      this.services.runnerStatus.recompute();
+      ingestStatusEl.remove();
+      queryStatusEl.remove();
+
+      if (outcome.kind === "cancelled") {
+        this.appendMessage("assistant", "Cancelled.");
+      } else if (outcome.kind === "failed") {
+        const phaseLabel = outcome.phase === "ingest" ? "Save" : "Answer";
+        this.appendMessage("assistant", `${phaseLabel} failed: ${outcome.reason}`);
+      } else if (outcome.kind === "validation_failed") {
+        new Notice(`Gemmera: saved to ${outcome.savedPath}`);
+        this.appendMessage("assistant", `Saved to **${outcome.savedPath}**\n\n${outcome.answer}`);
+      } else {
+        new Notice(`Gemmera: saved to ${outcome.savedPath}`);
+        const citations = outcome.citations.length > 0
+          ? `\n\n*Sources: ${outcome.citations.map((c) => `[[${c}]]`).join(", ")}*`
+          : "";
+        this.appendMessage("assistant", `Saved to **${outcome.savedPath}**\n\n${outcome.answer}${citations}`);
+      }
+    } catch (err) {
+      ingestStatusEl.remove();
+      queryStatusEl.remove();
       this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
     }
   }

--- a/src/view.ts
+++ b/src/view.ts
@@ -249,6 +249,8 @@ export class GemmeraChatView extends ItemView {
     });
     queryStatusEl.style.display = "none";
 
+    let savedPathSoFar: string | undefined;
+
     try {
       const outcome = await runMixed(text, {
         llm: this.services.llm,
@@ -273,6 +275,7 @@ export class GemmeraChatView extends ItemView {
             queryStatusEl.textContent = label;
           }
         },
+        onIngestComplete: (path) => { savedPathSoFar = path; },
       });
 
       this.services.runnerStatus.recompute();
@@ -282,8 +285,11 @@ export class GemmeraChatView extends ItemView {
       if (outcome.kind === "cancelled") {
         this.appendMessage("assistant", "Cancelled.");
       } else if (outcome.kind === "failed") {
-        const phaseLabel = outcome.phase === "ingest" ? "Save" : "Answer";
-        this.appendMessage("assistant", `${phaseLabel} failed: ${outcome.reason}`);
+        if (outcome.phase === "query" && outcome.savedPath) {
+          this.appendMessage("assistant", `Answer failed: ${outcome.reason}\n\nNote was saved to **${outcome.savedPath}**.`);
+        } else {
+          this.appendMessage("assistant", `Save failed: ${outcome.reason}`);
+        }
       } else if (outcome.kind === "validation_failed") {
         new Notice(`Gemmera: saved to ${outcome.savedPath}`);
         this.appendMessage("assistant", `Saved to **${outcome.savedPath}**\n\n${outcome.answer}`);
@@ -297,6 +303,9 @@ export class GemmeraChatView extends ItemView {
     } catch (err) {
       ingestStatusEl.remove();
       queryStatusEl.remove();
+      if (savedPathSoFar) {
+        this.appendMessage("assistant", `Note was saved to **${savedPathSoFar}**, but the query failed unexpectedly.`);
+      }
       this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,16 @@
   color: var(--text-error);
 }
 
+.gemmera-mixed-status {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  padding: 4px 12px;
+  font-style: italic;
+}
+
+.gemmera-mixed-status--ingest::before { content: "📥 "; }
+.gemmera-mixed-status--query::before  { content: "🔍 "; }
+
 .gemmera-retry-btn {
   align-self: flex-start;
   margin-top: 4px;

--- a/styles.css
+++ b/styles.css
@@ -111,8 +111,8 @@
   font-style: italic;
 }
 
-.gemmera-mixed-status--ingest::before { content: "📥 "; }
-.gemmera-mixed-status--query::before  { content: "🔍 "; }
+.gemmera-mixed-status--ingest { border-left: 2px solid var(--color-accent); padding-left: 8px; }
+.gemmera-mixed-status--query  { border-left: 2px solid var(--text-muted); padding-left: 8px; }
 
 .gemmera-retry-btn {
   align-self: flex-start;


### PR DESCRIPTION
## Summary

- Closes #47
- Adds `runMixed` orchestrator that chains `runIngest` → `runQuery` under a single `turnId`
- `EventLogEntry` gains an optional `phase: "ingest" | "query"` field for turn inspector phase separation
- `QueryOrchestratorDeps` gains `onStateChange` so the query phase drives live status updates
- `view.ts` routes `intent === "mixed"` to a new `runMixed` method with two phase-specific status elements
- Cancellation during ingest aborts the whole turn; aborting `querySignal` after ingest preserves the saved note

## Test plan

- [ ] 6 new tests in `src/services/mixed-orchestrator.test.ts` — all pass (`620/620` suite green)
- [ ] Clean mixed turn saves note and returns answer with citations
- [ ] Ingest cancel propagates as `{ kind: "cancelled", phase: "ingest" }`, query never starts
- [ ] Pre-aborted `querySignal` yields `{ kind: "failed", phase: "query" }`, job queue confirms note was saved
- [ ] `onStateChange` called with correct phase for both ingest and query states
- [ ] TypeScript compiles clean (`tsc --noEmit`)