### PR TITLE
feat(a11y): keyboard Escape, ARIA labels, focus visibility, reduced-motion (#71)

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -31,6 +31,8 @@ export class GemmeraChatView extends ItemView {
 
   private chatHistory: ChatHistoryStore | null = null;
   private currentSessionId: string | null = null;
+  private escCleared = false;
+  private prefersReducedMotion = false;
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -38,6 +40,7 @@ export class GemmeraChatView extends ItemView {
     private readonly settings: GemmeraSettings,
   ) {
     super(leaf);
+    this.prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   }
 
   getViewType(): string {
@@ -58,7 +61,10 @@ export class GemmeraChatView extends ItemView {
     container.addClass("gemmera-view");
 
     const headerEl = container.createEl("div", { cls: "gemmera-header" });
-    const statusEl = headerEl.createEl("div", { cls: "gemmera-status" });
+    const statusEl = headerEl.createEl("div", {
+      cls: "gemmera-status",
+      attr: { role: "status", "aria-live": "polite" },
+    });
     this.checkOllamaStatus(statusEl);
     this.services.llm.pickDefaultModel().then((m) => { this.model = m; }).catch(() => {});
 
@@ -74,19 +80,38 @@ export class GemmeraChatView extends ItemView {
     const bodyEl = container.createEl("div", { cls: "gemmera-body" });
     const mainEl = bodyEl.createEl("div", { cls: "gemmera-main" });
 
-    this.messagesEl = mainEl.createEl("div", { cls: "gemmera-messages" });
+    this.messagesEl = mainEl.createEl("div", {
+      cls: "gemmera-messages",
+      attr: { role: "log", "aria-label": "Chat messages" },
+    });
 
     this.inputAreaEl = mainEl.createEl("div", { cls: "gemmera-input-area" });
     this.inputEl = this.inputAreaEl.createEl("textarea", {
       cls: "gemmera-input",
-      attr: { placeholder: "Skriv ett meddelande...", rows: "3" },
+      attr: {
+        placeholder: "Skriv ett meddelande...",
+        rows: "3",
+        "aria-label": "Message input",
+      },
     });
     this.sendBtn = this.inputAreaEl.createEl("button", {
       cls: "gemmera-send",
       text: "Skicka",
+      attr: { "aria-label": "Send message" },
     });
     this.sendBtn.addEventListener("click", () => this.handleSend());
     this.inputEl.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        if (this.inputEl.value.trim().length > 0 && !this.escCleared) {
+          this.inputEl.value = "";
+          this.escCleared = true;
+          e.preventDefault();
+        } else {
+          this.app.workspace.detachLeavesOfType(VIEW_TYPE);
+        }
+        return;
+      }
+      this.escCleared = false;
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         this.handleSend();
@@ -262,7 +287,7 @@ export class GemmeraChatView extends ItemView {
         messages,
         onToken: (token) => {
           textEl.textContent += token;
-          this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+          this.scrollToBottom();
         },
       });
       this.history.push({ role: "assistant", content: reply.content });
@@ -315,14 +340,17 @@ export class GemmeraChatView extends ItemView {
     const saveBtn = actions.createEl("button", {
       cls: "gemmera-disambig-chip__btn gemmera-disambig-chip__btn--save",
       text: "Save",
+      attr: { "aria-label": "Save as note" },
     });
     const askBtn = actions.createEl("button", {
       cls: "gemmera-disambig-chip__btn gemmera-disambig-chip__btn--ask",
       text: "Ask",
+      attr: { "aria-label": "Ask question" },
     });
     const cancelBtn = actions.createEl("button", {
       cls: "gemmera-disambig-chip__btn gemmera-disambig-chip__btn--cancel",
       text: "Cancel",
+      attr: { "aria-label": "Cancel" },
     });
 
     saveBtn.addEventListener("click", () => this.handleChipAction("save"));
@@ -402,11 +430,18 @@ export class GemmeraChatView extends ItemView {
     this.sendBtn.disabled = disabled;
   }
 
+  private scrollToBottom(): void {
+    this.messagesEl.scrollTo({
+      top: this.messagesEl.scrollHeight,
+      behavior: this.prefersReducedMotion ? "auto" : "smooth",
+    });
+  }
+
   private appendStreamingMessage(): { el: HTMLElement; textEl: HTMLElement } {
     const el = this.messagesEl.createEl("div", { cls: "gemmera-message gemmera-message--assistant" });
     el.createEl("span", { cls: "gemmera-message__role", text: "Gemma" });
     const textEl = el.createEl("p", { cls: "gemmera-message__text", text: "" });
-    this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+    this.scrollToBottom();
     return { el, textEl };
   }
 
@@ -422,7 +457,7 @@ export class GemmeraChatView extends ItemView {
       const badge = msg.createEl("span", { cls: "gemmera-classifier-badge", text: decoration.badge });
       if (decoration.tooltip) badge.setAttribute("title", decoration.tooltip);
     }
-    this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+    this.scrollToBottom();
   }
 
   private appendErrorMessage(err: unknown, onRetry: () => void): void {
@@ -435,7 +470,11 @@ export class GemmeraChatView extends ItemView {
     });
     el.createEl("span", { cls: "gemmera-message__role", text: "Gemma" });
     el.createEl("p", { cls: "gemmera-message__text", text: displayText });
-    const retryBtn = el.createEl("button", { cls: "gemmera-retry-btn", text: "Retry" });
+    const retryBtn = el.createEl("button", {
+      cls: "gemmera-retry-btn",
+      text: "Retry",
+      attr: { "aria-label": "Retry last message" },
+    });
     retryBtn.addEventListener("click", () => {
       el.remove();
       onRetry();
@@ -445,7 +484,7 @@ export class GemmeraChatView extends ItemView {
       new Notice("Gemmera: Ollama is not responding. Check Settings → Gemmera → Ollama.");
     }
 
-    this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+    this.scrollToBottom();
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -132,7 +132,16 @@
   color: var(--text-normal);
 }
 
-.gemmera-input:focus { outline: none; border-color: var(--interactive-accent); }
+.gemmera-input:focus { outline: 2px solid var(--interactive-accent); outline-offset: -1px; border-color: var(--interactive-accent); }
+
+/* ── Focus visibility ──────────────────────────────────────────────────── */
+
+.gemmera-send:focus-visible,
+.gemmera-disambig-chip__btn:focus-visible,
+.gemmera-retry-btn:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+}
 
 .gemmera-send {
   align-self: flex-end;


### PR DESCRIPTION
## Summary

Closes #71. Ports the a11y additions from the closed PR #130 (commit `2e85916`) onto dev's restructured `view.ts`. Small, focused: 2 files, +57/-9.

### What changed

- **Escape** clears the input on first press, closes the leaf on second
- **ARIA**: status (`role` + `aria-live`), messages (`role="log"`), input / send / retry / disambig-chip button labels
- **`scrollToBottom`** helper honours `prefers-reduced-motion: reduce`
- **`:focus-visible`** outline on send / disambig / retry buttons
- **Input `:focus`** outline restored (was `outline: none`)

### Dropped from the original commit

- Citation chip a11y — dev doesn't render citations in `view.ts` yet
- `.gemmera-bar--busy` reduced-motion rule — dev uses the in-chat `IndexingPill`, not a status-bar item

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 614 / 614 pass
- [x] `npm run build` clean
- [ ] Manual smoke: open chat, Tab through controls, hit Escape twice, screen reader announces status changes (you'd need to verify in Obsidian — I couldn't)

🤖 Generated with [Claude Code](https://claude.com/claude-code)