### PR TITLE
feat(rag): query tool loop — ask intent through hybrid retriever + synthesis notes (#14)

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -224,6 +224,7 @@ export { RunnerControls } from "./runner-controls";
 export { ScheduledReconciler } from "./scheduled-reconciler";
 export { IngestWriter } from "./ingest-writer";
 export { runIngest } from "./ingest-orchestrator";
+export { createSynthesisNote, buildSynthesisSpec } from "./synthesis-writer";
 export type {
   IngestPreview,
   PreviewDecision,

--- a/src/services/query-orchestrator.test.ts
+++ b/src/services/query-orchestrator.test.ts
@@ -22,6 +22,15 @@ class StubRetriever implements Retriever {
   }
 }
 
+class SpyRetriever implements Retriever {
+  readonly calls: Array<{ query: string; topK: number | undefined }> = [];
+  constructor(private readonly hits: RetrievalHit[] = []) {}
+  async retrieve(query: string, opts?: { topK?: number }): Promise<RetrievalHit[]> {
+    this.calls.push({ query, topK: opts?.topK });
+    return this.hits;
+  }
+}
+
 class SequenceLLM implements LLMService {
   private calls = 0;
   constructor(private readonly replies: string[]) {}
@@ -239,6 +248,27 @@ describe("runQuery", () => {
     const states = events.filter((e) => e.kind === "enter").map((e) => e.state);
     expect(states).toContain("RETRY_WITH_CONSTRAINED_CITATIONS");
     expect(states[states.length - 1]).toBe("VALIDATION_FAILED");
+  });
+
+  // Invariant for #14: vault-tagged turns must never bypass retrieval. The
+  // event-log assertion alone could pass if an orchestrator logged the state
+  // without calling the retriever, so this spy guards against that drift.
+  it("retrieval invariant: retriever.retrieve is called with the user query", async () => {
+    const spy = new SpyRetriever([makeHit("Notes/a.md", "x")]);
+    const eventLog = new InMemoryEventLog();
+    const deps: QueryOrchestratorDeps = {
+      retriever: spy,
+      assembler: new StubAssembler([makeChunk("Notes/a.md")]),
+      llm: new SequenceLLM([validReply("A.", ["Notes/a.md"])]),
+      eventLog,
+      turnId: "turn-1",
+      model: "test-model",
+    };
+    await runQuery({ query: "What is X?" }, deps);
+    expect(spy.calls).toHaveLength(1);
+    expect(spy.calls[0]?.query).toBe("What is X?");
+    const events = await eventLog.eventsFor("turn-1");
+    expect(events.some((e) => e.kind === "enter" && e.state === "RETRIEVE")).toBe(true);
   });
 
   it("empty retrieval event log goes PLAN_RETRIEVAL → RETRIEVE → PRESENT → DONE", async () => {

--- a/src/services/synthesis-writer.test.ts
+++ b/src/services/synthesis-writer.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { IngestWriter } from "./ingest-writer";
+import { buildSynthesisSpec, createSynthesisNote } from "./synthesis-writer";
+
+describe("buildSynthesisSpec", () => {
+  it("derives title from the question and strips trailing punctuation", () => {
+    const spec = buildSynthesisSpec({
+      question: "What is Gemmera?",
+      answer: "A local RAG plugin.",
+      citations: ["Notes/about.md"],
+      model: "gemma4:e4b",
+      runId: "run-1",
+    });
+    expect(spec.title).toBe("What is Gemmera");
+  });
+
+  it("truncates long titles to 80 chars with an ellipsis", () => {
+    const long = "Q ".repeat(80).trim() + "?";
+    const spec = buildSynthesisSpec({
+      question: long,
+      answer: "x",
+      citations: [],
+      model: "m",
+      runId: "r",
+    });
+    expect(spec.title.length).toBeLessThanOrEqual(80);
+    expect(spec.title.endsWith("...")).toBe(true);
+  });
+
+  it("stamps cowork.source as 'synthesis' so notes are distinguishable from ingest", () => {
+    const spec = buildSynthesisSpec({
+      question: "q",
+      answer: "a",
+      citations: [],
+      model: "gemma4:e4b",
+      runId: "run-42",
+    });
+    expect(spec.cowork.source).toBe("synthesis");
+    expect(spec.cowork.run_id).toBe("run-42");
+    expect(spec.cowork.model).toBe("gemma4:e4b");
+  });
+
+  it("places citations in `related` and as wikilinks in body Sources section", () => {
+    const spec = buildSynthesisSpec({
+      question: "q",
+      answer: "a",
+      citations: ["Notes/a.md", "Notes/b.md"],
+      model: "m",
+      runId: "r",
+    });
+    expect(spec.related).toEqual(["Notes/a.md", "Notes/b.md"]);
+    expect(spec.body_markdown).toContain("## Sources");
+    expect(spec.body_markdown).toContain("[[Notes/a]]");
+    expect(spec.body_markdown).toContain("[[Notes/b]]");
+  });
+
+  it("omits Sources section when no citations are provided", () => {
+    const spec = buildSynthesisSpec({
+      question: "q",
+      answer: "a",
+      citations: [],
+      model: "m",
+      runId: "r",
+    });
+    expect(spec.body_markdown).not.toContain("## Sources");
+  });
+});
+
+describe("createSynthesisNote", () => {
+  it("writes a file with cowork frontmatter into the requested folder", async () => {
+    const vault = new MockVaultService();
+    const writer = new IngestWriter(vault);
+    const { path, spec } = await createSynthesisNote(
+      {
+        question: "Why does the sky look blue?",
+        answer: "Rayleigh scattering.",
+        citations: ["Notes/physics.md"],
+        model: "gemma4:e4b",
+        runId: "run-9",
+      },
+      writer,
+      { folder: "Synthesis/", now: () => Date.parse("2026-05-14T00:00:00Z") },
+    );
+
+    expect(path.startsWith("Synthesis/2026-05-14 ")).toBe(true);
+    expect(path.endsWith(".md")).toBe(true);
+
+    const content = await vault.read(path);
+    expect(content).toContain("cowork_managed: true");
+    expect(content).toContain("source: synthesis");
+    expect(content).toContain("[[Notes/physics]]");
+    expect(spec.cowork.source).toBe("synthesis");
+  });
+});

--- a/src/services/synthesis-writer.ts
+++ b/src/services/synthesis-writer.ts
@@ -1,0 +1,82 @@
+import type { NoteSpec } from "../contracts";
+import type { IngestWriter } from "./ingest-writer";
+
+export interface SynthesisInput {
+  question: string;
+  answer: string;
+  citations: string[];
+  model: string;
+  runId: string;
+  version?: string;
+}
+
+export interface SynthesisOptions {
+  folder?: string;
+  now?: () => number;
+}
+
+/**
+ * Writes a "synthesis" note produced by the query tool loop (#14). The note
+ * uses the same frontmatter contract as ingest output (planning/rag.md
+ * §"Frontmatter contract") but stamps `cowork.source: "synthesis"` so it can
+ * be distinguished from ingest-authored notes.
+ *
+ * Citation paths are preserved as wikilinks in a `## Sources` section and
+ * also written to `related` so the link-graph indexer picks them up.
+ */
+export async function createSynthesisNote(
+  input: SynthesisInput,
+  writer: IngestWriter,
+  opts: SynthesisOptions = {},
+): Promise<{ path: string; spec: NoteSpec }> {
+  const spec = buildSynthesisSpec(input);
+  const { path } = await writer.writeNew(spec, {
+    folder: opts.folder,
+    now: opts.now,
+  });
+  return { path, spec };
+}
+
+export function buildSynthesisSpec(input: SynthesisInput): NoteSpec {
+  const title = deriveTitle(input.question);
+  const body = composeBody(input.question, input.answer, input.citations);
+  return {
+    title,
+    type: "evergreen",
+    tags: ["synthesis"],
+    aliases: [],
+    source: "manual",
+    entities: [],
+    related: [...input.citations],
+    status: "inbox",
+    summary: input.question,
+    key_points: [],
+    body_markdown: body,
+    cowork: {
+      source: "synthesis",
+      run_id: input.runId,
+      model: input.model,
+      version: input.version ?? "0.0.1",
+      confidence: "medium",
+    },
+  };
+}
+
+function deriveTitle(question: string): string {
+  const cleaned = question.replace(/\s+/g, " ").trim();
+  if (cleaned.length === 0) return "Synthesis";
+  const stripped = cleaned.replace(/[?!.]+$/, "");
+  return stripped.length > 80 ? `${stripped.slice(0, 77)}...` : stripped;
+}
+
+function composeBody(question: string, answer: string, citations: string[]): string {
+  const parts = [`## Question`, "", question, "", `## Answer`, "", answer];
+  if (citations.length > 0) {
+    parts.push("", `## Sources`, "");
+    for (const path of citations) {
+      const display = path.replace(/\.md$/, "");
+      parts.push(`- [[${display}]]`);
+    }
+  }
+  return parts.join("\n");
+}

--- a/src/services/vault-index.ts
+++ b/src/services/vault-index.ts
@@ -9,10 +9,16 @@ const DEFAULT_TOP_K = 3;
 const SNIPPET_CHARS = 2000;
 
 /**
- * Stub IndexService backed by linear vault scan. Same behavior as the existing
- * `searchVault` in src/search.ts, but exposed through the IndexService
- * contract so the UI can be wired against an interface today and swapped for
- * a real index later (see planning/decisions/01-rust-integration.md).
+ * Stub IndexService backed by a linear vault scan.
+ *
+ * As of #14, vault-tagged turns ("ask" / "mixed") go through the
+ * HybridRetriever via `runQuery`. This linear scanner remains as the
+ * fallback context source for `meta` intent and any unclassified turn that
+ * lands in `runChat` — i.e., turns that do not warrant the full RAG loop.
+ *
+ * Do NOT wire new vault-grounded code paths against this — use
+ * `services.retriever` (HybridRetriever) so the retrieval-event invariant
+ * holds.
  */
 export class VaultLinearIndexService implements IndexService {
   constructor(private readonly vault: VaultService) {}

--- a/src/view.ts
+++ b/src/view.ts
@@ -9,6 +9,8 @@ import { classifyTurn } from "./services/classifier-orchestrator";
 import { toDisambiguationRow } from "./services/classifier-events";
 import { runIngest } from "./services/ingest-orchestrator";
 import { runMixed } from "./services/mixed-orchestrator";
+import { runQuery } from "./services/query-orchestrator";
+import { createSynthesisNote } from "./services/synthesis-writer";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
@@ -224,7 +226,16 @@ export class GemmeraChatView extends ItemView {
       return;
     }
 
-    // ── Chat ──────────────────────────────────────────────────────────
+    // ── Ask (#14) — vault-grounded query through the RAG tool loop ────
+    if (intent === "ask") {
+      await this.runAsk(text, turnId, route ?? null);
+      this.recentTurns = [...this.recentTurns.slice(-2), { text, intent: "ask" }];
+      this.setInputDisabled(false);
+      this.inputEl.focus();
+      return;
+    }
+
+    // ── Chat (meta / fallback, no retrieval) ──────────────────────────
     await this.runChat(text, intent, turnId, route ?? null);
   }
 
@@ -353,6 +364,72 @@ export class GemmeraChatView extends ItemView {
       if (savedPathSoFar) {
         this.appendMessage("assistant", `Note was saved to **${savedPathSoFar}**, but the query failed unexpectedly.`);
       }
+      this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
+    }
+  }
+
+  // INVARIANT (#14): every vault-tagged turn ("ask" intent, or "mixed" via
+  // runMixed) must reach `runQuery`, which exercises the hybrid retriever and
+  // emits a RETRIEVE event. Do NOT route ask intents through `runChat`: that
+  // path uses the linear scan kept only as a fallback for `meta`.
+  private async runAsk(
+    text: string,
+    turnId: string,
+    route: RouteDecision | null = null,
+  ): Promise<void> {
+    const decoration = buildMessageDecoration(
+      route,
+      this.settings.showClassifierDecisions,
+      this.settings.alwaysPreviewBeforeSave,
+    );
+    this.appendMessage("user", text, decoration);
+
+    const statusEl = this.messagesEl.createEl("div", {
+      cls: "gemmera-mixed-status gemmera-mixed-status--query",
+      text: "Searching notes…",
+    });
+
+    try {
+      const outcome = await runQuery(
+        { query: text },
+        {
+          retriever: this.services.retriever,
+          assembler: this.services.payloadAssembler,
+          llm: this.services.llm,
+          eventLog: this.services.eventLog,
+          turnId,
+          model: this.settings.chatModel,
+          onStateChange: (_state, label) => {
+            statusEl.textContent = label;
+          },
+        },
+      );
+
+      statusEl.remove();
+
+      if (outcome.kind === "empty") {
+        this.appendMessage("assistant", "No relevant notes found.");
+      } else if (outcome.kind === "failed") {
+        this.appendMessage("assistant", `Answer failed: ${outcome.reason}`);
+      } else if (outcome.kind === "validation_failed") {
+        this.appendMessage("assistant", outcome.answer);
+      } else {
+        const el = this.messagesEl.createEl("div", { cls: "gemmera-message gemmera-message--assistant" });
+        el.createEl("span", { cls: "gemmera-message__role", text: "Gemma" });
+        el.createEl("p", { cls: "gemmera-message__text", text: outcome.answer });
+        if (outcome.citations.length > 0) {
+          this.renderCitationChips(el, outcome.citations);
+        }
+        this.renderSynthesisButton(el, {
+          question: text,
+          answer: outcome.answer,
+          citations: outcome.citations,
+          turnId,
+        });
+        this.scrollToBottom();
+      }
+    } catch (err) {
+      statusEl.remove();
       this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
     }
   }
@@ -511,7 +588,11 @@ export class GemmeraChatView extends ItemView {
             { text: resolution.text, intent: "capture" },
           ];
         } else {
-          await this.runChat(resolution.text, chosenLabel, resolution.turnId);
+          await this.runAsk(resolution.text, resolution.turnId);
+          this.recentTurns = [
+            ...this.recentTurns.slice(-2),
+            { text: resolution.text, intent: "ask" },
+          ];
         }
       }
     }
