### PR TITLE
feat(ui): tool dispatcher + NotePreviewModal for save_note create (#53)

### DIFF
--- a/src/services/tool-dispatcher.test.ts
+++ b/src/services/tool-dispatcher.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { MockVaultService } from "../contracts/mocks/mock-vault";
+import { dispatchToolCall, buildFrontmatter, type ToolDispatchDeps } from "./tool-dispatcher";
+
+function makeDeps(overrides: Partial<ToolDispatchDeps> = {}): ToolDispatchDeps {
+  const vault = new MockVaultService();
+  return {
+    vault,
+    inboxFolder: "Inbox/",
+    openNotePreview: vi.fn().mockResolvedValue(null),
+    appendSystemMessage: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("dispatchToolCall — routing", () => {
+  it("routes save_note with mode=create to save handler", async () => {
+    const confirmResult = { confirmed: true as const, title: "Dogs", folder: "Inbox/", tags: [] };
+    const deps = makeDeps({ openNotePreview: vi.fn().mockResolvedValue(confirmResult) });
+
+    const result = await dispatchToolCall(
+      { id: "1", name: "save_note", arguments: { mode: "create", title: "Dogs", body_markdown: "Dogs are great." } },
+      deps,
+    );
+
+    expect(result.kind).toBe("done");
+    expect(await deps.vault.exists("Inbox/Dogs.md")).toBe(true);
+  });
+
+  it("returns unknown_tool for save_note with mode=append (not yet handled)", async () => {
+    const deps = makeDeps();
+    const result = await dispatchToolCall(
+      { id: "2", name: "save_note", arguments: { mode: "append" } },
+      deps,
+    );
+    expect(result.kind).toBe("unknown_tool");
+  });
+
+  it("returns unknown_tool for unrecognised tool names", async () => {
+    const deps = makeDeps();
+    const result = await dispatchToolCall(
+      { id: "3", name: "hallucinated_tool", arguments: {} },
+      deps,
+    );
+    expect(result.kind).toBe("unknown_tool");
+  });
+
+  it("returns cancelled and posts system message when preview is dismissed", async () => {
+    const appendSystemMessage = vi.fn();
+    const deps = makeDeps({
+      openNotePreview: vi.fn().mockResolvedValue(null),
+      appendSystemMessage,
+    });
+
+    const result = await dispatchToolCall(
+      { id: "4", name: "save_note", arguments: { mode: "create", title: "X", body_markdown: "" } },
+      deps,
+    );
+
+    expect(result.kind).toBe("cancelled");
+    expect(appendSystemMessage).toHaveBeenCalledWith("Save cancelled.");
+  });
+});
+
+describe("dispatchToolCall — collision handling", () => {
+  it("suffixes (2) when the base path already exists", async () => {
+    const vault = new MockVaultService({ "Inbox/Dogs.md": "existing" });
+    const confirmResult = { confirmed: true as const, title: "Dogs", folder: "Inbox/", tags: [] };
+    const deps = makeDeps({ vault, openNotePreview: vi.fn().mockResolvedValue(confirmResult) });
+
+    const result = await dispatchToolCall(
+      { id: "5", name: "save_note", arguments: { mode: "create", title: "Dogs", body_markdown: "" } },
+      deps,
+    );
+
+    expect(result.kind).toBe("done");
+    expect(await vault.exists("Inbox/Dogs (2).md")).toBe(true);
+    expect(await vault.exists("Inbox/Dogs.md")).toBe(true); // original untouched
+  });
+});
+
+describe("buildFrontmatter", () => {
+  it("wraps title in double-quotes (valid YAML)", () => {
+    const fm = buildFrontmatter("Hello world", []);
+    expect(fm).toContain('title: "Hello world"');
+  });
+
+  it("escapes quotes inside title", () => {
+    const fm = buildFrontmatter('Title with "quotes"', []);
+    expect(fm).toContain('title: "Title with \\"quotes\\""');
+  });
+
+  it("omits tags line when tags array is empty", () => {
+    const fm = buildFrontmatter("My note", []);
+    expect(fm).not.toContain("tags:");
+  });
+
+  it("includes quoted tags when provided", () => {
+    const fm = buildFrontmatter("My note", ["rust", "cli"]);
+    expect(fm).toContain('tags: ["rust", "cli"]');
+  });
+});

--- a/src/services/tool-dispatcher.ts
+++ b/src/services/tool-dispatcher.ts
@@ -1,22 +1,10 @@
-import type { IndexService, LLMToolCall, VaultService } from "../contracts";
-import type { IngestWriter } from "./ingest-writer";
+import type { LLMToolCall, VaultService } from "../contracts";
 import type { NotePreviewResult } from "../ui/note-preview-modal";
-
-// ── Tool argument shapes ──────────────────────────────────────────────────────
-
-export interface SaveNoteCreateArgs {
-  mode: "create";
-  title: string;
-  body_markdown: string;
-  tags?: string[];
-}
 
 // ── Deps ──────────────────────────────────────────────────────────────────────
 
 export interface ToolDispatchDeps {
   vault: VaultService;
-  ingestWriter: IngestWriter;
-  index: IndexService;
   /** Default folder for new notes (e.g. "Inbox/"). */
   inboxFolder: string;
   /**
@@ -36,7 +24,7 @@ export interface ToolDispatchDeps {
 // ── Result ────────────────────────────────────────────────────────────────────
 
 export type ToolResult =
-  | { kind: "done"; summary: string }
+  | { kind: "done"; summary: string; citations?: string[] }
   | { kind: "cancelled"; message: string }
   | { kind: "unknown_tool" };
 
@@ -55,8 +43,8 @@ export async function dispatchToolCall(
   switch (call.name) {
     case "save_note": {
       const args = call.arguments as { mode?: string; title?: string; body_markdown?: string; tags?: string[] };
-      if (args.mode === "create" || !args.mode) {
-        return dispatchSaveNoteCreate(args as SaveNoteCreateArgs, deps);
+      if (!args.mode || args.mode === "create") {
+        return dispatchSaveNoteCreate(args, deps);
       }
       return { kind: "unknown_tool" };
     }
@@ -68,7 +56,7 @@ export async function dispatchToolCall(
 // ── save_note (create) ────────────────────────────────────────────────────────
 
 async function dispatchSaveNoteCreate(
-  args: SaveNoteCreateArgs,
+  args: { title?: string; body_markdown?: string; tags?: string[] },
   deps: ToolDispatchDeps,
 ): Promise<ToolResult> {
   const result = await deps.openNotePreview({
@@ -85,7 +73,7 @@ async function dispatchSaveNoteCreate(
 
   const folder = result.folder.endsWith("/") ? result.folder : result.folder + "/";
   const safeName = result.title.replace(/[\\/:*?"<>|]/g, "_");
-  const path = `${folder}${safeName}.md`;
+  const path = await findUniquePath(deps.vault, folder, safeName);
 
   const frontmatter = buildFrontmatter(result.title, result.tags);
   const content = `${frontmatter}\n${args.body_markdown ?? ""}`;
@@ -94,10 +82,23 @@ async function dispatchSaveNoteCreate(
   return { kind: "done", summary: `Saved **${result.title}** to ${path}` };
 }
 
-function buildFrontmatter(title: string, tags: string[]): string {
-  const lines = ["---", `title: "${title}"`];
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function findUniquePath(vault: VaultService, folder: string, name: string): Promise<string> {
+  const base = `${folder}${name}.md`;
+  if (!await vault.exists(base)) return base;
+  for (let i = 2; i <= 99; i++) {
+    const candidate = `${folder}${name} (${i}).md`;
+    if (!await vault.exists(candidate)) return candidate;
+  }
+  return `${folder}${name} (${Date.now()}).md`;
+}
+
+/** Build a YAML frontmatter block. Strings are JSON-escaped (valid YAML double-quoted scalars). */
+export function buildFrontmatter(title: string, tags: string[]): string {
+  const lines = ["---", `title: ${JSON.stringify(title)}`];
   if (tags.length > 0) {
-    lines.push(`tags: [${tags.map((t) => `"${t}"`).join(", ")}]`);
+    lines.push(`tags: [${tags.map((t) => JSON.stringify(t)).join(", ")}]`);
   }
   lines.push("---");
   return lines.join("\n");

--- a/src/services/tool-dispatcher.ts
+++ b/src/services/tool-dispatcher.ts
@@ -1,0 +1,121 @@
+import type { IndexService, LLMToolCall, VaultService } from "../contracts";
+import type { IngestWriter } from "./ingest-writer";
+import type { NotePreviewResult } from "../ui/note-preview-modal";
+
+// ── Tool argument shapes ──────────────────────────────────────────────────────
+
+export interface SaveNoteCreateArgs {
+  mode: "create";
+  title: string;
+  body_markdown: string;
+  tags?: string[];
+}
+
+// ── Deps ──────────────────────────────────────────────────────────────────────
+
+export interface ToolDispatchDeps {
+  vault: VaultService;
+  ingestWriter: IngestWriter;
+  index: IndexService;
+  /** Default folder for new notes (e.g. "Inbox/"). */
+  inboxFolder: string;
+  /**
+   * UI callback: show the note preview modal and return the user's decision.
+   * Injected from the view layer to keep this service UI-agnostic.
+   */
+  openNotePreview: (opts: {
+    title: string;
+    body: string;
+    folder: string;
+    tags: string[];
+  }) => Promise<NotePreviewResult | null>;
+  /** Append a system-level message to the chat thread. */
+  appendSystemMessage: (text: string) => void;
+}
+
+// ── Result ────────────────────────────────────────────────────────────────────
+
+export type ToolResult =
+  | { kind: "done"; summary: string }
+  | { kind: "cancelled"; message: string }
+  | { kind: "unknown_tool" };
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────
+
+/**
+ * Routes a single LLM tool call to its handler (#53).
+ *
+ * Only `save_note(mode="create")` is handled here; additional write and read
+ * tools are added in subsequent issues (#62, #65).
+ */
+export async function dispatchToolCall(
+  call: LLMToolCall,
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  switch (call.name) {
+    case "save_note": {
+      const args = call.arguments as { mode?: string; title?: string; body_markdown?: string; tags?: string[] };
+      if (args.mode === "create" || !args.mode) {
+        return dispatchSaveNoteCreate(args as SaveNoteCreateArgs, deps);
+      }
+      return { kind: "unknown_tool" };
+    }
+    default:
+      return { kind: "unknown_tool" };
+  }
+}
+
+// ── save_note (create) ────────────────────────────────────────────────────────
+
+async function dispatchSaveNoteCreate(
+  args: SaveNoteCreateArgs,
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const result = await deps.openNotePreview({
+    title: args.title ?? "New note",
+    body: args.body_markdown ?? "",
+    folder: deps.inboxFolder,
+    tags: args.tags ?? [],
+  });
+
+  if (!result) {
+    deps.appendSystemMessage("Save cancelled.");
+    return { kind: "cancelled", message: "Save cancelled." };
+  }
+
+  const folder = result.folder.endsWith("/") ? result.folder : result.folder + "/";
+  const safeName = result.title.replace(/[\\/:*?"<>|]/g, "_");
+  const path = `${folder}${safeName}.md`;
+
+  const frontmatter = buildFrontmatter(result.title, result.tags);
+  const content = `${frontmatter}\n${args.body_markdown ?? ""}`;
+
+  await deps.vault.create(path, content);
+  return { kind: "done", summary: `Saved **${result.title}** to ${path}` };
+}
+
+function buildFrontmatter(title: string, tags: string[]): string {
+  const lines = ["---", `title: "${title}"`];
+  if (tags.length > 0) {
+    lines.push(`tags: [${tags.map((t) => `"${t}"`).join(", ")}]`);
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+// ── Tool definitions (for LLMService.chat calls) ──────────────────────────────
+
+export const SAVE_NOTE_TOOL = {
+  name: "save_note",
+  description: "Save a new note to the vault. Use mode 'create' for new notes.",
+  parameters: {
+    type: "object",
+    required: ["mode", "title", "body_markdown"],
+    properties: {
+      mode: { type: "string", enum: ["create", "append"] },
+      title: { type: "string", description: "Note title (also used as filename)" },
+      body_markdown: { type: "string", description: "Note body in Markdown" },
+      tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
+    },
+  },
+} as const;

--- a/src/ui/note-preview-modal.ts
+++ b/src/ui/note-preview-modal.ts
@@ -54,29 +54,20 @@ class NotePreviewModal extends Modal {
 
     // Title
     contentEl.createEl("label", { text: "Title", cls: "gemmera-note-preview__label" });
-    const titleInput = contentEl.createEl("input", {
-      type: "text",
-      cls: "gemmera-note-preview__input",
-      value: this.opts.title,
-    } as Parameters<HTMLElement["createEl"]>[1]);
+    const titleInput = contentEl.createEl("input", { cls: "gemmera-note-preview__input" });
+    titleInput.type = "text";
     titleInput.value = this.opts.title;
 
     // Folder
     contentEl.createEl("label", { text: "Folder", cls: "gemmera-note-preview__label" });
-    const folderInput = contentEl.createEl("input", {
-      type: "text",
-      cls: "gemmera-note-preview__input",
-      value: this.opts.folder,
-    } as Parameters<HTMLElement["createEl"]>[1]);
+    const folderInput = contentEl.createEl("input", { cls: "gemmera-note-preview__input" });
+    folderInput.type = "text";
     folderInput.value = this.opts.folder;
 
     // Tags
     contentEl.createEl("label", { text: "Tags (comma-separated)", cls: "gemmera-note-preview__label" });
-    const tagsInput = contentEl.createEl("input", {
-      type: "text",
-      cls: "gemmera-note-preview__input",
-      value: this.opts.tags.join(", "),
-    } as Parameters<HTMLElement["createEl"]>[1]);
+    const tagsInput = contentEl.createEl("input", { cls: "gemmera-note-preview__input" });
+    tagsInput.type = "text";
     tagsInput.value = this.opts.tags.join(", ");
 
     // Body preview
@@ -93,20 +84,42 @@ class NotePreviewModal extends Modal {
       text: "Save",
       cls: "gemmera-note-preview__btn gemmera-note-preview__btn--primary",
     });
-    saveBtn.addEventListener("click", () => {
+
+    const doSave = (): void => {
+      const title = titleInput.value.trim();
+      if (!title) return;
       this.decide({
         confirmed: true,
-        title: titleInput.value.trim() || this.opts.title,
+        title,
         folder: folderInput.value.trim() || this.opts.folder,
         tags: tagsInput.value.split(",").map((t) => t.trim()).filter(Boolean),
       });
-    });
+    };
+
+    // Disable Save when title is empty.
+    const updateSaveEnabled = (): void => {
+      saveBtn.disabled = titleInput.value.trim().length === 0;
+    };
+    titleInput.addEventListener("input", updateSaveEnabled);
+    updateSaveEnabled();
+
+    saveBtn.addEventListener("click", doSave);
+
+    // Enter in any input field triggers Save (Obsidian convention).
+    for (const input of [titleInput, folderInput, tagsInput]) {
+      input.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") { e.preventDefault(); doSave(); }
+      });
+    }
 
     const cancelBtn = actions.createEl("button", {
       text: "Cancel",
       cls: "gemmera-note-preview__btn",
     });
     cancelBtn.addEventListener("click", () => this.decide(null));
+
+    titleInput.focus();
+    titleInput.select();
   }
 
   onClose(): void {

--- a/src/ui/note-preview-modal.ts
+++ b/src/ui/note-preview-modal.ts
@@ -1,0 +1,124 @@
+import { MarkdownRenderer, Modal, type App } from "obsidian";
+
+export interface NotePreviewOpts {
+  title: string;
+  body: string;
+  folder: string;
+  tags: string[];
+}
+
+export interface NotePreviewResult {
+  confirmed: true;
+  title: string;
+  folder: string;
+  tags: string[];
+}
+
+/**
+ * Preview gate for LLM-driven save_note(mode=create) tool calls (#53).
+ *
+ * Shows editable title, folder path, and tags, plus a rendered Markdown
+ * body preview. The modal resolves a Promise the tool dispatcher awaits.
+ * Closing via Esc or outside click resolves to null (cancelled).
+ */
+export function openNotePreview(
+  app: App,
+  opts: NotePreviewOpts,
+): Promise<NotePreviewResult | null> {
+  return new Promise((resolve) => {
+    const modal = new NotePreviewModal(app, opts, (result) => {
+      modal.close();
+      resolve(result);
+    });
+    modal.open();
+  });
+}
+
+class NotePreviewModal extends Modal {
+  private resolved = false;
+
+  constructor(
+    app: App,
+    private readonly opts: NotePreviewOpts,
+    private readonly onDone: (result: NotePreviewResult | null) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("gemmera-note-preview");
+
+    contentEl.createEl("h2", { text: "Save new note" });
+
+    // Title
+    contentEl.createEl("label", { text: "Title", cls: "gemmera-note-preview__label" });
+    const titleInput = contentEl.createEl("input", {
+      type: "text",
+      cls: "gemmera-note-preview__input",
+      value: this.opts.title,
+    } as Parameters<HTMLElement["createEl"]>[1]);
+    titleInput.value = this.opts.title;
+
+    // Folder
+    contentEl.createEl("label", { text: "Folder", cls: "gemmera-note-preview__label" });
+    const folderInput = contentEl.createEl("input", {
+      type: "text",
+      cls: "gemmera-note-preview__input",
+      value: this.opts.folder,
+    } as Parameters<HTMLElement["createEl"]>[1]);
+    folderInput.value = this.opts.folder;
+
+    // Tags
+    contentEl.createEl("label", { text: "Tags (comma-separated)", cls: "gemmera-note-preview__label" });
+    const tagsInput = contentEl.createEl("input", {
+      type: "text",
+      cls: "gemmera-note-preview__input",
+      value: this.opts.tags.join(", "),
+    } as Parameters<HTMLElement["createEl"]>[1]);
+    tagsInput.value = this.opts.tags.join(", ");
+
+    // Body preview
+    contentEl.createEl("p", { text: "Preview", cls: "gemmera-note-preview__label" });
+    const previewEl = contentEl.createEl("div", { cls: "gemmera-note-preview__body" });
+    MarkdownRenderer.render(this.app, this.opts.body, previewEl, "", this).catch(() => {
+      previewEl.textContent = this.opts.body;
+    });
+
+    // Buttons
+    const actions = contentEl.createEl("div", { cls: "gemmera-note-preview__actions" });
+
+    const saveBtn = actions.createEl("button", {
+      text: "Save",
+      cls: "gemmera-note-preview__btn gemmera-note-preview__btn--primary",
+    });
+    saveBtn.addEventListener("click", () => {
+      this.decide({
+        confirmed: true,
+        title: titleInput.value.trim() || this.opts.title,
+        folder: folderInput.value.trim() || this.opts.folder,
+        tags: tagsInput.value.split(",").map((t) => t.trim()).filter(Boolean),
+      });
+    });
+
+    const cancelBtn = actions.createEl("button", {
+      text: "Cancel",
+      cls: "gemmera-note-preview__btn",
+    });
+    cancelBtn.addEventListener("click", () => this.decide(null));
+  }
+
+  onClose(): void {
+    if (!this.resolved) {
+      this.resolved = true;
+      this.onDone(null);
+    }
+  }
+
+  private decide(result: NotePreviewResult | null): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.onDone(result);
+  }
+}

--- a/src/view.ts
+++ b/src/view.ts
@@ -11,9 +11,11 @@ import { runIngest } from "./services/ingest-orchestrator";
 import { runMixed } from "./services/mixed-orchestrator";
 import { runQuery } from "./services/query-orchestrator";
 import { createSynthesisNote } from "./services/synthesis-writer";
+import { dispatchToolCall, SAVE_NOTE_TOOL } from "./services/tool-dispatcher";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
+import { openNotePreview } from "./ui/note-preview-modal";
 import { buildMessageDecoration } from "./message-decoration";
 import { showSaveUndoNotice } from "./notices";
 import { labelForState } from "./services/turn-status";
@@ -468,12 +470,32 @@ export class GemmeraChatView extends ItemView {
       const reply = await this.services.llm.chat({
         model: this.settings.chatModel,
         messages,
+        tools: [SAVE_NOTE_TOOL],
         onToken: (token) => {
           textEl.textContent += token;
           this.scrollToBottom();
         },
       });
       this.history.push({ role: "assistant", content: reply.content });
+
+      // Dispatch structured tool calls emitted by the LLM (#53).
+      if (reply.toolCalls && reply.toolCalls.length > 0) {
+        const dispatchDeps = {
+          vault: this.services.vault,
+          ingestWriter: this.services.ingestWriter,
+          index: this.services.index,
+          inboxFolder: this.settings.inboxFolder,
+          openNotePreview: (opts: Parameters<typeof openNotePreview>[1]) =>
+            openNotePreview(this.app, opts),
+          appendSystemMessage: (msg: string) => this.appendMessage("assistant", msg),
+        };
+        for (const call of reply.toolCalls) {
+          const result = await dispatchToolCall(call, dispatchDeps);
+          if (result.kind === "done") {
+            this.appendMessage("assistant", result.summary);
+          }
+        }
+      }
 
       if (this.chatHistory) {
         const ch = this.chatHistory;

--- a/src/view.ts
+++ b/src/view.ts
@@ -11,7 +11,7 @@ import { runIngest } from "./services/ingest-orchestrator";
 import { runMixed } from "./services/mixed-orchestrator";
 import { runQuery } from "./services/query-orchestrator";
 import { createSynthesisNote } from "./services/synthesis-writer";
-import { dispatchToolCall, SAVE_NOTE_TOOL } from "./services/tool-dispatcher";
+import { dispatchToolCall, SAVE_NOTE_TOOL, type ToolDispatchDeps } from "./services/tool-dispatcher";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
@@ -480,19 +480,23 @@ export class GemmeraChatView extends ItemView {
 
       // Dispatch structured tool calls emitted by the LLM (#53).
       if (reply.toolCalls && reply.toolCalls.length > 0) {
-        const dispatchDeps = {
+        const dispatchDeps: ToolDispatchDeps = {
           vault: this.services.vault,
-          ingestWriter: this.services.ingestWriter,
-          index: this.services.index,
           inboxFolder: this.settings.inboxFolder,
-          openNotePreview: (opts: Parameters<typeof openNotePreview>[1]) =>
-            openNotePreview(this.app, opts),
-          appendSystemMessage: (msg: string) => this.appendMessage("assistant", msg),
+          openNotePreview: (opts) => openNotePreview(this.app, opts),
+          appendSystemMessage: (msg) => this.appendMessage("assistant", msg),
         };
         for (const call of reply.toolCalls) {
-          const result = await dispatchToolCall(call, dispatchDeps);
-          if (result.kind === "done") {
-            this.appendMessage("assistant", result.summary);
+          try {
+            const result = await dispatchToolCall(call, dispatchDeps);
+            if (result.kind === "done") {
+              this.appendMessage("assistant", result.summary);
+            } else if (result.kind === "unknown_tool") {
+              this.appendMessage("assistant", `Unknown tool: ${call.name}`);
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.appendMessage("assistant", `Tool call failed: ${msg}`);
           }
         }
       }

--- a/styles.css
+++ b/styles.css
@@ -230,3 +230,54 @@
   font-weight: 700;
   margin-left: 4px;
 }
+
+/* ── NotePreviewModal (#53) ──────────────────────────────────────────────── */
+
+.gemmera-note-preview__label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin: 10px 0 4px;
+}
+
+.gemmera-note-preview__input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-size: 0.9rem;
+}
+
+.gemmera-note-preview__body {
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 10px;
+  margin-top: 4px;
+  font-size: 0.85rem;
+}
+
+.gemmera-note-preview__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+  justify-content: flex-end;
+}
+
+.gemmera-note-preview__btn {
+  padding: 6px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.gemmera-note-preview__btn--primary {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border: none;
+}


### PR DESCRIPTION
## Summary
- **New** `src/services/tool-dispatcher.ts`: routes `LLMToolCall` objects to the right handler; #53 implements `save_note(mode=create)`
- **New** `src/ui/note-preview-modal.ts`: Obsidian Modal with editable title, folder path (defaults to `Inbox/`), comma-separated tags, and `MarkdownRenderer` body preview; resolves a Promise so the dispatcher can await the user's decision
- **Modified** `src/view.ts`: passes `SAVE_NOTE_TOOL` to `llm.chat()` in `runChat` and dispatches any returned `toolCalls` through `dispatchToolCall`; cancel appends a "Save cancelled." system message
- **Modified** `styles.css`: `.gemmera-note-preview__*` rules for the new modal

## Test plan
- [ ] With `llmBackend: "mock"` send a message containing "create" — mock emits `save_note` tool call → preview modal appears
- [ ] Fill in title / folder / tags and click **Save** → note written under `Inbox/`
- [ ] Click **Cancel** → no file written; chat shows "Save cancelled."
- [ ] `npm test` passes (680 tests)
- [ ] `npm run build` succeeds

Closes #53