### PR TITLE
fix(scope): gitignore-correct .coworkignore semantics + working live reload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { FileSystemAdapter, Menu, Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, watch as fsWatch } from "fs";
 import { GemmeraChatView, VIEW_TYPE } from "./view";
 import { createServices, Services } from "./services";
 import { OllamaLifecycle, type OllamaStatus } from "./services/ollama-lifecycle";
@@ -42,18 +42,7 @@ export default class GemmeraPlugin extends Plugin {
     // process jobs the user expected to stay paused.
     await this.services.runnerControls.applyPersistedState();
     this.services.eventBridge.start();
-    // Reload .coworkignore rules whenever the file is saved, so the user does
-    // not need to restart Obsidian after editing it.
-    this.registerEvent(
-      this.app.vault.on("modify", async (file) => {
-        if (file.path === ".coworkignore") {
-          try {
-            const content = await this.app.vault.adapter.read(".coworkignore");
-            this.services.coworkIgnore.reload(content);
-          } catch { /* file removed; keep current rules */ }
-        }
-      }),
-    );
+    this.registerCoworkIgnoreReload();
     this.services.ingestionRunner.start();
     this.services.embeddingService.start();
     this.services.bm25IndexService.start();
@@ -115,6 +104,12 @@ export default class GemmeraPlugin extends Plugin {
       id: "open-chat",
       name: "Öppna chatt",
       callback: () => this.openChatView(),
+    });
+
+    this.addCommand({
+      id: "reload-coworkignore",
+      name: "Gemmera: Reload .coworkignore",
+      callback: () => { void this.reloadCoworkIgnore(); },
     });
 
     this.addCommand({
@@ -317,6 +312,35 @@ export default class GemmeraPlugin extends Plugin {
     const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE);
     const view = leaves[0]?.view as GemmeraChatView | undefined;
     view?.setComposerText(text);
+  }
+
+  private async reloadCoworkIgnore(): Promise<void> {
+    try {
+      const content = await this.app.vault.adapter.read(".coworkignore");
+      this.services.coworkIgnore.reload(content);
+    } catch {
+      // File removed — keep current rules.
+    }
+  }
+
+  // Obsidian's Vault hides root-level dotfiles, so `vault.on("modify")` never
+  // fires for `.coworkignore`. Watch the vault root via fs and filter by name;
+  // parent-dir watch (vs. file watch) survives editors that save atomically by
+  // replacing the inode.
+  private registerCoworkIgnoreReload(): void {
+    const adapter = this.app.vault.adapter;
+    if (!(adapter instanceof FileSystemAdapter)) return;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const watcher = fsWatch(adapter.getBasePath(), { persistent: false }, (_event, filename) => {
+      if (filename !== ".coworkignore") return;
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => { void this.reloadCoworkIgnore(); }, 200);
+    });
+    watcher.on("error", (err) => console.error("[gemmera] .coworkignore watcher error", err));
+    this.register(() => {
+      if (debounce) clearTimeout(debounce);
+      watcher.close();
+    });
   }
 
   private async reindexNote(file: TFile): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -332,7 +332,10 @@ export default class GemmeraPlugin extends Plugin {
     if (!(adapter instanceof FileSystemAdapter)) return;
     let debounce: ReturnType<typeof setTimeout> | null = null;
     const watcher = fsWatch(adapter.getBasePath(), { persistent: false }, (_event, filename) => {
-      if (filename !== ".coworkignore") return;
+      // Some Linux FSes (FUSE, certain NFS configs) pass null filename on
+      // `change` events. Treat null as "could be ours" — reload is cheap,
+      // debounced, and idempotent, so a few unrelated wake-ups are fine.
+      if (filename !== null && filename !== ".coworkignore") return;
       if (debounce) clearTimeout(debounce);
       debounce = setTimeout(() => { void this.reloadCoworkIgnore(); }, 200);
     });

--- a/src/services/cowork-ignore.test.ts
+++ b/src/services/cowork-ignore.test.ts
@@ -13,6 +13,12 @@ describe("CoworkIgnore — parsing", () => {
     const ig = new CoworkIgnore("# this is a comment\n  # also a comment");
     expect(ig.matches("Notes/foo.md")).toBe(false);
   });
+
+  it("tolerates CRLF line endings", () => {
+    const ig = new CoworkIgnore("Templates/\r\n*.canvas\r\n");
+    expect(ig.matches("Templates/x.md")).toBe(true);
+    expect(ig.matches("diagram.canvas")).toBe(true);
+  });
 });
 
 // ── Folder patterns ───────────────────────────────────────────────────────────
@@ -32,6 +38,33 @@ describe("CoworkIgnore — folder patterns (trailing /)", () => {
   it("does not ignore files in other folders", () => {
     expect(ig.matches("Notes/foo.md")).toBe(false);
     expect(ig.matches("NotTemplates/foo.md")).toBe(false);
+  });
+
+  it("matches at any depth when pattern has no internal slash (gitignore semantics)", () => {
+    expect(ig.matches("Sub/Templates/x.md")).toBe(true);
+    expect(ig.matches("a/b/Templates/x.md")).toBe(true);
+    expect(ig.matches("a/b/Templates")).toBe(true);
+  });
+});
+
+describe("CoworkIgnore — anchored folder patterns", () => {
+  it("leading slash anchors to vault root", () => {
+    const ig = new CoworkIgnore("/Templates/");
+    expect(ig.matches("Templates/x.md")).toBe(true);
+    expect(ig.matches("Sub/Templates/x.md")).toBe(false);
+  });
+
+  it("internal slash anchors to vault root", () => {
+    const ig = new CoworkIgnore("Archive/2024/");
+    expect(ig.matches("Archive/2024/x.md")).toBe(true);
+    expect(ig.matches("Outer/Archive/2024/x.md")).toBe(false);
+  });
+
+  it("glob folder pattern works at any depth", () => {
+    const ig = new CoworkIgnore("Draft-*/");
+    expect(ig.matches("Draft-2024/x.md")).toBe(true);
+    expect(ig.matches("Sub/Draft-2024/x.md")).toBe(true);
+    expect(ig.matches("DraftX/x.md")).toBe(false);
   });
 });
 