@@ -548,6 +629,41 @@ export class GemmeraChatView extends ItemView {
   private renderCitationChips(parent: HTMLElement, citations: string[], needsReview = new Set<string>()): void {
     if (citations.length === 0) return;
     new CitationChipRow(this.app, parent, citations, needsReview);
+  }
+
+  private renderSynthesisButton(
+    parent: HTMLElement,
+    payload: { question: string; answer: string; citations: string[]; turnId: string },
+  ): void {
+    const btn = parent.createEl("button", {
+      cls: "gemmera-synthesis-btn",
+      text: "Save answer as note",
+      attr: { "aria-label": "Save this answer as a synthesis note" },
+    });
+    btn.addEventListener("click", async () => {
+      btn.disabled = true;
+      btn.textContent = "Saving…";
+      try {
+        const { path } = await createSynthesisNote(
+          {
+            question: payload.question,
+            answer: payload.answer,
+            citations: payload.citations,
+            model: this.settings.chatModel,
+            runId: payload.turnId,
+          },
+          this.services.ingestWriter,
+          { folder: this.settings.inboxFolder },
+        );
+        btn.remove();
+        new Notice(`Gemmera: synthesis saved to ${path}`);
+        this.appendMessage("assistant", `Synthesis saved to **${path}**`);
+      } catch (err) {
+        btn.disabled = false;
+        btn.textContent = "Save answer as note";
+        new Notice(`Gemmera: synthesis save failed — ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
   }
 
   // ── DOM helpers ──────────────────────────────────────────────────────

--- a/styles.css
+++ b/styles.css
@@ -114,13 +114,16 @@
 .gemmera-mixed-status--ingest { border-left: 2px solid var(--color-accent); padding-left: 8px; }
 .gemmera-mixed-status--query  { border-left: 2px solid var(--text-muted); padding-left: 8px; }
 
-.gemmera-retry-btn {
+.gemmera-retry-btn,
+.gemmera-synthesis-btn {
   align-self: flex-start;
   margin-top: 4px;
   font-size: 0.8rem;
   padding: 2px 10px;
   cursor: pointer;
 }
+
+.gemmera-synthesis-btn[disabled] { opacity: 0.6; cursor: progress; }
 
 .gemmera-input-area {
   padding: 10px;
@@ -148,7 +151,8 @@
 
 .gemmera-send:focus-visible,
 .gemmera-disambig-chip__btn:focus-visible,
-.gemmera-retry-btn:focus-visible {
+.gemmera-retry-btn:focus-visible,
+.gemmera-synthesis-btn:focus-visible {
   outline: 2px solid var(--interactive-accent);
   outline-offset: 1px;
 }


### PR DESCRIPTION
## Summary

Closes #14. Wires the `ask` intent through the RAG query tool loop and adds the optional synthesis-note write-back.

Before this PR, `ask`-tagged turns went through `runChat`, which used the week-2 `VaultLinearIndexService` (a linear text scan). The hybrid retriever + reranker + payload assembler from #8/#9/#10 were only invoked by `runMixed`. After this PR, `ask` turns go through `runQuery` like `mixed` does, and the linear scanner is scoped to `meta`/fallback only.

### Changes

- **`runAsk` in `src/view.ts`** drives `runQuery` with the same services `runMixed` uses (`retriever`, `payloadAssembler`, `eventLog`). Dispatch in `handleSend` and the disambiguation chip "Ask" action now both route through it.
- **`src/services/synthesis-writer.ts`** — `createSynthesisNote` builds a `NoteSpec` with `cowork.source: "synthesis"`, citations in `related[]`, and a `## Sources` wikilink section, then writes via the existing `IngestWriter` so the frontmatter contract is shared.
- **"Save answer as note" button** rendered under answered turns; on click writes a synthesis note using `turnId` as `run_id`.
- **`VaultLinearIndexService` docstring** narrowed to its remaining `meta`/fallback role.
- **Retrieval invariant test** — `SpyRetriever` asserts `retriever.retrieve` is called with the user query for the happy path, closing the "log the state without doing the work" loophole the event-log-only assertion left open.

### Acceptance criteria (issue #14)

- [x] Vault questions never bypass retrieval — invariant test in `query-orchestrator.test.ts` + comment pinning the dispatch in `view.ts`.
- [x] Answers include source paths in the UI payload — citation chips render on the answered branch of `runAsk`.
- [x] Synthesis notes carry the same `cowork` block + frontmatter contract as ingest output — `createSynthesisNote` reuses `IngestWriter`; test asserts `cowork_managed: true` and `source: synthesis` in the written file.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 635/635 pass (+7 new: 6 synthesis-writer, 1 retrieval invariant)
- [ ] Smoke in demo vault: ingest a note, ask a question that targets it, verify citation chips and retrieval status chip render
- [ ] Smoke synthesis: click "Save answer as note", verify the produced file in `Inbox/` has `cowork.source: synthesis` and a `## Sources` section

## Notes / follow-ups

- `VaultLinearIndexService` kept in `createServices` because `runChat` still uses it for `meta` turns. Removal would change behavior for non-vault paths; out of scope here.
- Synthesis notes land in `settings.inboxFolder` (default `Inbox/`). A dedicated `Synthesis/` folder setting was considered but deferred to avoid expanding the settings surface.
- Reranker not wired into `runAsk` because `services.reranker` is not yet exposed; query-orchestrator handles its absence gracefully. Follow-up issue welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)