### PR TITLE
feat(dev): turn inspector modal behind devMode setting (#74)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -113,6 +113,24 @@ export default class GemmeraPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: "open-turn-inspector",
+      name: "Turn Inspector — view last turn trace",
+      checkCallback: (checking: boolean) => {
+        if (!this.settings.devMode) return false;
+        if (!checking) {
+          const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE);
+          const view = leaves[0]?.view as GemmeraChatView | undefined;
+          if (view) {
+            view.openTurnInspector();
+          } else {
+            new Notice("Gemmera: Open the chat panel first.");
+          }
+        }
+        return true;
+      },
+    });
+
+    this.addCommand({
       id: "capture-selection",
       name: "Gemmera: Fånga markering",
       hotkeys: [{ modifiers: ["Ctrl", "Shift"], key: "C" }],

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,6 +48,13 @@ export interface GemmeraSettings {
 
   /** Ollama tag used for chat and the classifier (e.g. `gemma4:e4b`). */
   chatModel: string;
+
+  /**
+   * When true, the "Open turn inspector" command appears in the palette.
+   * Shows raw state traces with tool args, payloads, and per-step timing.
+   * Intended for developers; hidden by default in production.
+   */
+  devMode: boolean;
 }
 
 export const DEFAULT_CHAT_MODEL = "gemma4:e4b";
@@ -62,4 +69,5 @@ export const DEFAULT_SETTINGS: GemmeraSettings = {
   ollamaPath: "",
   turnTimeoutMs: 120_000,
   chatModel: DEFAULT_CHAT_MODEL,
+  devMode: false,
 };

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -256,6 +256,17 @@ export class GemmeraSettingsTab extends PluginSettingTab {
           await this.refresh();
         });
       });
