### PR TITLE
feat(ui): read tools via IndexService + citation chips (#65)

### DIFF
--- a/src/services/tool-dispatcher.test.ts
+++ b/src/services/tool-dispatcher.test.ts
@@ -114,6 +114,37 @@ describe("dispatchToolCall — collision handling", () => {
   });
 });
 
+describe("dispatchToolCall — read tools", () => {
+  it("marks get_note summaries when content is truncated", async () => {
+    const vault = new MockVaultService({ "Long.md": "x".repeat(2001) });
+    const result = await dispatchToolCall(
+      { id: "6", name: "get_note", arguments: { path: "Long.md" } },
+      makeDeps({ vault }),
+    );
+
+    expect(result.kind).toBe("done");
+    if (result.kind !== "done") return;
+    expect(result.summary).toContain("Read **Long.md**");
+    expect(result.summary).toContain("[...truncated at 2000 chars; full note is 2001 chars]");
+    expect(result.citations).toEqual(["Long.md"]);
+  });
+
+  it("uses tokenized basename and note content for find_related_notes", async () => {
+    const vault = new MockVaultService({ "notes/vandringsnoter_sundsvall_harnosand.md": "Bridge route and ferry notes" });
+    const search = vi.fn().mockResolvedValue([
+      { path: "notes/related.md", basename: "related", snippet: "route", score: 1 },
+    ]);
+    const result = await dispatchToolCall(
+      { id: "7", name: "find_related_notes", arguments: { path: "notes/vandringsnoter_sundsvall_harnosand.md" } },
+      makeDeps({ vault, index: { search } }),
+    );
+
+    expect(result.kind).toBe("done");
+    expect(search).toHaveBeenCalledWith(expect.stringContaining("vandringsnoter sundsvall harnosand"), { topK: 5 });
+    expect(search).toHaveBeenCalledWith(expect.stringContaining("Bridge route"), { topK: 5 });
+  });
+});
+
 describe("buildFrontmatter", () => {
   it("wraps title in double-quotes (valid YAML)", () => {
     const fm = buildFrontmatter("Hello world", []);

--- a/src/services/tool-dispatcher.ts
+++ b/src/services/tool-dispatcher.ts
@@ -78,6 +78,18 @@ export async function dispatchToolCall(
         call.arguments as { question: string; answer: string; citations?: string[] },
         deps,
       );
+    // ── Read tools (#65) ──
+    case "search_notes":
+      return dispatchSearchNotes(
+        call.arguments as { query: string; top_k?: number },
+        deps,
+      );
+    case "get_note":
+      return dispatchGetNote(call.arguments as { path: string }, deps);
+    case "find_related_notes":
+      return dispatchFindRelated(call.arguments as { path: string }, deps);
+    case "list_folder":
+      return dispatchListFolder(call.arguments as { folder?: string }, deps);
     default:
       return { kind: "unknown_tool" };
   }
@@ -280,6 +292,94 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// ── Read tool handlers (#65) ──────────────────────────────────────────────────
+
+async function dispatchSearchNotes(
+  args: { query: string; top_k?: number },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const results = await deps.index.search(args.query, { topK: args.top_k ?? 5 });
+  if (results.length === 0) {
+    return { kind: "done", summary: `No notes found for "${args.query}".` };
+  }
+  const citations = results.map((r) => r.path);
+  const lines = results.map((r) => `- **${r.basename}**: ${r.snippet.slice(0, 80)}…`);
+  return {
+    kind: "done",
+    summary: `Found ${results.length} note(s) for "${args.query}":\n${lines.join("\n")}`,
+    citations,
+  };
+}
+
+async function dispatchGetNote(
+  args: { path: string },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const exists = await deps.vault.exists(args.path);
+  if (!exists) {
+    return { kind: "cancelled", message: `Note not found: ${args.path}` };
+  }
+  const content = await deps.vault.read(args.path);
+  const max = 2000;
+  const truncated = content.length > max;
+  const visible = truncated
+    ? `${content.slice(0, max)}\n\n[...truncated at ${max} chars; full note is ${content.length} chars]`
+    : content;
+  return {
+    kind: "done",
+    summary: `Read **${args.path}**:\n\n${visible}`,
+    citations: [args.path],
+  };
+}
+
+async function dispatchFindRelated(
+  args: { path: string },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const basename = args.path.split("/").pop()?.replace(/\.md$/, "") ?? args.path;
+  const lexicalName = basename.replace(/[_-]+/g, " ");
+  const exists = await deps.vault.exists(args.path);
+  const content = exists ? await deps.vault.read(args.path) : "";
+  const query = [lexicalName, content.slice(0, 500)].filter(Boolean).join("\n\n");
+  const results = await deps.index.search(query, { topK: 5 });
+  const related = results.filter((r) => r.path !== args.path);
+  if (related.length === 0) {
+    return { kind: "done", summary: `No related notes found for ${args.path}.` };
+  }
+  const citations = related.map((r) => r.path);
+  const lines = related.map((r) => `- **${r.basename}**`);
+  return {
+    kind: "done",
+    summary: `Notes related to **${basename}**:\n${lines.join("\n")}`,
+    citations,
+  };
+}
+
+async function dispatchListFolder(
+  args: { folder?: string },
+  deps: ToolDispatchDeps,
+): Promise<ToolResult> {
+  const files = await deps.vault.listMarkdownFiles();
+  const folder = args.folder ? (args.folder.endsWith("/") ? args.folder : args.folder + "/") : "";
+  const filtered = folder
+    ? files.filter((f) => f.path.startsWith(folder))
+    : files;
+
+  if (filtered.length === 0) {
+    return { kind: "done", summary: folder ? `No notes in ${folder}.` : "Vault is empty." };
+  }
+  const citations = filtered.map((f) => f.path);
+  const lines = filtered.slice(0, 20).map((f) => `- ${f.basename}`);
+  const suffix = filtered.length > 20 ? `\n…and ${filtered.length - 20} more` : "";
+  return {
+    kind: "done",
+    summary: `${filtered.length} note(s) in ${folder || "vault"}:\n${lines.join("\n")}${suffix}`,
+    citations,
+  };
+}
+
+// ── Tool definitions (for LLMService.chat) ────────────────────────────────────
+
 export const SAVE_NOTE_TOOL = {
   name: "save_note",
   description: "Create or append to a note in the vault.",
@@ -353,3 +453,54 @@ export const WRITE_TOOLS = [
   DELETE_TOOL,
   SYNTHESIS_TOOL,
 ] as const;
+
+export const SEARCH_NOTES_TOOL = {
+  name: "search_notes",
+  description: "Full-text search across the vault. Returns scored results with snippets.",
+  parameters: {
+    type: "object",
+    required: ["query"],
+    properties: {
+      query: { type: "string" },
+      top_k: { type: "number", description: "Max results to return (default 5)" },
+    },
+  },
+} as const;
+
+export const GET_NOTE_TOOL = {
+  name: "get_note",
+  description: "Read the full content of a note by path.",
+  parameters: {
+    type: "object",
+    required: ["path"],
+    properties: { path: { type: "string" } },
+  },
+} as const;
+
+export const FIND_RELATED_TOOL = {
+  name: "find_related_notes",
+  description: "Find notes semantically related to the given note path.",
+  parameters: {
+    type: "object",
+    required: ["path"],
+    properties: { path: { type: "string" } },
+  },
+} as const;
+
+export const LIST_FOLDER_TOOL = {
+  name: "list_folder",
+  description: "List all Markdown notes in a vault folder (or the whole vault).",
+  parameters: {
+    type: "object",
+    properties: { folder: { type: "string", description: "Folder path, e.g. 'Inbox/'" } },
+  },
+} as const;
+
+export const READ_TOOLS = [
+  SEARCH_NOTES_TOOL,
+  GET_NOTE_TOOL,
+  FIND_RELATED_TOOL,
+  LIST_FOLDER_TOOL,
+] as const;
+
+export const ALL_TOOLS = [...WRITE_TOOLS, ...READ_TOOLS] as const;

--- a/src/view.ts
+++ b/src/view.ts
@@ -11,7 +11,7 @@ import { runIngest } from "./services/ingest-orchestrator";
 import { runMixed } from "./services/mixed-orchestrator";
 import { runQuery } from "./services/query-orchestrator";
 import { createSynthesisNote } from "./services/synthesis-writer";
-import { dispatchToolCall, WRITE_TOOLS, type ToolDispatchDeps } from "./services/tool-dispatcher";
+import { dispatchToolCall, ALL_TOOLS, type ToolDispatchDeps } from "./services/tool-dispatcher";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
@@ -475,7 +475,7 @@ export class GemmeraChatView extends ItemView {
       const reply = await this.services.llm.chat({
         model: this.settings.chatModel,
         messages,
-        tools: [...WRITE_TOOLS],
+        tools: [...ALL_TOOLS],
         onToken: (token) => {
           textEl.textContent += token;
           this.scrollToBottom();
@@ -505,7 +505,10 @@ export class GemmeraChatView extends ItemView {
           try {
             const result = await dispatchToolCall(call, dispatchDeps);
             if (result.kind === "done") {
-              this.appendMessage("assistant", result.summary);
+              const msgEl = this.appendMessage("assistant", result.summary);
+              if (result.citations && result.citations.length > 0) {
+                this.renderCitationChips(msgEl, result.citations);
+              }
             } else if (result.kind === "unknown_tool") {
               this.appendMessage("assistant", `Unknown tool: ${call.name}`);
             }
@@ -733,7 +736,7 @@ export class GemmeraChatView extends ItemView {
     role: "user" | "assistant",
     text: string,
     decoration?: { badge: string | null; tooltip: string | null } | null,
-  ): void {
+  ): HTMLElement {
     const msg = this.messagesEl.createEl("div", { cls: `gemmera-message gemmera-message--${role}` });
     msg.createEl("span", { cls: "gemmera-message__role", text: role === "user" ? "Du" : "Gemma" });
     msg.createEl("p", { cls: "gemmera-message__text", text });
@@ -742,6 +745,7 @@ export class GemmeraChatView extends ItemView {
       if (decoration.tooltip) badge.setAttribute("title", decoration.tooltip);
     }
     this.scrollToBottom();
+    return msg;
   }
 
   private appendErrorMessage(err: unknown, onRetry: () => void): void {


### PR DESCRIPTION
## Summary
- **New** `src/services/stub-index-service.ts`: fixture-backed `IndexService` with 8 demo-vault entries; match scoring uses term overlap on basename + snippet. Swapping in the real BM25/embedding index requires no UI changes.
- **Extended** `tool-dispatcher.ts` with four read tools:

  | Tool | Handler | Returns |
  |---|---|---|
  | `search_notes` | `IndexService.search` | Summary + citation chips |
  | `get_note` | `VaultService.read` | Note content + citation chip |
  | `find_related_notes` | `IndexService.search(basename)` | Related paths + chips |
  | `list_folder` | `VaultService.listMarkdownFiles` filtered | File list + chips |

- **Modified** `view.ts`: read tool results render their `citations[]` as `CitationChipRow` — hover shows Obsidian's native page preview; click opens the note; Tab/Enter navigate chips
- Tools passed to `llm.chat()` updated from `WRITE_TOOLS` to `ALL_TOOLS`

## Test plan
- [ ] With `llmBackend: "mock"`, send "sök efter projekt" — mock returns `search_notes` call → results shown with citation chips
- [ ] Hover a citation chip → Obsidian native page preview appears
- [ ] Click a chip → note opens in editor
- [ ] Tab through chips, Enter to open
- [ ] `npm test` passes (680 tests)
- [ ] `npm run build` succeeds

> **Note:** This branch stacks on `feature/tool-dispatcher-write-62` (#141). Merge in order: #139 → #141 → this PR.

Closes #65