--- a/src/services/cowork-ignore.ts
+++ b/src/services/cowork-ignore.ts
@@ -16,10 +16,7 @@ export const DEFAULT_COWORKIGNORE = [
 ].join("\n");
 
 interface Rule {
-  pattern: string;
   negated: boolean;
-  isDirPattern: boolean;
-  /** Compiled regex for non-directory patterns. */
   regex: RegExp;
 }
 
@@ -33,22 +30,22 @@ function parseRule(raw: string): Rule | null {
   const isDirPattern = pattern.endsWith("/");
   if (isDirPattern) pattern = pattern.slice(0, -1);
 
-  const regex = buildRegex(pattern);
-  return { pattern, negated, isDirPattern, regex };
+  return { negated, regex: buildRegex(pattern, isDirPattern) };
 }
 
-function buildRegex(pattern: string): RegExp {
-  // A leading "/" is stripped (anchors to root in gitignore — same as having a slash)
-  const stripped = pattern.startsWith("/") ? pattern.slice(1) : pattern;
-  const hasSlash = stripped.includes("/");
-  const regexBody = globToRegexBody(stripped);
-
-  if (hasSlash) {
-    // Anchored to root
-    return new RegExp("^" + regexBody + "$");
-  }
-  // Unanchored: match at any depth against the path
-  return new RegExp("(^|/)" + regexBody + "$");
+// Gitignore semantics:
+//   - leading "/" or any internal "/" → anchored to vault root
+//   - otherwise → unanchored, matches at any depth
+//   - trailing "/" (dir pattern) also matches everything beneath the directory
+function buildRegex(pattern: string, isDirPattern: boolean): RegExp {
+  const leadingSlash = pattern.startsWith("/");
+  const stripped = leadingSlash ? pattern.slice(1) : pattern;
+  const anchored = leadingSlash || stripped.includes("/");
+  const body = globToRegexBody(stripped);
+  const tail = isDirPattern ? "(?:/.*)?" : "";
+  return anchored
+    ? new RegExp("^" + body + tail + "$")
+    : new RegExp("(?:^|/)" + body + tail + "$");
 }
 
 function globToRegexBody(pattern: string): string {
@@ -77,13 +74,6 @@ function globToRegexBody(pattern: string): string {
   return result;
 }
 
-function testRule(rule: Rule, path: string): boolean {
-  if (rule.isDirPattern) {
-    return path === rule.pattern || path.startsWith(rule.pattern + "/");
-  }
-  return rule.regex.test(path);
-}
-
 /**
  * Parses a `.coworkignore` file and implements `UserIgnoreMatcher`.
  * Evaluation is last-match-wins, consistent with gitignore. Hard-coded
@@ -107,7 +97,7 @@ export class CoworkIgnore implements UserIgnoreMatcher {
 
     let ignored = false;
     for (const rule of this.rules) {
-      if (testRule(rule, path)) {
+      if (rule.regex.test(path)) {
         ignored = !rule.negated;
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #136 fixing two issues found in post-merge review:

### 1. Live reload was dead code
`app.vault.on("modify", …)` never fires for root-level dotfiles — Obsidian hides them from the `Vault` API. The handler in `main.ts` never executed.

**Fix:** parent-dir `fs.watch` filtered for `.coworkignore` (parent-dir watch survives atomic-save inode swaps that single-file watches miss), debounced 200ms, plus a `Gemmera: Reload .coworkignore` command for manual triggering.

### 2. Directory patterns deviated from gitignore semantics
`Templates/` was always anchored to the vault root, so `Sub/Templates/x.md` was silently *not* ignored under the default config. Per gitignore, a pattern with no internal slash is unanchored and matches at any depth.

**Fix:** unify `parseRule`/`testRule` through a single regex builder with a `(?:/.*)?` tail for dir patterns. As a side benefit:
- `/Templates/` correctly anchors to root (was previously also unanchored — bug)
- Glob dir patterns like `Draft-*/` now work
- Removes the special-case dir-matching branch

## Behavior after fix

| Pattern | `Templates/x.md` | `Sub/Templates/x.md` | `Templates` |
|---|---|---|---|
| `Templates/` | ✓ | ✓ (new) | ✓ |
| `/Templates/` | ✓ | ✗ (now correct) | ✓ |
| `Archive/2024/` | n/a | ✗ | n/a |
| `Draft-*/` | n/a | ✓ (new) | n/a |

## Tests
5 new (37 total, all green):
- unanchored dir matches at any depth
- leading-slash anchoring
- internal-slash anchoring
- glob dir patterns
- CRLF line endings

Full suite: 685/685 passing, `tsc` clean.

## Test plan

- [ ] Create `Sub/Templates/note.md` under default config → verify it is **not** queued for indexing
- [ ] Edit `.coworkignore` in an external editor → rules reload within ~200ms (check console)
- [ ] Run `Gemmera: Reload .coworkignore` from command palette → rules reload immediately
- [ ] Delete `.coworkignore` → no crash; existing rules retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)