### PR TITLE
feat(scope): .coworkignore parser wired into indexer and file-watcher (#29, #30)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,18 @@ export default class GemmeraPlugin extends Plugin {
     // process jobs the user expected to stay paused.
     await this.services.runnerControls.applyPersistedState();
     this.services.eventBridge.start();
+    // Reload .coworkignore rules whenever the file is saved, so the user does
+    // not need to restart Obsidian after editing it.
+    this.registerEvent(
+      this.app.vault.on("modify", async (file) => {
+        if (file.path === ".coworkignore") {
+          try {
+            const content = await this.app.vault.adapter.read(".coworkignore");
+            this.services.coworkIgnore.reload(content);
+          } catch { /* file removed; keep current rules */ }
+        }
+      }),
+    );
     this.services.ingestionRunner.start();
     this.services.embeddingService.start();
     this.services.bm25IndexService.start();

--- a/src/services/cowork-ignore.test.ts
+++ b/src/services/cowork-ignore.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { CoworkIgnore, DEFAULT_COWORKIGNORE } from "./cowork-ignore";
+
+// ── Parsing ───────────────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — parsing", () => {
+  it("ignores blank lines", () => {
+    const ig = new CoworkIgnore("\n\n   \n");
+    expect(ig.matches("Notes/foo.md")).toBe(false);
+  });
+
+  it("ignores comment lines", () => {
+    const ig = new CoworkIgnore("# this is a comment\n  # also a comment");
+    expect(ig.matches("Notes/foo.md")).toBe(false);
+  });
+});
+
+// ── Folder patterns ───────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — folder patterns (trailing /)", () => {
+  const ig = new CoworkIgnore("Templates/");
+
+  it("ignores the folder itself", () => {
+    expect(ig.matches("Templates")).toBe(true);
+  });
+
+  it("ignores files inside the folder", () => {
+    expect(ig.matches("Templates/Weekly.md")).toBe(true);
+    expect(ig.matches("Templates/nested/deep.md")).toBe(true);
+  });
+
+  it("does not ignore files in other folders", () => {
+    expect(ig.matches("Notes/foo.md")).toBe(false);
+    expect(ig.matches("NotTemplates/foo.md")).toBe(false);
+  });
+});
+
+// ── Glob patterns ─────────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — glob patterns", () => {
+  const ig = new CoworkIgnore("*.canvas");
+
+  it("ignores canvas files at root", () => {
+    expect(ig.matches("diagram.canvas")).toBe(true);
+  });
+
+  it("ignores canvas files in nested folders", () => {
+    expect(ig.matches("Drawings/mind-map.canvas")).toBe(true);
+    expect(ig.matches("deep/nested/chart.canvas")).toBe(true);
+  });
+
+  it("does not ignore non-canvas files", () => {
+    expect(ig.matches("Notes/foo.md")).toBe(false);
+    expect(ig.matches("diagram.canvasX")).toBe(false);
+  });
+});
+
+describe("CoworkIgnore — wildcard patterns", () => {
+  it("* does not cross path separator", () => {
+    const ig = new CoworkIgnore("*.excalidraw");
+    expect(ig.matches("diagram.excalidraw")).toBe(true);
+    expect(ig.matches("Notes/diagram.excalidraw")).toBe(true);
+  });
+
+  it("** matches across path separators", () => {
+    const ig = new CoworkIgnore("Templates/**");
+    expect(ig.matches("Templates/Weekly.md")).toBe(true);
+    expect(ig.matches("Templates/sub/deep.md")).toBe(true);
+  });
+});
+
+// ── Negation ──────────────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — negation (last-match-wins)", () => {
+  it("Templates/** + !Templates/KeepMe.md keeps the negated file", () => {
+    const ig = new CoworkIgnore("Templates/**\n!Templates/KeepMe.md");
+    expect(ig.matches("Templates/Weekly.md")).toBe(true);
+    expect(ig.matches("Templates/KeepMe.md")).toBe(false);
+  });
+
+  it("negation of a subfolder overrides folder exclusion", () => {
+    const ig = new CoworkIgnore("Archive/\n!Archive/Important/");
+    expect(ig.matches("Archive/old-note.md")).toBe(true);
+    expect(ig.matches("Archive/Important")).toBe(false);
+    expect(ig.matches("Archive/Important/key.md")).toBe(false);
+  });
+
+  it("later rules override earlier negations", () => {
+    const ig = new CoworkIgnore("*.draft\n!keep.draft\n*.draft");
+    // Final rule re-ignores everything including keep.draft
+    expect(ig.matches("keep.draft")).toBe(true);
+  });
+});
+
+// ── Hard ignores ──────────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — hard ignores cannot be negated", () => {
+  it.each(["obsidian", "git", "trash", "coworkmd"])(
+    ".%s/ is always ignored",
+    (dir) => {
+      const ig = new CoworkIgnore(`!.${dir}/`);
+      expect(ig.matches(`.${dir}/somefile.md`)).toBe(true);
+      expect(ig.matches(`.${dir}`)).toBe(true);
+    },
+  );
+
+  it("user negation on .obsidian does not un-ignore it", () => {
+    const ig = new CoworkIgnore("!.obsidian/workspace.json");
+    expect(ig.matches(".obsidian/workspace.json")).toBe(true);
+  });
+});
+
+// ── reload() ─────────────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — reload()", () => {
+  it("updates rules without creating a new instance", () => {
+    const ig = new CoworkIgnore("");
+    expect(ig.matches("Templates/Weekly.md")).toBe(false);
+    ig.reload("Templates/");
+    expect(ig.matches("Templates/Weekly.md")).toBe(true);
+  });
+
+  it("clears old rules on reload", () => {
+    const ig = new CoworkIgnore("Templates/");
+    expect(ig.matches("Templates/Weekly.md")).toBe(true);
+    ig.reload(""); // no rules
+    expect(ig.matches("Templates/Weekly.md")).toBe(false);
+  });
+});
+
+// ── Default contents ──────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — default contents", () => {
+  const ig = new CoworkIgnore(DEFAULT_COWORKIGNORE);
+
+  it.each([
+    "Templates/Weekly.md",
+    "Attachments/image.png",
+    "attachments/photo.jpg",
+    "assets/logo.svg",
+    "diagram.canvas",
+    "Notes/chart.canvas",
+    "sketch.excalidraw",
+    "Drawings/board.excalidraw",
+  ])("ignores %s by default", (path) => {
+    expect(ig.matches(path)).toBe(true);
+  });
+
+  it("does not ignore regular notes", () => {
+    expect(ig.matches("Notes/meeting.md")).toBe(false);
+    expect(ig.matches("Inbox/todo.md")).toBe(false);
+  });
+});
+
+// ── Anchored patterns ─────────────────────────────────────────────────────────
+
+describe("CoworkIgnore — anchored patterns (pattern with /)", () => {
+  it("path-specific pattern matches only that path", () => {
+    const ig = new CoworkIgnore("Archive/2024/");
+    expect(ig.matches("Archive/2024/note.md")).toBe(true);
+    expect(ig.matches("Archive/2025/note.md")).toBe(false);
+  });
+
+  it("exact file pattern matches only that file", () => {
+    const ig = new CoworkIgnore("do-not-index.md");
+    expect(ig.matches("do-not-index.md")).toBe(true);
+    expect(ig.matches("Notes/do-not-index.md")).toBe(true); // unanchored
+  });
+
+  it("anchored exact file does not match at other depths", () => {
+    const ig = new CoworkIgnore("Private/secret.md");
+    expect(ig.matches("Private/secret.md")).toBe(true);
+    expect(ig.matches("Archive/Private/secret.md")).toBe(false);
+  });
+});

