### PR TITLE
feat(tool-loop): layered retry policy — model output, infra, citations (#51)

### DIFF
--- a/src/services/ingest-orchestrator.ts
+++ b/src/services/ingest-orchestrator.ts
@@ -16,6 +16,7 @@ import type {
 import { parseContent } from "./ingest-parser";
 import { decideStrategy } from "./ingest-strategy";
 import { IngestWriter } from "./ingest-writer";
+import { RetryBudget } from "./retry-policy";
 import type { TurnStatusCallback } from "./turn-status";
 import { labelForState } from "./turn-status";
 import { unique } from "./util";
@@ -80,6 +81,8 @@ export interface IngestOrchestratorDeps {
   version?: string;
   runId?: () => string;
   signal?: AbortSignal;
+  /** Shared retry budget for model-output retries across this turn. */
+  retryBudget?: RetryBudget;
 }
 
 /**
@@ -121,13 +124,14 @@ export async function runIngest(
 
   // ── PARSE_CONTENT ────────────────────────────────────────────────────
   await enter(STATES.parse);
+  const budget = deps.retryBudget ?? new RetryBudget();
   const parse = await parseContent(input.text, input.instruction, {
     llm: deps.llm,
     promptLoader: deps.promptLoader,
     runId: deps.runId,
     model: deps.model,
     version: deps.version,
-  }, deps.signal);
+  }, deps.signal, budget);
   if (!parse.ok) {
     if (parse.reason === "empty") {
       await enter(STATES.cancelled, { reason: "empty_input" });

--- a/src/services/ingest-parser.test.ts
+++ b/src/services/ingest-parser.test.ts
@@ -8,6 +8,7 @@ import type {
   PromptLoader,
 } from "../contracts";
 import { parseContent } from "./ingest-parser";
+import { RetryBudget } from "./retry-policy";
 
 class StaticLLM implements LLMService {
   constructor(public reply: string) {}
@@ -114,5 +115,110 @@ describe("parseContent", () => {
     });
     expect(result.ok).toBe(false);
     expect(called).toBe(false);
+  });
+});
+
+// ── Retry policy (#51) ────────────────────────────────────────────────────────
+
+function validSpecJson(): string {
+  return JSON.stringify({
+    title: "Test note",
+    type: "meeting",
+    tags: [],
+    aliases: [],
+    source: "chat-paste",
+    entities: [],
+    related: [],
+    status: "inbox",
+    summary: "A test note.",
+    key_points: [],
+    body_markdown: "# Test\n\nContent.",
+    confidence: "high",
+  });
+}
+
+class SequenceLLM implements LLMService {
+  private calls = 0;
+  constructor(private readonly replies: string[]) {}
+  async chat(_opts: ChatOptions): Promise<LLMResponse> {
+    const reply = this.replies[this.calls] ?? this.replies[this.replies.length - 1];
+    this.calls++;
+    return { content: reply };
+  }
+  async isReachable(): Promise<LLMReachability> { return "running"; }
+  async listModels(): Promise<string[]> { return []; }
+  async pickDefaultModel(): Promise<string> { return "mock"; }
+}
+
+class FailThenSucceedLLM implements LLMService {
+  private calls = 0;
+  constructor(private readonly failCount: number, private readonly successReply: string) {}
+  async chat(_opts: ChatOptions): Promise<LLMResponse> {
+    if (this.calls++ < this.failCount) throw new Error("connection refused");
+    return { content: this.successReply };
+  }
+  async isReachable(): Promise<LLMReachability> { return "running"; }
+  async listModels(): Promise<string[]> { return []; }
+  async pickDefaultModel(): Promise<string> { return "mock"; }
+}
+
+describe("parseContent — retry policy (#51)", () => {
+  it("invalid JSON → 1 retry → succeeds on second call", async () => {
+    const llm = new SequenceLLM(["not json", validSpecJson()]);
+    const budget = new RetryBudget(3);
+    const result = await parseContent("test", undefined, { llm, promptLoader: stubPromptLoader }, undefined, budget);
+    expect(result.ok).toBe(true);
+    expect(budget.count).toBe(1);
+  });
+
+  it("invalid JSON on both attempts → parse_failed", async () => {
+    const llm = new SequenceLLM(["not json"]);
+    const budget = new RetryBudget(3);
+    const result = await parseContent("test", undefined, { llm, promptLoader: stubPromptLoader }, undefined, budget);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("parse_failed");
+  });
+
+  it("schema-valid JSON but missing required fields → 1 feedback retry → succeeds", async () => {
+    const llm = new SequenceLLM([
+      JSON.stringify({ title: "ok" }), // schema_failed — missing type and body_markdown
+      validSpecJson(),
+    ]);
+    const budget = new RetryBudget(3);
+    const result = await parseContent("test", undefined, { llm, promptLoader: stubPromptLoader }, undefined, budget);
+    expect(result.ok).toBe(true);
+    expect(budget.count).toBe(1);
+  });
+
+  it("schema fails on both attempts → schema_failed", async () => {
+    const llm = new SequenceLLM([JSON.stringify({ title: "ok" })]);
+    const budget = new RetryBudget(3);
+    const result = await parseContent("test", undefined, { llm, promptLoader: stubPromptLoader }, undefined, budget);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("schema_failed");
+  });
+
+  it("budget exhausted before any retry → parse_failed without retrying", async () => {
+    let callCount = 0;
+    const llm: LLMService = {
+      async chat(): Promise<LLMResponse> { callCount++; return { content: "not json" }; },
+      async isReachable(): Promise<LLMReachability> { return "running"; },
+      async listModels(): Promise<string[]> { return []; },
+      async pickDefaultModel(): Promise<string> { return "mock"; },
+    };
+    const budget = new RetryBudget(0);
+    const result = await parseContent("test", undefined, { llm, promptLoader: stubPromptLoader }, undefined, budget);
+    expect(result.ok).toBe(false);
+    expect(callCount).toBe(1); // no retry attempted
+  });
+
+  it("Ollama connection refused → 1 infra retry → succeeds (does not consume budget)", async () => {
+    const llm = new FailThenSucceedLLM(1, validSpecJson());
+    const budget = new RetryBudget(3);
+    const result = await parseContent("test", undefined, { llm, promptLoader: stubPromptLoader }, undefined, budget);
+    expect(result.ok).toBe(true);
+    expect(budget.count).toBe(0); // infra retries don't count against budget
   });
 });

--- a/src/services/ingest-parser.ts
+++ b/src/services/ingest-parser.ts
@@ -1,4 +1,5 @@
 import type { LLMService, NoteSpec, PromptLoader } from "../contracts";
+import { RetryBudget, withInfraRetry, withJsonRetry } from "./retry-policy";
 
 export interface IngestParserDeps {
   llm: LLMService;
@@ -23,44 +24,102 @@ export type ParseResult =
  * to `[]`) but strict on the required scalars (`title`, `type`, `source`,
  * `body_markdown`). A parse miss returns a typed `ParseResult` so the
  * orchestrator can decide between retry and error-state.
+ *
+ * Retry policy (#51):
+ * - Ollama connection refused → 1 infra retry after 500 ms (does not consume budget).
+ * - Invalid JSON → 1 retry via `budget`; second failure → parse_failed.
+ * - Schema-valid but rule-violating → 1 retry with error feedback via `budget`;
+ *   second failure → schema_failed.
+ * When `budget` is omitted a zero-slot budget is used (no retries, existing behaviour).
  */
 export async function parseContent(
   text: string,
   instruction: string | undefined,
   deps: IngestParserDeps,
   signal?: AbortSignal,
+  budget?: RetryBudget,
 ): Promise<ParseResult> {
   if (!text.trim()) return { ok: false, reason: "empty", raw: "" };
 
   const prompt = await deps.promptLoader.load("ingest-parser");
   const userPrompt = composeUserPrompt(text, instruction);
-
-  const response = await deps.llm.chat({
-    messages: [
-      { role: "system", content: prompt.body + SCHEMA_HINT },
-      { role: "user", content: userPrompt },
-    ],
-    format: "json",
-    stream: false,
-    signal,
-  });
-
-  const raw = response.content?.trim() ?? "";
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return { ok: false, reason: "parse_failed", raw };
-  }
-
-  const spec = coerceSpec(parsed, {
+  const b = budget ?? new RetryBudget(0);
+  const coworkDefaults = {
     runId: (deps.runId ?? defaultRunId)(),
     model: deps.model ?? "gemma3:latest",
     version: deps.version ?? "0.0.1",
-  });
-  if (!spec) return { ok: false, reason: "schema_failed", raw };
+  };
+
+  // Infra-wrapped LLM call. On Ollama connection refused, retries once after
+  // 500 ms then throws; the throw propagates out of parseContent and the
+  // orchestrator enters TOOL_FAILED.
+  const callLlm = (systemContent: string) => async (s?: AbortSignal): Promise<string> => {
+    const resp = await withInfraRetry(
+      () => deps.llm.chat({
+        messages: [
+          { role: "system", content: systemContent },
+          { role: "user", content: userPrompt },
+        ],
+        format: "json",
+        stream: false,
+        signal: s,
+      }),
+      500,
+      s,
+    );
+    return resp.content?.trim() ?? "";
+  };
+
+  const systemContent = prompt.body + SCHEMA_HINT;
+
+  // Step 1 — JSON parse retry.
+  // Invalid JSON → 1 retry (budget slot consumed); second failure → parse_failed.
+  const jsonResult = await withJsonRetry(
+    callLlm(systemContent),
+    safeJsonParse,
+    b,
+    signal,
+  );
+  if (!jsonResult.ok) {
+    return { ok: false, reason: "parse_failed", raw: "" };
+  }
+
+  // Step 2 — Schema validation retry.
+  // Valid JSON but missing required fields → 1 retry with explicit error feedback
+  // appended; second failure → schema_failed.
+  let spec = coerceSpec(jsonResult.value, coworkDefaults);
+  if (!spec) {
+    if (b.consume()) {
+      const hint = buildSchemaHint(jsonResult.value);
+      const retrySystem = systemContent + `\n\nYour previous response failed validation: ${hint}`;
+      const raw2 = await callLlm(retrySystem)(signal);
+      const parsed2 = safeJsonParse(raw2);
+      if (parsed2 !== null) spec = coerceSpec(parsed2, coworkDefaults);
+    }
+    if (!spec) return { ok: false, reason: "schema_failed", raw: "" };
+  }
 
   return { ok: true, spec };
+}
+
+function safeJsonParse(raw: string): unknown | null {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function buildSchemaHint(raw: unknown): string {
+  if (!raw || typeof raw !== "object") return "Response was not a JSON object.";
+  const r = raw as Record<string, unknown>;
+  const missing: string[] = [];
+  if (!r.title || typeof r.title !== "string") missing.push("title (required string)");
+  if (!r.type) missing.push(`type (must be one of: source, evergreen, project, meeting, person, concept)`);
+  if (!r.body_markdown || typeof r.body_markdown !== "string") missing.push("body_markdown (required string)");
+  return missing.length > 0
+    ? `Missing or invalid required fields: ${missing.join("; ")}.`
+    : "One or more field values did not match the required schema.";
 }
 
 function composeUserPrompt(text: string, instruction?: string): string {

--- a/src/services/query-orchestrator.test.ts
+++ b/src/services/query-orchestrator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { InMemoryEventLog } from "./event-log";
+import { RetryBudget } from "./retry-policy";
 import { runQuery, type QueryOrchestratorDeps, type QueryInput } from "./query-orchestrator";
 import type {
   ChatOptions,
@@ -247,5 +248,97 @@ describe("runQuery", () => {
     const events = await eventLog!.eventsFor("turn-1");
     const states = events.filter((e) => e.kind === "enter").map((e) => e.state);
     expect(states).toEqual(["PLAN_RETRIEVAL", "RETRIEVE", "PRESENT", "DONE"]);
+  });
+});
+
+// ── Retry policy (#51) ────────────────────────────────────────────────────────
+
+class FailThenSucceedRetriever implements Retriever {
+  private calls = 0;
+  constructor(private readonly failCount: number, private readonly hits: RetrievalHit[]) {}
+  async retrieve(): Promise<RetrievalHit[]> {
+    if (this.calls++ < this.failCount) throw new Error("embedding failed");
+    return this.hits;
+  }
+}
+
+describe("runQuery — retry policy (#51)", () => {
+  it("invalid JSON → 1 budget retry → succeeds", async () => {
+    const { deps } = setup({
+      llmReplies: ["not json", validReply("ok", ["Notes/a.md"])],
+    });
+    const budget = new RetryBudget(3);
+    deps.retryBudget = budget;
+
+    const outcome = await runQuery({ query: "q" }, deps);
+    expect(outcome.kind).toBe("answered");
+    expect(budget.count).toBe(1);
+  });
+
+  it("invalid JSON on both attempts → failed", async () => {
+    const { deps } = setup({ llmReplies: ["not json"] });
+    deps.retryBudget = new RetryBudget(3);
+
+    const outcome = await runQuery({ query: "q" }, deps);
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.reason).toBe("generate:invalid_json");
+  });
+
+  it("hallucinated citations → budget retry → succeeds with valid citations", async () => {
+    const { deps } = setup({
+      llmReplies: [
+        validReply("First.", ["Notes/ghost.md"]),          // invalid citation
+        validReply("Fixed.", ["Notes/a.md"]),              // valid
+      ],
+    });
+    deps.retryBudget = new RetryBudget(3);
+
+    const outcome = await runQuery({ query: "q" }, deps);
+    expect(outcome.kind).toBe("answered");
+    if (outcome.kind !== "answered") return;
+    expect(outcome.citations).toEqual(["Notes/a.md"]);
+  });
+
+  it("hallucinated citations + budget exhausted → validation_failed without retry", async () => {
+    const { deps } = setup({
+      llmReplies: [validReply("First.", ["Notes/ghost.md"])],
+    });
+    deps.retryBudget = new RetryBudget(0);
+
+    const outcome = await runQuery({ query: "q" }, deps);
+    expect(outcome.kind).toBe("validation_failed");
+  });
+
+  it("embedding fail → 1 infra retry after 250 ms → succeeds (no budget consumed)", async () => {
+    const { deps } = setup({ llmReplies: [validReply("ok", ["Notes/a.md"])] });
+    const budget = new RetryBudget(3);
+    deps.retryBudget = budget;
+    deps.retriever = new FailThenSucceedRetriever(1, [makeHit("Notes/a.md", "text")]);
+
+    const outcome = await runQuery({ query: "q" }, deps);
+    expect(outcome.kind).toBe("answered");
+    expect(budget.count).toBe(0); // infra retries don't consume budget
+  });
+
+  it("retriever fails twice → TOOL_FAILED", async () => {
+    const { deps } = setup({ llmReplies: [] });
+    deps.retriever = new FailThenSucceedRetriever(99, []);
+
+    const outcome = await runQuery({ query: "q" }, deps);
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") return;
+    expect(outcome.reason).toMatch(/retrieve:/);
+  });
+
+  it("reranker fail → 0 retries, falls back to raw hits, still answers", async () => {
+    const failingReranker: Retriever = {
+      async retrieve(): Promise<RetrievalHit[]> { throw new Error("reranker down"); },
+    };
+    const { deps } = setup({ llmReplies: [validReply("ok", ["Notes/a.md"])] });
+    deps.reranker = failingReranker;
+
+    const outcome = await runQuery({ query: "q" }, deps);
+    expect(outcome.kind).toBe("answered");
   });
 });

--- a/src/services/query-orchestrator.ts
+++ b/src/services/query-orchestrator.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatMessage,
   EventLog,
   EventLogEntry,
   LLMService,
@@ -7,6 +8,7 @@ import type {
   RetrievalPayload,
   Retriever,
 } from "../contracts";
+import { RetryBudget, withInfraRetry, withJsonRetry } from "./retry-policy";
 import type { TurnStatusCallback } from "./turn-status";
 import { labelForState } from "./turn-status";
 
@@ -52,6 +54,8 @@ export interface QueryOrchestratorDeps {
   signal?: AbortSignal;
   /** Called synchronously on each state entry so the UI can update its status chip. */
   onStateChange?: TurnStatusCallback;
+  /** Shared retry budget for model-output retries across this turn. */
+  retryBudget?: RetryBudget;
 }
 
 interface LLMQueryResponse {
@@ -97,11 +101,18 @@ export async function runQuery(
   await enter(STATES.planRetrieval);
   const { query } = input;
 
+  const budget = deps.retryBudget ?? new RetryBudget();
+
   // ── RETRIEVE ──────────────────────────────────────────────────────────
+  // Embedding fail → 1 infra retry after 250 ms; second failure → TOOL_FAILED.
   await enter(STATES.retrieve);
   let hits: RetrievalHit[];
   try {
-    hits = await deps.retriever.retrieve(query, { topK: TOP_K_RETRIEVE });
+    hits = await withInfraRetry(
+      () => deps.retriever.retrieve(query, { topK: TOP_K_RETRIEVE }),
+      250,
+      deps.signal,
+    );
   } catch (err) {
     const reason = `retrieve:${stringifyError(err)}`;
     await enter(STATES.failed, { reason });
@@ -115,12 +126,13 @@ export async function runQuery(
   }
 
   // ── RERANK ────────────────────────────────────────────────────────────
+  // Reranker fail → 0 retries, skip and use raw hits per tool-loop.md.
   await enter(STATES.rerank);
   if (deps.reranker) {
     try {
       hits = await deps.reranker.retrieve(query, { topK: TOP_K_RERANK });
     } catch {
-      // Reranker failure: 0 retries, skip and use raw hits per tool-loop.md.
+      // intentional skip
     }
   }
 
@@ -130,67 +142,79 @@ export async function runQuery(
   const validPaths = new Set(payload.chunks.map((c) => c.path));
 
   // ── GENERATE ──────────────────────────────────────────────────────────
+  // Ollama connection refused → 1 infra retry after 500 ms.
+  // Invalid JSON → 1 model-output retry consuming from budget.
   await enter(STATES.generate);
   const model = deps.model ?? (await deps.llm.pickDefaultModel());
   const systemPrompt = buildSystemPrompt();
   const userMessage = buildUserMessage(query, payload);
 
+  const callLlm = (messages: ChatMessage[]) =>
+    async (signal?: AbortSignal): Promise<string> => {
+      const response = await withInfraRetry(
+        () => deps.llm.chat({ messages, model, format: "json", signal }),
+        500,
+        signal,
+      );
+      return response.content;
+    };
+
   let llmRaw: string;
+  let parsed: LLMQueryResponse | null;
   try {
-    const response = await deps.llm.chat({
-      messages: [
+    const jsonResult = await withJsonRetry(
+      callLlm([
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage },
-      ],
-      model,
-      format: "json",
-      signal: deps.signal,
-    });
-    llmRaw = response.content;
+      ]),
+      parseQueryResponse,
+      budget,
+      deps.signal,
+    );
+    if (!jsonResult.ok) {
+      await enter(STATES.failed, { reason: "generate:invalid_json" });
+      return { kind: "failed", reason: "generate:invalid_json" };
+    }
+    llmRaw = ""; // not needed downstream; value captured in jsonResult
+    parsed = jsonResult.value;
   } catch (err) {
     const reason = `generate:${stringifyError(err)}`;
     await enter(STATES.failed, { reason });
     return { kind: "failed", reason };
   }
 
-  let parsed = parseQueryResponse(llmRaw);
-  if (!parsed) {
-    const reason = "generate:invalid_json";
-    await enter(STATES.failed, { reason });
-    return { kind: "failed", reason };
-  }
-
   // ── VALIDATE_CITATIONS ────────────────────────────────────────────────
+  // Hallucinated citations → 1 feedback retry consuming from budget;
+  // second failure → VALIDATION_FAILED.
   await enter(STATES.validateCitations, { citationCount: parsed.citations.length });
   const invalid = parsed.citations.filter((p) => !validPaths.has(p));
 
   if (invalid.length > 0) {
     // ── RETRY_WITH_CONSTRAINED_CITATIONS ─────────────────────────────
+    if (!budget.consume()) {
+      await enter(STATES.validationFailed, { reason: "budget_exhausted" });
+      return { kind: "validation_failed", answer: parsed.answer };
+    }
+
     const allowed = [...validPaths];
     await enter(STATES.retryConstrainedCitations, { invalid, allowed });
 
     const retryMessage = buildRetryMessage(allowed);
-    let retryRaw: string;
+    let retryParsed: LLMQueryResponse | null;
     try {
-      const retryResponse = await deps.llm.chat({
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userMessage },
-          { role: "assistant", content: llmRaw },
-          { role: "user", content: retryMessage },
-        ],
-        model,
-        format: "json",
-        signal: deps.signal,
-      });
-      retryRaw = retryResponse.content;
+      const retryRaw = await callLlm([
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userMessage },
+        { role: "assistant", content: JSON.stringify(parsed) },
+        { role: "user", content: retryMessage },
+      ])(deps.signal);
+      retryParsed = parseQueryResponse(retryRaw);
     } catch (err) {
       const reason = `retry:${stringifyError(err)}`;
       await enter(STATES.failed, { reason });
       return { kind: "failed", reason };
     }
 
-    const retryParsed = parseQueryResponse(retryRaw);
     if (!retryParsed) {
       await enter(STATES.validationFailed, { reason: "retry:invalid_json" });
       return { kind: "validation_failed", answer: parsed.answer };


### PR DESCRIPTION
## Summary

Closes #51. Implements the full layered retry policy from tool-loop.md across ingest-parser and query-orchestrator.

### Model-output retries

**ingest-parser (`PARSE_CONTENT`)**
- Invalid JSON → `withJsonRetry` → 1 retry consuming from `RetryBudget`
- Schema-valid but rule-violating → 1 feedback retry with error hint appended to system prompt
- Both bounded by shared `RetryBudget` (default `MAX_RETRIES_PER_TURN = 3`)

**query-orchestrator (`GENERATE`)**
- Invalid JSON → `withJsonRetry` → 1 retry from budget
- Hallucinated citations → `budget.consume()` check before `RETRY_WITH_CONSTRAINED_CITATIONS`; budget exhausted → `VALIDATION_FAILED` immediately

### Transient infra retries (do not consume budget)
- Ollama connection refused → `withInfraRetry(500 ms)` in ingest-parser
- Embedding fail → `withInfraRetry(250 ms)` in query-orchestrator `RETRIEVE`
- Reranker fail → 0 retries, skip (unchanged, already correct)

### Wiring
- `IngestOrchestratorDeps.retryBudget` — propagates budget into `parseContent`
- `QueryOrchestratorDeps.retryBudget` — propagates into generate + citation retry
- Both default to `new RetryBudget()` when omitted (fully backward-compatible)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 13 new tests covering every policy branch with fault-injected fakes
- [x] Full suite 641/641 green

Closes #51