### PR TITLE
feat(ui): tool dispatcher — all write tools (#62)

### DIFF
--- a/src/contracts/mocks/mock-vault.ts
+++ b/src/contracts/mocks/mock-vault.ts
@@ -32,6 +32,11 @@ export class MockVaultService implements VaultService {
     this.files.set(path, content);
   }
 
+  async modify(path: string, content: string): Promise<void> {
+    if (!this.files.has(path)) throw new Error(`File not found: ${path}`);
+    this.files.set(path, content);
+  }
+
   /** Test-only convenience: overwrite an existing file or create a new one. */
   setFile(path: string, content: string): void {
     this.files.set(path, content);

--- a/src/contracts/vault.ts
+++ b/src/contracts/vault.ts
@@ -19,6 +19,7 @@ export interface VaultService {
   read(path: string): Promise<string>;
   exists(path: string): Promise<boolean>;
   create(path: string, content: string): Promise<void>;
+  modify(path: string, content: string): Promise<void>;
   append(path: string, content: string): Promise<void>;
   getHeadings(path: string): Promise<HeadingRef[]>;
   /**

--- a/src/services/links-index-service.ts
+++ b/src/services/links-index-service.ts
@@ -61,6 +61,10 @@ export class LinksIndexService {
     return this.inFlight;
   }
 
+  neighborCount(path: string): number {
+    return this.index.neighborCount(path);
+  }
+
   private schedule(event: RunnerEvent): void {
     const next = this.inFlight.then(() => this.process(event));
     this.inFlight = next.catch(() => undefined);

--- a/src/services/real-vault.ts
+++ b/src/services/real-vault.ts
@@ -26,6 +26,11 @@ export class ObsidianVaultService implements VaultService {
     await this.app.vault.create(path, content);
   }
 
+  async modify(path: string, content: string): Promise<void> {
+    const file = this.requireFile(path);
+    await this.app.vault.modify(file, content);
+  }
+
   async append(path: string, content: string): Promise<void> {
     const file = this.requireFile(path);
     await this.app.vault.append(file, content);

--- a/src/services/tool-dispatcher.test.ts
+++ b/src/services/tool-dispatcher.test.ts
@@ -1,13 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import { MockVaultService } from "../contracts/mocks/mock-vault";
-import { dispatchToolCall, buildFrontmatter, type ToolDispatchDeps } from "./tool-dispatcher";
+import { dispatchToolCall, buildFrontmatter, appendUnderDatedSection, patchFrontmatter, type ToolDispatchDeps } from "./tool-dispatcher";
+import { InMemoryJobQueue } from "./in-memory-job-queue";
+import { IngestWriter } from "./ingest-writer";
 
 function makeDeps(overrides: Partial<ToolDispatchDeps> = {}): ToolDispatchDeps {
   const vault = new MockVaultService();
   return {
     vault,
+    ingestWriter: new IngestWriter(vault),
+    jobQueue: new InMemoryJobQueue(),
+    index: { search: vi.fn().mockResolvedValue([]) },
+    linksIndex: { neighborCount: vi.fn().mockReturnValue(0) },
     inboxFolder: "Inbox/",
+    chatModel: "gemma",
     openNotePreview: vi.fn().mockResolvedValue(null),
+    confirmDelete: vi.fn().mockResolvedValue("cancelled"),
+    confirmRename: vi.fn().mockResolvedValue("cancelled"),
     appendSystemMessage: vi.fn(),
     ...overrides,
   };
@@ -27,13 +36,15 @@ describe("dispatchToolCall — routing", () => {
     expect(await deps.vault.exists("Inbox/Dogs.md")).toBe(true);
   });
 
-  it("returns unknown_tool for save_note with mode=append (not yet handled)", async () => {
-    const deps = makeDeps();
+  it("appends save_note with mode=append under today's heading", async () => {
+    const vault = new MockVaultService({ "Inbox/Dogs.md": "Existing" });
+    const deps = makeDeps({ vault });
     const result = await dispatchToolCall(
-      { id: "2", name: "save_note", arguments: { mode: "append" } },
+      { id: "2", name: "save_note", arguments: { mode: "append", path: "Inbox/Dogs.md", body_markdown: "New entry" } },
       deps,
     );
-    expect(result.kind).toBe("unknown_tool");
+    expect(result.kind).toBe("done");
+    expect(await vault.read("Inbox/Dogs.md")).toContain("New entry");
   });
 
   it("returns unknown_tool for unrecognised tool names", async () => {
@@ -59,6 +70,30 @@ describe("dispatchToolCall — routing", () => {
 
     expect(result.kind).toBe("cancelled");
     expect(appendSystemMessage).toHaveBeenCalledWith("Save cancelled.");
+  });
+});
+
+describe("appendUnderDatedSection", () => {
+  it("adds today's heading when the note lacks one", () => {
+    const updated = appendUnderDatedSection("Existing", "New entry", new Date("2026-05-14T12:00:00Z"));
+    expect(updated).toBe("Existing\n\n## 2026-05-14\n\nNew entry");
+  });
+
+  it("does not duplicate today's heading", () => {
+    const updated = appendUnderDatedSection("Existing\n\n## 2026-05-14\n\nFirst", "Second", new Date("2026-05-14T12:00:00Z"));
+    expect(updated).toBe("Existing\n\n## 2026-05-14\n\nFirst\n\nSecond");
+  });
+});
+
+describe("patchFrontmatter", () => {
+  it("escapes regex metacharacters in frontmatter keys", () => {
+    const updated = patchFrontmatter("---\nfoo.bar: old\nfooXbar: keep\n---\nBody", { "foo.bar": "new" });
+    expect(updated).toContain('foo.bar: "new"');
+    expect(updated).toContain("fooXbar: keep");
+  });
+
+  it("returns null for unclosed frontmatter", () => {
+    expect(patchFrontmatter("---\ntitle: Broken\nBody", { title: "New" })).toBeNull();
   });
 });
 

--- a/src/services/tool-dispatcher.ts
+++ b/src/services/tool-dispatcher.ts
@@ -1,61 +1,89 @@
-import type { LLMToolCall, VaultService } from "../contracts";
+import type {
+  IndexService,
+  JobQueue,
+  LLMToolCall,
+  LinksIndex,
+  VaultService,
+} from "../contracts";
+import type { IngestWriter } from "./ingest-writer";
+import { runDestructiveOp } from "./destructive-op-machine";
+import { createSynthesisNote } from "./synthesis-writer";
 import type { NotePreviewResult } from "../ui/note-preview-modal";
-
-// ── Deps ──────────────────────────────────────────────────────────────────────
 
 export interface ToolDispatchDeps {
   vault: VaultService;
+  ingestWriter: IngestWriter;
+  jobQueue: JobQueue;
+  index: IndexService;
+  linksIndex: Pick<LinksIndex, "neighborCount">;
   /** Default folder for new notes (e.g. "Inbox/"). */
   inboxFolder: string;
-  /**
-   * UI callback: show the note preview modal and return the user's decision.
-   * Injected from the view layer to keep this service UI-agnostic.
-   */
+  /** Model tag, used when creating synthesis notes. */
+  chatModel: string;
+  /** UI callback: note preview modal for create. Returns null on cancel. */
   openNotePreview: (opts: {
     title: string;
     body: string;
     folder: string;
     tags: string[];
   }) => Promise<NotePreviewResult | null>;
+  /**
+   * UI callback: mandatory delete confirmation (non-overridable).
+   * Resolves "confirmed" or "cancelled".
+   */
+  confirmDelete: (path: string, preview: string) => Promise<"confirmed" | "cancelled">;
+  /**
+   * UI callback: rename/move preview. May be auto-confirmed by the caller
+   * when the user has disabled "Always preview" (rename is safe + reversible).
+   */
+  confirmRename: (from: string, to: string, linkCount: number) => Promise<"confirmed" | "cancelled">;
   /** Append a system-level message to the chat thread. */
   appendSystemMessage: (text: string) => void;
 }
-
-// ── Result ────────────────────────────────────────────────────────────────────
 
 export type ToolResult =
   | { kind: "done"; summary: string; citations?: string[] }
   | { kind: "cancelled"; message: string }
   | { kind: "unknown_tool" };
 
-// ── Dispatcher ────────────────────────────────────────────────────────────────
-
-/**
- * Routes a single LLM tool call to its handler (#53).
- *
- * Only `save_note(mode="create")` is handled here; additional write and read
- * tools are added in subsequent issues (#62, #65).
- */
 export async function dispatchToolCall(
   call: LLMToolCall,
   deps: ToolDispatchDeps,
 ): Promise<ToolResult> {
   switch (call.name) {
     case "save_note": {
-      const args = call.arguments as { mode?: string; title?: string; body_markdown?: string; tags?: string[] };
+      const args = call.arguments as { mode?: string; title?: string; path?: string; body_markdown?: string; tags?: string[] };
       if (!args.mode || args.mode === "create") {
-        return dispatchSaveNoteCreate(args, deps);
+        return dispatchSaveCreate(args, deps);
+      }
+      if (args.mode === "append") {
+        return dispatchSaveAppend(args, deps);
       }
       return { kind: "unknown_tool" };
     }
+    case "update_frontmatter":
+      return dispatchUpdateFrontmatter(
+        call.arguments as { path: string; updates: Record<string, unknown> },
+        deps,
+      );
+    case "rename_or_move_note":
+      return dispatchRename(
+        call.arguments as { from: string; to: string },
+        deps,
+      );
+    case "delete_note":
+      return dispatchDelete(call.arguments as { path: string }, deps);
+    case "create_synthesis_note":
+      return dispatchSynthesis(
+        call.arguments as { question: string; answer: string; citations?: string[] },
+        deps,
+      );
     default:
       return { kind: "unknown_tool" };
   }
 }
 
-// ── save_note (create) ────────────────────────────────────────────────────────
-
-async function dispatchSaveNoteCreate(
+async function dispatchSaveCreate(
   args: { title?: string; body_markdown?: string; tags?: string[] },
   deps: ToolDispatchDeps,
 ): Promise<ToolResult> {
@@ -82,7 +110,105 @@ async function dispatchSaveNoteCreate(
   return { kind: "done", summary: `Saved **${result.title}** to ${path}` };
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+async function dispatchSaveAppend(
+  args: { path?: string; body_markdown?: string },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const path = args.path;
+  if (!path) return { kind: "unknown_tool" };
+
+  const exists = await deps.vault.exists(path);
+  if (!exists) {
+    deps.appendSystemMessage(`Note not found: ${path}`);
+    return { kind: "cancelled", message: `Note not found: ${path}` };
+  }
+
+  const raw = await deps.vault.read(path);
+  const updated = appendUnderDatedSection(raw, args.body_markdown ?? "");
+  await deps.vault.modify(path, updated);
+  return { kind: "done", summary: `Appended to **${path}**` };
+}
+
+async function dispatchUpdateFrontmatter(
+  args: { path: string; updates: Record<string, unknown> },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const exists = await deps.vault.exists(args.path);
+  if (!exists) {
+    deps.appendSystemMessage(`Note not found: ${args.path}`);
+    return { kind: "cancelled", message: `Note not found: ${args.path}` };
+  }
+
+  const raw = await deps.vault.read(args.path);
+  const updated = patchFrontmatter(raw, args.updates);
+  if (updated === null) {
+    const message = `Could not update frontmatter in ${args.path}: unclosed frontmatter block.`;
+    deps.appendSystemMessage(message);
+    return { kind: "cancelled", message };
+  }
+  await deps.vault.modify(args.path, updated);
+  return { kind: "done", summary: `Updated frontmatter in **${args.path}**` };
+}
+
+async function dispatchRename(
+  args: { from: string; to: string },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const outcome = await runDestructiveOp(
+    { kind: "rename", from: args.from, to: args.to, affectedLinkCount: deps.linksIndex.neighborCount(args.from) },
+    {
+      vault: deps.vault,
+      jobQueue: deps.jobQueue,
+      confirmDelete: deps.confirmDelete,
+      confirmRename: deps.confirmRename,
+    },
+  );
+
+  if (outcome.kind === "cancelled") {
+    deps.appendSystemMessage("Rename cancelled.");
+    return { kind: "cancelled", message: "Rename cancelled." };
+  }
+  return { kind: "done", summary: `Renamed **${args.from}** -> **${args.to}**` };
+}
+
+async function dispatchDelete(
+  args: { path: string },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const outcome = await runDestructiveOp(
+    { kind: "delete", path: args.path },
+    {
+      vault: deps.vault,
+      jobQueue: deps.jobQueue,
+      confirmDelete: deps.confirmDelete,
+      confirmRename: deps.confirmRename,
+    },
+  );
+
+  if (outcome.kind === "cancelled") {
+    deps.appendSystemMessage("Delete cancelled.");
+    return { kind: "cancelled", message: "Delete cancelled." };
+  }
+  return { kind: "done", summary: `Deleted **${args.path}** (moved to trash)` };
+}
+
+async function dispatchSynthesis(
+  args: { question: string; answer: string; citations?: string[] },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const { path } = await createSynthesisNote(
+    {
+      question: args.question,
+      answer: args.answer,
+      citations: args.citations ?? [],
+      model: deps.chatModel,
+      runId: `tool-call-${Date.now()}`,
+    },
+    deps.ingestWriter,
+    { folder: deps.inboxFolder },
+  );
+  return { kind: "done", summary: `Synthesis note saved to **${path}**` };
+}
 
 async function findUniquePath(vault: VaultService, folder: string, name: string): Promise<string> {
   const base = `${folder}${name}.md`;
@@ -94,29 +220,136 @@ async function findUniquePath(vault: VaultService, folder: string, name: string)
   return `${folder}${name} (${Date.now()}).md`;
 }
 
-/** Build a YAML frontmatter block. Strings are JSON-escaped (valid YAML double-quoted scalars). */
+/** Build a YAML frontmatter block. Values use JSON-compatible YAML flow scalars. */
 export function buildFrontmatter(title: string, tags: string[]): string {
-  const lines = ["---", `title: ${JSON.stringify(title)}`];
+  const lines = ["---", `title: ${yamlValue(title)}`];
   if (tags.length > 0) {
-    lines.push(`tags: [${tags.map((t) => JSON.stringify(t)).join(", ")}]`);
+    lines.push(`tags: [${tags.map((t) => yamlValue(t)).join(", ")}]`);
   }
   lines.push("---");
   return lines.join("\n");
 }
 
-// ── Tool definitions (for LLMService.chat calls) ──────────────────────────────
+export function appendUnderDatedSection(raw: string, body: string, now = new Date()): string {
+  const today = now.toISOString().slice(0, 10);
+  const text = body.trim();
+  if (!text) return raw;
+  const headingRe = new RegExp(`(^|\\n)## ${escapeRegExp(today)}(?:\\n|$)`);
+  const separator = raw.endsWith("\n") ? "\n" : "\n\n";
+  if (headingRe.test(raw)) {
+    return `${raw}${separator}${text}`;
+  }
+  return `${raw}${separator}## ${today}\n\n${text}`;
+}
+
+export function patchFrontmatter(raw: string, updates: Record<string, unknown>): string | null {
+  if (!raw.startsWith("---")) {
+    const fm = Object.entries(updates)
+      .map(([k, v]) => `${k}: ${yamlValue(v)}`)
+      .join("\n");
+    return `---\n${fm}\n---\n${raw}`;
+  }
+
+  const end = raw.indexOf("---", 3);
+  if (end === -1) return null;
+
+  const before = raw.slice(3, end);
+  const after = raw.slice(end + 3);
+
+  let fm = before;
+  for (const [key, value] of Object.entries(updates)) {
+    const re = new RegExp(`^${escapeRegExp(key)}:.*$`, "m");
+    const line = `${key}: ${yamlValue(value)}`;
+    if (re.test(fm)) {
+      fm = fm.replace(re, line);
+    } else {
+      fm += fm.endsWith("\n") ? line + "\n" : "\n" + line + "\n";
+    }
+  }
+
+  return `---${fm}---${after}`;
+}
+
+function yamlValue(value: unknown): string {
+  if (value === undefined || value === null) return "null";
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  return JSON.stringify(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 export const SAVE_NOTE_TOOL = {
   name: "save_note",
-  description: "Save a new note to the vault. Use mode 'create' for new notes.",
+  description: "Create or append to a note in the vault.",
   parameters: {
     type: "object",
-    required: ["mode", "title", "body_markdown"],
+    required: ["mode"],
     properties: {
       mode: { type: "string", enum: ["create", "append"] },
-      title: { type: "string", description: "Note title (also used as filename)" },
+      title: { type: "string", description: "Title for new note (mode=create)" },
+      path: { type: "string", description: "Existing note path (mode=append)" },
       body_markdown: { type: "string", description: "Note body in Markdown" },
-      tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
+      tags: { type: "array", items: { type: "string" } },
     },
   },
 } as const;
+
+export const UPDATE_FRONTMATTER_TOOL = {
+  name: "update_frontmatter",
+  description: "Update YAML frontmatter fields in an existing note.",
+  parameters: {
+    type: "object",
+    required: ["path", "updates"],
+    properties: {
+      path: { type: "string" },
+      updates: { type: "object" },
+    },
+  },
+} as const;
+
+export const RENAME_TOOL = {
+  name: "rename_or_move_note",
+  description: "Rename or move a note; all incoming links update automatically.",
+  parameters: {
+    type: "object",
+    required: ["from", "to"],
+    properties: {
+      from: { type: "string" },
+      to: { type: "string" },
+    },
+  },
+} as const;
+
+export const DELETE_TOOL = {
+  name: "delete_note",
+  description: "Move a note to the system trash. Requires explicit confirmation.",
+  parameters: {
+    type: "object",
+    required: ["path"],
+    properties: { path: { type: "string" } },
+  },
+} as const;
+
+export const SYNTHESIS_TOOL = {
+  name: "create_synthesis_note",
+  description: "Save a Q&A answer as a permanent synthesis note with citations.",
+  parameters: {
+    type: "object",
+    required: ["question", "answer"],
+    properties: {
+      question: { type: "string" },
+      answer: { type: "string" },
+      citations: { type: "array", items: { type: "string" } },
+    },
+  },
+} as const;
+
+export const WRITE_TOOLS = [
+  SAVE_NOTE_TOOL,
+  UPDATE_FRONTMATTER_TOOL,
+  RENAME_TOOL,
+  DELETE_TOOL,
+  SYNTHESIS_TOOL,
+] as const;

--- a/src/view.ts
+++ b/src/view.ts
@@ -11,11 +11,13 @@ import { runIngest } from "./services/ingest-orchestrator";
 import { runMixed } from "./services/mixed-orchestrator";
 import { runQuery } from "./services/query-orchestrator";
 import { createSynthesisNote } from "./services/synthesis-writer";
-import { dispatchToolCall, SAVE_NOTE_TOOL, type ToolDispatchDeps } from "./services/tool-dispatcher";
+import { dispatchToolCall, WRITE_TOOLS, type ToolDispatchDeps } from "./services/tool-dispatcher";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
 import { openNotePreview } from "./ui/note-preview-modal";
+import { openDeleteConfirm } from "./ui/delete-confirm-modal";
+import { openRenamePreview } from "./ui/rename-preview-modal";
 import { buildMessageDecoration } from "./message-decoration";
 import { showSaveUndoNotice } from "./notices";
 import { labelForState } from "./services/turn-status";
@@ -473,7 +475,7 @@ export class GemmeraChatView extends ItemView {
       const reply = await this.services.llm.chat({
         model: this.settings.chatModel,
         messages,
-        tools: [SAVE_NOTE_TOOL],
+        tools: [...WRITE_TOOLS],
         onToken: (token) => {
           textEl.textContent += token;
           this.scrollToBottom();
@@ -481,13 +483,23 @@ export class GemmeraChatView extends ItemView {
       });
       this.history.push({ role: "assistant", content: reply.content });
 
-      // Dispatch structured tool calls emitted by the LLM (#53).
+      // Dispatch structured tool calls emitted by the LLM (#53, #62).
       if (reply.toolCalls && reply.toolCalls.length > 0) {
         const dispatchDeps: ToolDispatchDeps = {
           vault: this.services.vault,
+          ingestWriter: this.services.ingestWriter,
+          jobQueue: this.services.jobQueue,
+          index: this.services.index,
+          linksIndex: this.services.linksIndexService,
           inboxFolder: this.settings.inboxFolder,
-          openNotePreview: (opts) => openNotePreview(this.app, opts),
-          appendSystemMessage: (msg) => this.appendMessage("assistant", msg),
+          chatModel: this.settings.chatModel,
+          openNotePreview: (opts: Parameters<typeof openNotePreview>[1]) =>
+            openNotePreview(this.app, opts),
+          confirmDelete: (path: string, preview: string) =>
+            openDeleteConfirm(this.app, path, preview),
+          confirmRename: (from: string, to: string, linkCount: number) =>
+            openRenamePreview(this.app, from, to, linkCount),
+          appendSystemMessage: (msg: string) => this.appendMessage("assistant", msg),
         };
         for (const call of reply.toolCalls) {
           try {


### PR DESCRIPTION
## Summary
Extends `tool-dispatcher.ts` from #53 to handle all six write tool calls that the LLM can emit:

| Tool | Handler | Modal |
|---|---|---|
| `save_note(mode=create)` | `dispatchSaveCreate` | `NotePreviewModal` (editable) |
| `save_note(mode=append)` | `dispatchSaveAppend` | none (direct write under dated heading) |
| `update_frontmatter` | `dispatchUpdateFrontmatter` | none (read-patch-write) |
| `rename_or_move_note` | `dispatchRename` → `runDestructiveOp` | `RenamePreviewModal` |
| `delete_note` | `dispatchDelete` → `runDestructiveOp` | `DeleteConfirmModal` (non-overridable) |
| `create_synthesis_note` | `dispatchSynthesis` → `createSynthesisNote` | none |

- Cancel on any write tool posts "X cancelled." as a system message
- `view.ts` wires `openDeleteConfirm` and `openRenamePreview` as UI callbacks in `dispatchDeps`
- All write tools exposed as `WRITE_TOOLS` array (replaces single `SAVE_NOTE_TOOL`)

## Test plan
- [ ] Mock LLM: send "rename notes/a.md to notes/b.md" → rename modal appears, link count shown, confirm renames file
- [ ] Mock LLM: send "delete notes/x.md" → delete modal appears regardless of Always-preview setting
- [ ] Cancel on delete → no file removed; chat shows "Delete cancelled."
- [ ] `npm test` passes (680 tests)
- [ ] `npm run build` succeeds

> **Note:** This branch is based on `feature/tool-dispatcher-53` (#139). Merge #139 first.

Closes #62