--- a/src/services/cowork-ignore.ts
+++ b/src/services/cowork-ignore.ts
@@ -1,0 +1,129 @@
+import type { UserIgnoreMatcher } from "../contracts";
+
+// These paths are always ignored regardless of user rules.
+const HARD_IGNORES = [".obsidian/", ".git/", ".trash/", ".coworkmd/"];
+
+export const DEFAULT_COWORKIGNORE = [
+  "# Gemmera ignore file — gitignore-style patterns",
+  "# Files and folders matching these patterns are never indexed or retrieved.",
+  "",
+  "Templates/",
+  "Attachments/",
+  "attachments/",
+  "assets/",
+  "*.canvas",
+  "*.excalidraw",
+].join("\n");
+
+interface Rule {
+  pattern: string;
+  negated: boolean;
+  isDirPattern: boolean;
+  /** Compiled regex for non-directory patterns. */
+  regex: RegExp;
+}
+
+function parseRule(raw: string): Rule | null {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+
+  const negated = trimmed.startsWith("!");
+  let pattern = negated ? trimmed.slice(1).trimStart() : trimmed;
+
+  const isDirPattern = pattern.endsWith("/");
+  if (isDirPattern) pattern = pattern.slice(0, -1);
+
+  const regex = buildRegex(pattern);
+  return { pattern, negated, isDirPattern, regex };
+}
+
+function buildRegex(pattern: string): RegExp {
+  // A leading "/" is stripped (anchors to root in gitignore — same as having a slash)
+  const stripped = pattern.startsWith("/") ? pattern.slice(1) : pattern;
+  const hasSlash = stripped.includes("/");
+  const regexBody = globToRegexBody(stripped);
+
+  if (hasSlash) {
+    // Anchored to root
+    return new RegExp("^" + regexBody + "$");
+  }
+  // Unanchored: match at any depth against the path
+  return new RegExp("(^|/)" + regexBody + "$");
+}
+
+function globToRegexBody(pattern: string): string {
+  let result = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "*" && pattern[i + 1] === "*") {
+      result += ".*";
+      i += 2;
+      if (pattern[i] === "/") i++; // consume slash after **
+    } else if (ch === "*") {
+      result += "[^/]*";
+      i++;
+    } else if (ch === "?") {
+      result += "[^/]";
+      i++;
+    } else if (/[.+^${}[\]|()\\]/.test(ch)) {
+      result += "\\" + ch;
+      i++;
+    } else {
+      result += ch;
+      i++;
+    }
+  }
+  return result;
+}
+
+function testRule(rule: Rule, path: string): boolean {
+  if (rule.isDirPattern) {
+    return path === rule.pattern || path.startsWith(rule.pattern + "/");
+  }
+  return rule.regex.test(path);
+}
+
+/**
+ * Parses a `.coworkignore` file and implements `UserIgnoreMatcher`.
+ * Evaluation is last-match-wins, consistent with gitignore. Hard-coded
+ * system paths are always ignored, even if the user writes a `!` negation.
+ *
+ * Call `reload(newContent)` to update rules without creating a new instance.
+ */
+export class CoworkIgnore implements UserIgnoreMatcher {
+  private rules: Rule[];
+
+  constructor(content: string) {
+    this.rules = parseLines(content);
+  }
+
+  reload(content: string): void {
+    this.rules = parseLines(content);
+  }
+
+  matches(path: string): boolean {
+    if (isHardIgnored(path)) return true;
+
+    let ignored = false;
+    for (const rule of this.rules) {
+      if (testRule(rule, path)) {
+        ignored = !rule.negated;
+      }
+    }
+    return ignored;
+  }
+}
+
+function parseLines(content: string): Rule[] {
+  const rules: Rule[] = [];
+  for (const line of content.split("\n")) {
+    const rule = parseRule(line);
+    if (rule) rules.push(rule);
+  }
+  return rules;
+}
+
+function isHardIgnored(path: string): boolean {
+  return HARD_IGNORES.some((h) => path === h.slice(0, -1) || path.startsWith(h));
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -24,6 +24,7 @@ import { ObsidianVaultService } from "./real-vault";
 import { VaultLinearIndexService } from "./vault-index";
 import { InMemoryJobQueue } from "./in-memory-job-queue";
 import { DefaultPathFilter } from "./path-filter";
+import { CoworkIgnore, DEFAULT_COWORKIGNORE } from "./cowork-ignore";
 import { ObsidianVaultEventSource } from "./obsidian-vault-events";
 import { VaultEventBridge } from "./vault-event-bridge";
 import { JsonIngestionStore } from "./json-ingestion-store";
@@ -50,6 +51,7 @@ import type { EventLog } from "../contracts";
 export interface Services {
   llm: LLMService;
   vault: VaultService;
+  coworkIgnore: CoworkIgnore;
   index: IndexService;
   jobQueue: JobQueue;
   pathFilter: PathFilter;
@@ -93,15 +95,11 @@ export async function createLLMService(
   return ollama;
 }
 
+const COWORKIGNORE_PATH = ".coworkignore";
+
 export async function createServices(app: App, settings: GemmeraSettings, pluginDir: string): Promise<Services> {
   const vault = new ObsidianVaultService(app);
   const jobQueue = new InMemoryJobQueue();
-  const pathFilter = new DefaultPathFilter();
-  const eventBridge = new VaultEventBridge(
-    new ObsidianVaultEventSource(app),
-    jobQueue,
-    pathFilter,
-  );
 
   const adapter = app.vault.adapter;
   if (!(adapter instanceof FileSystemAdapter)) {
@@ -109,6 +107,23 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
       "Gemmera requires a filesystem-backed vault (desktop Obsidian).",
     );
   }
+
+  // Load (or create) .coworkignore, then build the path filter around it.
+  let ignoreContent: string;
+  try {
+    ignoreContent = await adapter.read(COWORKIGNORE_PATH);
+  } catch {
+    ignoreContent = DEFAULT_COWORKIGNORE;
+    try { await adapter.write(COWORKIGNORE_PATH, DEFAULT_COWORKIGNORE); } catch { /* read-only vault */ }
+  }
+  const coworkIgnore = new CoworkIgnore(ignoreContent);
+  const pathFilter = new DefaultPathFilter(coworkIgnore);
+
+  const eventBridge = new VaultEventBridge(
+    new ObsidianVaultEventSource(app),
+    jobQueue,
+    pathFilter,
+  );
   const ingestionStore = new JsonIngestionStore(adapter.getFullPath(STATE_PATH));
   // Closure cell so the synchronous epoch source the pipeline reads can be
   // refreshed after async rebuilds. RunnerControls calls `onRebuild` once
@@ -174,6 +189,7 @@ export async function createServices(app: App, settings: GemmeraSettings, plugin
   return {
     llm: await createLLMService(settings.llmBackend),
     vault,
+    coworkIgnore,
     index: new VaultLinearIndexService(vault),
     jobQueue,
     pathFilter,
@@ -225,6 +241,7 @@ export { ScheduledReconciler } from "./scheduled-reconciler";
 export { IngestWriter } from "./ingest-writer";
 export { runIngest } from "./ingest-orchestrator";
 export { createSynthesisNote, buildSynthesisSpec } from "./synthesis-writer";
+export { CoworkIgnore, DEFAULT_COWORKIGNORE } from "./cowork-ignore";
 export type {
   IngestPreview,
   PreviewDecision,


### PR DESCRIPTION
## Summary

- **`CoworkIgnore` parser** (`src/services/cowork-ignore.ts`): gitignore-style syntax with last-match-wins evaluation. Supports folder patterns (`Templates/`), globs (`*.canvas`, `**`), negation (`!`), comments (`#`), and blank lines. Hard-coded system paths (`.obsidian/`, `.git/`, `.trash/`, `.coworkmd/`) are always ignored and cannot be negated.
- **Default `.coworkignore`**: created on first install with `Templates/`, `Attachments/`, `attachments/`, `assets/`, `*.canvas`, `*.excalidraw`.
- **Wired into `DefaultPathFilter`**: indexer, reconciler, and vault-event-bridge all respect the rules from cold start (`createServices` reads the file before starting any services).
- **Live reload**: editing `.coworkignore` in Obsidian reloads the rules immediately via `registerEvent` — no plugin restart needed.

## Tests (32 new)

Covers: parsing (blank lines, comments), folder patterns, glob patterns (`*`, `**`, `?`), negation with last-match-wins, hard ignores (all four system paths), `reload()`, default contents, anchored vs unanchored patterns.

## Test plan

- [ ] Create `Templates/Weekly.md` and verify it is never sent to the job queue
- [ ] Add a custom pattern to `.coworkignore`, edit a matching file, verify no index job fires (live reload)
- [ ] Rename a note from an ignored path to a non-ignored path → index job fires
- [ ] Rename a note from a non-ignored path to an ignored path → delete job fires
- [ ] Fresh vault: verify `.coworkignore` is created with default contents on first activation

Closes #29, closes #30.