+
+    new Setting(containerEl)
+      .setName("Developer mode")
+      .setDesc("Enables the Turn Inspector command in the command palette. Shows raw state traces with tool args, payloads, and per-step timing. Reload the plugin after toggling.")
+      .addToggle((toggle) => {
+        toggle.setValue(this.settings.devMode);
+        toggle.onChange(async (value) => {
+          this.settings.devMode = value;
+          await this.saveSettings();
+        });
+      });
   }
 }
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -259,7 +259,7 @@ export class GemmeraSettingsTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Developer mode")
-      .setDesc("Enables the Turn Inspector command in the command palette. Shows raw state traces with tool args, payloads, and per-step timing. Reload the plugin after toggling.")
+      .setDesc("Enables the Turn Inspector command in the command palette. Shows raw state traces with tool args, payloads, and per-step timing.")
       .addToggle((toggle) => {
         toggle.setValue(this.settings.devMode);
         toggle.onChange(async (value) => {

--- a/src/ui/turn-inspector.ts
+++ b/src/ui/turn-inspector.ts
@@ -23,12 +23,12 @@ class TurnInspectorModal extends Modal {
   onOpen(): void {
     const { contentEl } = this;
     contentEl.empty();
-    contentEl.style.maxWidth = "860px";
+    contentEl.style.maxWidth = "min(860px, 95vw)";
 
     contentEl.createEl("h2", { text: "Turn Inspector" });
 
     if (this.entries.length === 0) {
-      contentEl.createEl("p", { text: "No state entries recorded for this turn." });
+      contentEl.createEl("p", { text: "No state entries found. The event log is cleared on plugin reload — send a message first." });
       this.addCloseButton(contentEl);
       return;
     }

--- a/src/ui/turn-inspector.ts
+++ b/src/ui/turn-inspector.ts
@@ -1,62 +1,71 @@
 import { Modal, type App } from "obsidian";
-import type { InspectorEntry } from "../services/turn-status";
+import type { EventLogEntry } from "../contracts/state-machine";
+import { formatInspectorEntries, type InspectorEntry } from "../services/turn-status";
 
 /**
- * Developer-facing modal that shows every state entered during a turn (#66).
- *
- * Open it via `openTurnInspector(app, entries)` after a turn completes.
- * Only surface this in dev mode — production users should not see raw state
- * names and timestamps.
+ * Developer-facing modal that shows every state entered during a turn (#74).
+ * Hidden behind the devMode setting — surface only via the registered command.
  */
-export function openTurnInspector(app: App, entries: InspectorEntry[]): void {
-  const modal = new TurnInspectorModal(app, entries);
-  modal.open();
+export function openTurnInspector(app: App, rawEntries: readonly EventLogEntry[]): void {
+  new TurnInspectorModal(app, rawEntries).open();
 }
 
 class TurnInspectorModal extends Modal {
-  constructor(
-    app: App,
-    private readonly entries: InspectorEntry[],
-  ) {
+  private readonly entries: InspectorEntry[];
+  private readonly rawEntries: readonly EventLogEntry[];
+
+  constructor(app: App, rawEntries: readonly EventLogEntry[]) {
     super(app);
+    this.rawEntries = rawEntries;
+    this.entries = formatInspectorEntries(rawEntries);
   }
 
   onOpen(): void {
     const { contentEl } = this;
     contentEl.empty();
+    contentEl.style.maxWidth = "860px";
 
     contentEl.createEl("h2", { text: "Turn Inspector" });
 
     if (this.entries.length === 0) {
       contentEl.createEl("p", { text: "No state entries recorded for this turn." });
+      this.addCloseButton(contentEl);
       return;
     }
 
+    // ── State trace table ─────────────────────────────────────────────────
     const table = contentEl.createEl("table");
     table.style.width = "100%";
     table.style.borderCollapse = "collapse";
     table.style.fontSize = "12px";
+    table.style.marginBottom = "12px";
 
     const head = table.createEl("thead");
     const headRow = head.createEl("tr");
-    for (const col of ["State", "Label", "From", "Time", "Payload"]) {
+    for (const col of ["State", "Label", "From", "Elapsed", "Payload"]) {
       const th = headRow.createEl("th", { text: col });
       th.style.textAlign = "left";
       th.style.padding = "4px 8px";
       th.style.borderBottom = "1px solid var(--background-modifier-border)";
+      th.style.whiteSpace = "nowrap";
     }
 
     const body = table.createEl("tbody");
-    for (const entry of this.entries) {
+    for (let i = 0; i < this.entries.length; i++) {
+      const e = this.entries[i];
+      const prev = this.entries[i - 1];
+      const elapsedMs = prev ? e.timestamp - prev.timestamp : 0;
+      const elapsedStr = i === 0 ? "—" : `${elapsedMs} ms`;
+
       const row = body.createEl("tr");
       row.style.verticalAlign = "top";
 
       const cells = [
-        entry.state,
-        entry.label,
-        entry.fromState ?? "—",
-        entry.time.replace("T", " ").replace("Z", ""),
-        entry.payloadPreview ?? "",
+        e.state,
+        e.label,
+        e.fromState ?? "—",
+        elapsedStr,
+        e.payloadPreview ?? "",
       ];
       for (const text of cells) {
         const td = row.createEl("td", { text });
@@ -68,12 +77,33 @@ class TurnInspectorModal extends Modal {
       }
     }
 
-    const closeBtn = contentEl.createEl("button", { text: "Close" });
-    closeBtn.style.marginTop = "12px";
-    closeBtn.addEventListener("click", () => this.close());
+    // ── Action buttons ────────────────────────────────────────────────────
+    const buttonRow = contentEl.createEl("div");
+    buttonRow.style.display = "flex";
+    buttonRow.style.gap = "8px";
+    buttonRow.style.marginTop = "4px";
+
+    const copyBtn = buttonRow.createEl("button", { text: "Copy JSON" });
+    copyBtn.addEventListener("click", () => {
+      const json = JSON.stringify(this.rawEntries, null, 2);
+      navigator.clipboard.writeText(json).then(() => {
+        copyBtn.textContent = "Copied!";
+        setTimeout(() => { copyBtn.textContent = "Copy JSON"; }, 1500);
+      }).catch(() => {
+        copyBtn.textContent = "Copy failed";
+        setTimeout(() => { copyBtn.textContent = "Copy JSON"; }, 1500);
+      });
+    });
+
+    this.addCloseButton(buttonRow);
   }
 
   onClose(): void {
     this.contentEl.empty();
+  }
+
+  private addCloseButton(parent: HTMLElement): void {
+    const btn = parent.createEl("button", { text: "Close" });
+    btn.addEventListener("click", () => this.close());
   }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -20,6 +20,7 @@ import { buildMessageDecoration } from "./message-decoration";
 import { showSaveUndoNotice } from "./notices";
 import { labelForState } from "./services/turn-status";
 import { CitationChipRow } from "./ui/citation-chips";
+import { openTurnInspector } from "./ui/turn-inspector";
 
 export const VIEW_TYPE = "gemmera-chat";
 
@@ -41,6 +42,7 @@ export class GemmeraChatView extends ItemView {
   private currentSessionId: string | null = null;
   private escCleared = false;
   private prefersReducedMotion = false;
+  private lastTurnId: string | undefined;
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -176,6 +178,7 @@ export class GemmeraChatView extends ItemView {
     this.setInputDisabled(true);
 
     const turnId = crypto.randomUUID();
+    this.lastTurnId = turnId;
 
     // ── Classify ──────────────────────────────────────────────────────
     let route: RouteDecision | null = null;
@@ -754,6 +757,15 @@ export class GemmeraChatView extends ItemView {
     }
 
     this.scrollToBottom();
+  }
+
+  async openTurnInspector(): Promise<void> {
+    if (!this.lastTurnId) {
+      new Notice("Gemmera: No turn recorded yet — send a message first.");
+      return;
+    }
+    const rawEntries = await this.services.eventLog.eventsFor(this.lastTurnId);
+    openTurnInspector(this.app, rawEntries);
   }
 }
 


### PR DESCRIPTION
## Summary

- **`devMode` setting**: new boolean in `GemmeraSettings` (default `false`), toggled via Settings → Advanced → "Developer mode". Persists in `data.json`.
- **Command**: `open-turn-inspector` registered with `checkCallback` — hidden from the command palette unless `devMode` is `true`. No command appears for production users.
- **Enhanced `TurnInspectorModal`**:
  - Elapsed time column: milliseconds since the previous state entry
  - "Copy JSON" button: writes the full raw `EventLogEntry[]` (untruncated payloads) to the clipboard as formatted JSON; shows "Copied!" / "Copy failed" feedback for 1.5 s
- **`GemmeraChatView`**: tracks `lastTurnId` at the start of every turn so the inspector always shows the most recent trace; `openTurnInspector()` fetches entries from the in-memory event log and opens the modal

## Test plan

- [ ] Enable Developer mode in Settings → Advanced
- [ ] Send a chat or capture message
- [ ] Open command palette → "Turn Inspector — view last turn trace" → modal appears with state table, elapsed times, and Copy JSON button
- [ ] Click "Copy JSON" → paste into a JSON validator → valid JSON with full payloads
- [ ] Disable Developer mode → command disappears from palette
- [ ] Open inspector before any turn → notice "No turn recorded yet"

Closes #74.