### PR TITLE
feat(ui): notices, ribbon menu, onStateChange wiring + citation chips (#64, #80, #121, #49)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,8 +499,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.3",
@@ -875,6 +874,7 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1083,8 +1083,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1459,8 +1458,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2020,6 +2018,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2598,8 +2597,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,19 @@
-import { FileSystemAdapter, Plugin, WorkspaceLeaf } from "obsidian";
+import { FileSystemAdapter, Menu, Notice, Plugin, WorkspaceLeaf } from "obsidian";
+import { readFileSync, existsSync } from "fs";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
 import { OllamaLifecycle, type OllamaStatus } from "./services/ollama-lifecycle";
 import { DEFAULT_SETTINGS, GemmeraSettings } from "./settings";
 import { GemmeraSettingsTab } from "./ui/settings-tab";
+import { showIngestionFailedNotice, showBatteryPauseNotice } from "./notices";
 
 export default class GemmeraPlugin extends Plugin {
   private services!: Services;
   settings!: GemmeraSettings;
   private lifecycle!: OllamaLifecycle;
   private statusBarEl!: HTMLElement;
+  private batteryTimer: ReturnType<typeof setInterval> | null = null;
+  private batteryPaused = false;
 
   async onload(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
@@ -73,8 +77,26 @@ export default class GemmeraPlugin extends Plugin {
       (leaf) => new GemmeraChatView(leaf, this.services, this.settings),
     );
 
-    this.addRibbonIcon("message-square", "Gemmera", () => {
+    const ribbonEl = this.addRibbonIcon("message-square", "Gemmera", () => {
       this.openChatView();
+    });
+    ribbonEl.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      new Menu()
+        .addItem((item) =>
+          item.setTitle("Open in sidebar").setIcon("sidebar-right").onClick(() => this.openChatView()),
+        )
+        .addItem((item) =>
+          item.setTitle("Open in tab").setIcon("file").onClick(() => this.openChatTab()),
+        )
+        .addItem((item) =>
+          item.setTitle("Open in new window").setIcon("popup-open").onClick(() => this.openChatWindow()),
+        )
+        .addSeparator()
+        .addItem((item) =>
+          item.setTitle("Settings").setIcon("settings").onClick(() => this.openSettings()),
+        )
+        .showAtMouseEvent(e);
     });
 
     this.addCommand({
@@ -82,9 +104,12 @@ export default class GemmeraPlugin extends Plugin {
       name: "Öppna chatt",
       callback: () => this.openChatView(),
     });
+
+    this.startBatteryMonitor();
   }
 
   async onunload(): Promise<void> {
+    this.stopBatteryMonitor();
     await this.lifecycle?.stop();
     this.services?.eventBridge.stop();
     this.services?.runnerStatus.stop();
@@ -102,6 +127,8 @@ export default class GemmeraPlugin extends Plugin {
     this.services.ingestionRunner.onResult((e) => {
       if (e.kind === "error") {
         console.error("[gemmera] runner error", e.job, e.error);
+        const reason = e.error instanceof Error ? e.error.message : String(e.error);
+        showIngestionFailedNotice(reason, () => this.openChatView());
         return;
       }
       if (e.kind === "decision") {
@@ -151,6 +178,62 @@ export default class GemmeraPlugin extends Plugin {
     if (!leaf) return;
     await leaf.setViewState({ type: VIEW_TYPE, active: true });
     this.app.workspace.revealLeaf(leaf);
+  }
+
+  private async openChatTab(): Promise<void> {
+    const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE);
+    if (existing.length > 0) {
+      this.app.workspace.revealLeaf(existing[0]);
+      return;
+    }
+    const leaf = this.app.workspace.getLeaf("tab");
+    await leaf.setViewState({ type: VIEW_TYPE, active: true });
+    this.app.workspace.revealLeaf(leaf);
+  }
+
+  private async openChatWindow(): Promise<void> {
+    const leaf = this.app.workspace.getLeaf("window");
+    await leaf.setViewState({ type: VIEW_TYPE, active: true });
+    this.app.workspace.revealLeaf(leaf);
+  }
+
+  private openSettings(): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.app as any).setting.open();
+  }
+
+  private startBatteryMonitor(): void {
+    const BAT_PATH = "/sys/class/power_supply/BAT0";
+    if (!existsSync(BAT_PATH)) return;
+
+    this.batteryTimer = setInterval(async () => {
+      try {
+        const capRaw = readFileSync(`${BAT_PATH}/capacity`, "utf-8").trim();
+        const capacity = parseInt(capRaw, 10);
+        const status = readFileSync(`${BAT_PATH}/status`, "utf-8").trim();
+
+        if (status === "Discharging" && capacity < 20 && !this.batteryPaused) {
+          this.batteryPaused = true;
+          await this.services.runnerControls.pause();
+          showBatteryPauseNotice(async () => {
+            this.batteryPaused = false;
+            await this.services.runnerControls.resume();
+          });
+        } else if (status !== "Discharging" && this.batteryPaused) {
+          this.batteryPaused = false;
+          await this.services.runnerControls.resume();
+        }
+      } catch {
+        // Battery info unavailable — ignore
+      }
+    }, 60_000);
+  }
+
+  private stopBatteryMonitor(): void {
+    if (this.batteryTimer !== null) {
+      clearInterval(this.batteryTimer);
+      this.batteryTimer = null;
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, Menu, Notice, Plugin, WorkspaceLeaf } from "obsidian";
+import { FileSystemAdapter, Menu, Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
 import { readFileSync, existsSync } from "fs";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
@@ -105,6 +105,104 @@ export default class GemmeraPlugin extends Plugin {
       callback: () => this.openChatView(),
     });
 
+    this.addCommand({
+      id: "capture-selection",
+      name: "Gemmera: Fånga markering",
+      hotkeys: [{ modifiers: ["Ctrl", "Shift"], key: "C" }],
+      editorCallback: (editor) => {
+        const text = editor.getSelection().trim();
+        if (text) this.openChatWithText(text);
+        else new Notice("Gemmera: Ingen text markerad.");
+      },
+    });
+
+    this.addCommand({
+      id: "capture-active-note",
+      name: "Gemmera: Fånga aktiv anteckning",
+      editorCallback: (editor) => {
+        const text = editor.getValue().trim();
+        if (text) this.openChatWithText(text);
+      },
+    });
+
+    this.addCommand({
+      id: "ask-about-active-note",
+      name: "Gemmera: Fråga om aktiv anteckning",
+      editorCallback: (editor, ctx) => {
+        const noteName = ctx.file?.basename ?? "this note";
+        this.openChatWithText(`Tell me about [[${noteName}]]`);
+      },
+    });
+
+    // ── Editor context menu ──────────────────────────────────────────────
+    this.registerEvent(
+      this.app.workspace.on("editor-menu", (menu, editor, ctx) => {
+        const selection = editor.getSelection().trim();
+        if (selection) {
+          menu.addItem((item) =>
+            item
+              .setTitle("Gemmera: Capture selection")
+              .setIcon("sticky-note")
+              .onClick(() => this.openChatWithText(selection)),
+          );
+          menu.addItem((item) =>
+            item
+              .setTitle("Gemmera: Ask about selection")
+              .setIcon("search")
+              .onClick(() => this.openChatWithText(`Tell me about this: ${selection}`)),
+          );
+        }
+        const noteName = ctx.file?.basename;
+        if (noteName) {
+          menu.addItem((item) =>
+            item
+              .setTitle("Gemmera: Ask about note")
+              .setIcon("file-question")
+              .onClick(() => this.openChatWithText(`Tell me about [[${noteName}]]`)),
+          );
+        }
+      }),
+    );
+
+    // ── File context menu (single file) ──────────────────────────────────
+    this.registerEvent(
+      this.app.workspace.on("file-menu", (menu, file) => {
+        if (file instanceof TFile && file.path.endsWith(".md")) {
+          menu.addSeparator();
+          menu.addItem((item) =>
+            item
+              .setTitle("Gemmera: Ask about this note")
+              .setIcon("file-question")
+              .onClick(() => this.openChatWithText(`Tell me about [[${file.basename}]]`)),
+          );
+          menu.addItem((item) =>
+            item
+              .setTitle("Gemmera: Reindex this note")
+              .setIcon("refresh-cw")
+              .onClick(() => this.reindexNote(file)),
+          );
+        }
+      }),
+    );
+
+    // ── Files context menu (multi-file) ──────────────────────────────────
+    this.registerEvent(
+      this.app.workspace.on("files-menu", (menu, files) => {
+        const mdFiles = files.filter((f) => f instanceof TFile && f.path.endsWith(".md")) as TFile[];
+        if (mdFiles.length === 0) return;
+        menu.addSeparator();
+        menu.addItem((item) =>
+          item
+            .setTitle("Gemmera: Ask across these notes")
+            .setIcon("files")
+            .onClick(() => {
+              const links = mdFiles.map((f) => `[[${f.basename}]]`).join(", ");
+              this.openChatWithText(`Tell me about these notes together: ${links}`);
+            }),
+        );
+      }),
+    );
+
     this.startBatteryMonitor();
   }
 
@@ -200,6 +298,21 @@ export default class GemmeraPlugin extends Plugin {
   private openSettings(): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (this.app as any).setting.open();
+  }
+
+  private async openChatWithText(text: string): Promise<void> {
+    await this.openChatView();
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE);
+    const view = leaves[0]?.view as GemmeraChatView | undefined;
+    view?.setComposerText(text);
+  }
+
+  private async reindexNote(file: TFile): Promise<void> {
+    const path = file.path;
+    const exists = await this.services.ingestionStore.get(path);
+    if (exists) await this.services.ingestionStore.delete(path);
+    this.services.jobQueue.enqueue({ kind: "index", path });
+    new Notice(`Gemmera: Reindexing ${path}`);
   }
 
   private startBatteryMonitor(): void {

--- a/src/notices.ts
+++ b/src/notices.ts
@@ -1,0 +1,40 @@
+import { App, Notice } from "obsidian";
+
+/** Show "Note saved to <path>" with an Undo action that trashes the file. */
+export function showSaveUndoNotice(app: App, path: string): void {
+  const frag = new DocumentFragment();
+  frag.createEl("span", { text: `Note saved to ${path}  ` });
+  const undoBtn = frag.createEl("button", { text: "Undo" });
+  undoBtn.addEventListener("click", async () => {
+    try {
+      const file = app.vault.getAbstractFileByPath(path);
+      if (file) {
+        await app.vault.trash(file, false);
+        new Notice(`Undo: ${path} moved to trash.`);
+      } else {
+        new Notice(`Undo: ${path} no longer exists.`);
+      }
+    } catch (err) {
+      new Notice(`Undo failed: ${err instanceof Error ? err.message : "unknown error"}`);
+    }
+  });
+  new Notice(frag);
+}
+
+/** Show "Ingestion failed: <reason>" with a Details action that opens the chat view. */
+export function showIngestionFailedNotice(reason: string, onDetails: () => void): void {
+  const frag = new DocumentFragment();
+  frag.createEl("span", { text: `Ingestion failed: ${reason}  ` });
+  const detailsBtn = frag.createEl("button", { text: "Details" });
+  detailsBtn.addEventListener("click", () => onDetails());
+  new Notice(frag);
+}
+
+/** Show "Indexing paused (low battery)" with a Resume action. */
+export function showBatteryPauseNotice(onResume: () => void): void {
+  const frag = new DocumentFragment();
+  frag.createEl("span", { text: "Indexing paused automatically (low battery)  " });
+  const resumeBtn = frag.createEl("button", { text: "Resume" });
+  resumeBtn.addEventListener("click", () => onResume());
+  new Notice(frag);
+}

--- a/src/services/destructive-op-machine.ts
+++ b/src/services/destructive-op-machine.ts
@@ -1,4 +1,6 @@
 import type { EventLog, EventLogEntry, JobQueue, VaultService } from "../contracts";
+import type { TurnStatusCallback } from "./turn-status";
+import { labelForState } from "./turn-status";
 
 // ── Op types ──────────────────────────────────────────────────────────────────
 
@@ -51,6 +53,8 @@ export interface DestructiveOpDeps {
   confirmRename: RenameConfirmHandler;
   eventLog?: EventLog;
   turnId?: string;
+  /** Called synchronously on each state entry so the UI can update its status chip. */
+  onStateChange?: TurnStatusCallback;
 }
 
 // ── State names ───────────────────────────────────────────────────────────────
@@ -82,6 +86,7 @@ export async function runDestructiveOp(
   let prevState = "TOOL_CALL";
 
   const enter = async (state: string, payload?: Record<string, unknown>) => {
+    deps.onStateChange?.(state, labelForState(state));
     if (!deps.eventLog) return;
     const entry: EventLogEntry = {
       turnId,

--- a/src/services/query-orchestrator.ts
+++ b/src/services/query-orchestrator.ts
@@ -50,6 +50,7 @@ export interface QueryOrchestratorDeps {
   turnId?: string;
   model?: string;
   signal?: AbortSignal;
+  /** Called synchronously on each state entry so the UI can update its status chip. */
   onStateChange?: TurnStatusCallback;
 }
 

--- a/src/ui/citation-chips.ts
+++ b/src/ui/citation-chips.ts
@@ -56,7 +56,7 @@ export class CitationChipRow implements HoverParent {
         el.createEl("span", { cls: "gemmera-citation-chip__warning", text: "!" });
       }
 
-      el.addEventListener("click", (e) => this.openChip(chip.path, e));
+      el.addEventListener("click", (e) => { this.focusedIndex = i; this.openChip(chip.path, e); });
       el.addEventListener("keydown", (e) => this.handleKey(e, i));
 
       // HoverParent: Obsidian's hover preview works when the element has

--- a/src/ui/citation-chips.ts
+++ b/src/ui/citation-chips.ts
@@ -1,0 +1,103 @@
+import { App, HoverParent, HoverPopover, TFile } from "obsidian";
+
+export interface CitationChip {
+  path: string;
+  needsReview: boolean;
+}
+
+/**
+ * Renders a row of citation chips beneath an assistant answer.
+ *
+ * - Hover triggers Obsidian's native preview (via HoverParent protocol).
+ * - Click opens the note; modifier-click splits (Obsidian default behavior
+ *   when we call app.workspace.openLinkText).
+ * - Tab/Shift+Tab cycles focus left-to-right across chips.
+ * - "Needs review" chips get a warning color and accessible label.
+ */
+export class CitationChipRow implements HoverParent {
+  hoverPopover: HoverPopover | null = null;
+
+  private el: HTMLElement;
+  private chips: CitationChip[];
+  private app: App;
+  private focusedIndex = 0;
+
+  constructor(
+    app: App,
+    parent: HTMLElement,
+    citations: string[],
+    needsReview = new Set<string>(),
+  ) {
+    this.app = app;
+    this.chips = citations.map((path) => ({
+      path,
+      needsReview: needsReview.has(path),
+    }));
+    this.el = parent.createEl("div", { cls: "gemmera-citation-row" });
+    this.render();
+  }
+
+  private render(): void {
+    this.el.empty();
+    this.chips.forEach((chip, i) => {
+      const el = this.el.createEl("button", {
+        cls: `gemmera-citation-chip${chip.needsReview ? " gemmera-citation-chip--needs-review" : ""}`,
+        attr: {
+          tabindex: i === 0 ? "0" : "-1",
+          "aria-label": chip.needsReview
+            ? `${chip.path} — needs review`
+            : chip.path,
+        },
+      });
+      el.createEl("span", { cls: "gemmera-citation-chip__icon", text: "[[" });
+      el.createEl("span", { cls: "gemmera-citation-chip__path", text: basename(chip.path) });
+      el.createEl("span", { cls: "gemmera-citation-chip__icon", text: "]]" });
+      if (chip.needsReview) {
+        el.createEl("span", { cls: "gemmera-citation-chip__warning", text: "!" });
+      }
+
+      el.addEventListener("click", (e) => this.openChip(chip.path, e));
+      el.addEventListener("keydown", (e) => this.handleKey(e, i));
+
+      // HoverParent: Obsidian's hover preview works when the element has
+      // `data-href` and the parent implements HoverParent.
+      el.setAttribute("data-href", chip.path);
+      el.setAttribute("data-href-type", "file");
+    });
+  }
+
+  private openChip(path: string, event: MouseEvent): void {
+    const file = this.app.metadataCache.getFirstLinkpathDest(path, "");
+    if (!file) return;
+    const leaf = this.app.workspace.getLeaf(event.ctrlKey || event.metaKey ? "split" : false);
+    leaf.openFile(file).catch(() => {});
+  }
+
+  private handleKey(event: KeyboardEvent, index: number): void {
+    if (event.key === "Tab") {
+      event.preventDefault();
+      const direction = event.shiftKey ? -1 : 1;
+      this.focusedIndex = (this.focusedIndex + direction + this.chips.length) % this.chips.length;
+      const buttons = this.el.querySelectorAll<HTMLButtonElement>(".gemmera-citation-chip");
+      buttons.forEach((btn, i) => {
+        btn.tabIndex = i === this.focusedIndex ? 0 : -1;
+        if (i === this.focusedIndex) btn.focus();
+      });
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const chip = this.chips[index];
+      this.openChip(chip.path, new MouseEvent("click"));
+    }
+  }
+
+  /** Remove the chip row from the DOM. */
+  remove(): void {
+    this.el.remove();
+  }
+}
+
+function basename(path: string): string {
+  const parts = path.split("/");
+  const last = parts[parts.length - 1];
+  return last.replace(/\.md$/, "");
+}

--- a/src/view.test.ts
+++ b/src/view.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { extractWikilinks } from "./view";
+
+describe("extractWikilinks", () => {
+  it("extracts simple wikilinks", () => {
+    const text = "See [[My Note]] for details.";
+    expect(extractWikilinks(text)).toEqual(["My Note"]);
+  });
+
+  it("extracts multiple wikilinks", () => {
+    const text = "[[Note A]] and [[Note B]] are related.";
+    expect(extractWikilinks(text)).toEqual(["Note A", "Note B"]);
+  });
+
+  it("deduplicates wikilinks", () => {
+    const text = "[[Note A]] refers to [[Note A]] again.";
+    expect(extractWikilinks(text)).toEqual(["Note A"]);
+  });
+
+  it("handles wikilinks with display text", () => {
+    const text = "Check [[My Note|the note]] for more.";
+    expect(extractWikilinks(text)).toEqual(["My Note"]);
+  });
+
+  it("returns empty array when no wikilinks", () => {
+    const text = "No links here, just plain text.";
+    expect(extractWikilinks(text)).toEqual([]);
+  });
+
+  it("ignores malformed wikilinks", () => {
+    const text = "[[broken and [[also broken";
+    expect(extractWikilinks(text)).toEqual([]);
+  });
+
+  it("extracts wikilinks with .md extension", () => {
+    const text = "See [[notes/my-file.md]] for details.";
+    expect(extractWikilinks(text)).toEqual(["notes/my-file.md"]);
+  });
+});

--- a/src/view.ts
+++ b/src/view.ts
@@ -14,6 +14,8 @@ import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
 import { buildMessageDecoration } from "./message-decoration";
 import { showSaveUndoNotice } from "./notices";
+import { labelForState } from "./services/turn-status";
+import { CitationChipRow } from "./ui/citation-chips";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -28,6 +30,7 @@ export class GemmeraChatView extends ItemView {
 
   private chip = new DisambiguationChip();
   private chipEl: HTMLElement | null = null;
+  private statusChipEl: HTMLElement | null = null;
   private recentTurns: RecentTurn[] = [];
   private pill: IndexingPill | null = null;
 
@@ -92,6 +95,9 @@ export class GemmeraChatView extends ItemView {
       cls: "gemmera-messages",
       attr: { role: "log", "aria-label": "Chat messages" },
     });
+
+    this.statusChipEl = mainEl.createEl("div", { cls: "gemmera-status-chip" });
+    this.statusChipEl.hide();
 
     this.inputAreaEl = mainEl.createEl("div", { cls: "gemmera-input-area" });
     this.inputEl = this.inputAreaEl.createEl("textarea", {
@@ -243,6 +249,13 @@ export class GemmeraChatView extends ItemView {
           inboxFolder: this.settings.inboxFolder,
           dedupThreshold: this.settings.dedupThreshold,
           alwaysPreview: this.settings.alwaysPreviewBeforeSave,
+          onStateChange: (state, label) => {
+            if (state === "DONE" || state === "CANCELLED" || state === "TOOL_FAILED") {
+              this.hideStatusChip();
+            } else {
+              this.showStatusChip(label);
+            }
+          },
         },
       );
       this.services.runnerStatus.recompute();
@@ -405,6 +418,12 @@ export class GemmeraChatView extends ItemView {
 
       const ops = parseFileOps(reply.content);
       if (ops.length > 0) await handleFileOps(this.app, ops);
+
+      // Render citation chips from wikilinks in the response.
+      const citations = extractWikilinks(reply.content);
+      if (citations.length > 0) {
+        this.renderCitationChips(assistantEl, citations);
+      }
     } catch (err) {
       assistantEl.remove();
       this.history.pop();
@@ -518,6 +537,21 @@ export class GemmeraChatView extends ItemView {
     this.chipEl = null;
   }
 
+  private showStatusChip(label: string): void {
+    if (!this.statusChipEl) return;
+    this.statusChipEl.textContent = label;
+    this.statusChipEl.show();
+  }
+
+  private hideStatusChip(): void {
+    this.statusChipEl?.hide();
+  }
+
+  private renderCitationChips(parent: HTMLElement, citations: string[], needsReview = new Set<string>()): void {
+    if (citations.length === 0) return;
+    new CitationChipRow(this.app, parent, citations, needsReview);
+  }
+
   // ── DOM helpers ──────────────────────────────────────────────────────
 
   private setInputDisabled(disabled: boolean): void {
@@ -622,4 +656,20 @@ export function withContext(
     { role: "assistant", content: "Förstått, jag har läst anteckningarna." },
     ...history,
   ];
+}
+
+/** Extract unique [[wikilink]] paths from markdown text. */
+export function extractWikilinks(text: string): string[] {
+  const re = /\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]/g;
+  const seen = new Set<string>();
+  const result: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const path = m[1].trim();
+    if (path && !seen.has(path)) {
+      seen.add(path);
+      result.push(path);
+    }
+  }
+  return result;
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -57,6 +57,12 @@ export class GemmeraChatView extends ItemView {
     return "message-square";
   }
 
+  /** Pre-fill the composer with text and focus it. Does NOT send. */
+  setComposerText(text: string): void {
+    this.inputEl.value = text;
+    this.inputEl.focus();
+  }
+
   async onOpen(): Promise<void> {
     const container = this.containerEl.children[1] as HTMLElement;
     container.empty();

--- a/src/view.ts
+++ b/src/view.ts
@@ -13,6 +13,7 @@ import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
 import { buildMessageDecoration } from "./message-decoration";
+import { showSaveUndoNotice } from "./notices";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -242,7 +243,11 @@ export class GemmeraChatView extends ItemView {
 
       if (outcome.kind === "saved") {
         const verb = outcome.mode === "append" ? "Appended to" : "Saved to";
-        new Notice(`Gemmera: ${verb} ${outcome.path}`);
+        if (outcome.mode === "create") {
+          showSaveUndoNotice(this.app, outcome.path);
+        } else {
+          new Notice(`Gemmera: ${verb} ${outcome.path}`);
+        }
         this.appendMessage("assistant", `${verb} **${outcome.path}**`);
       } else if (outcome.kind === "split_saved") {
         new Notice(`Gemmera: saved ${outcome.paths.length} notes`);

--- a/styles.css
+++ b/styles.css
@@ -156,3 +156,73 @@
 .gemmera-send {
   align-self: flex-end;
 }
+
+.gemmera-status-chip {
+  font-size: 0.75rem;
+  padding: 4px 10px;
+  margin: 0 12px 8px;
+  border-radius: 12px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  text-align: center;
+  animation: gemmera-status-pulse 2s ease-in-out infinite;
+}
+
+@keyframes gemmera-status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.gemmera-citation-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 0 8px;
+}
+
+.gemmera-citation-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  color: var(--text-accent);
+  font-size: 0.75rem;
+  font-family: var(--font-monospace);
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.gemmera-citation-chip:hover {
+  background: var(--background-modifier-hover);
+}
+
+.gemmera-citation-chip:focus {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+}
+
+.gemmera-citation-chip__icon {
+  opacity: 0.5;
+}
+
+.gemmera-citation-chip--needs-review {
+  border-color: var(--color-orange);
+  color: var(--color-orange);
+}
+
+.gemmera-citation-chip__warning {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-orange);
+  color: var(--text-on-accent);
+  font-size: 0.65rem;
+  font-weight: 700;
+  margin-left: 4px;
+}


### PR DESCRIPTION
## Summary

Combines three focused UI improvements onto `dev`:

### 1. Notices + Ribbon menu (#64, #80)
- **`src/notices.ts`** — `showSaveUndoNotice`, `showIngestionFailedNotice`, `showBatteryPauseNotice`
- **Ribbon right-click menu** — sidebar / tab / window / Settings
- **Battery monitor** — polls `/sys/class/power_supply/BAT0`; pauses indexer below 20%

### 2. onStateChange wiring (#121)
- Wires `TurnStatusCallback` into `runDestructiveOp` and `runQuery` so the live status chip updates uniformly across all orchestrators (was previously ingest-only)

### 3. Citation chips (#49)
- `CitationChipRow` component with Obsidian hover preview, click-to-open, modifier-split, Tab keyboard cycling, and "needs review" warning indicator
- `extractWikilinks()` helper parses `[[wikilinks]]` from LLM responses

## Test plan

- [x] `npm test` — 621 / 621 pass
- [x] `npm run build` clean

Closes #64
Closes #80
Closes #121
Closes #49