### PR TITLE
feat(ui): chat history drawer — session list, auto-title, retention (#70)

### DIFF
--- a/src/services/chat-history.ts
+++ b/src/services/chat-history.ts
@@ -67,6 +67,7 @@ export class ChatHistoryStore {
   }
 
   async pruneIfNeeded(): Promise<void> {
+    if (this.retention.maxDays === undefined && this.retention.maxSessions === undefined) return;
     const data = await this.load();
     let sessions = [...data.sessions];
     if (this.retention.maxDays !== undefined) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -45,6 +45,7 @@ export class GemmeraChatView extends ItemView {
   private escCleared = false;
   private prefersReducedMotion = false;
   private lastTurnId: string | undefined;
+  private historyDrawerEl: HTMLElement | null = null;
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -139,12 +140,18 @@ export class GemmeraChatView extends ItemView {
     });
 
     this.contextPanelEl = bodyEl.createEl("div", { cls: "gemmera-context-panel" });
+    this.historyDrawerEl = this.contextPanelEl;
 
     const adapter = this.app.vault.adapter as FileSystemAdapter;
     const historyPath = adapter.getFullPath(".coworkmd/chats.json");
-    this.chatHistory = new ChatHistoryStore(historyPath);
+    this.chatHistory = new ChatHistoryStore(historyPath, this.retentionPolicy());
     // Sessions are created lazily on the first persisted turn so opening the
     // panel without sending anything doesn't accumulate empty rows in chats.json.
+
+    // Prune stale sessions on open, then render the drawer.
+    this.chatHistory.pruneIfNeeded().catch(() => {}).finally(() => {
+      this.renderHistoryDrawer().catch(() => {});
+    });
   }
 
   async onClose(): Promise<void> {
@@ -529,6 +536,7 @@ export class GemmeraChatView extends ItemView {
           const sid = this.currentSessionId;
           await ch.appendTurn(sid, { role: "user", content: text, timestamp: userTs });
           await ch.appendTurn(sid, { role: "assistant", content: reply.content, timestamp: Date.now() });
+          await this.renderHistoryDrawer();
         })().catch(() => {});
       }
 
@@ -552,6 +560,75 @@ export class GemmeraChatView extends ItemView {
       this.setInputDisabled(false);
       this.inputEl.focus();
     }
+  }
+
+  // ── Chat history drawer (#70) ─────────────────────────────────────────
+
+  private retentionPolicy(): { maxDays?: number; maxSessions?: number } {
+    return {};
+  }
+
+  private async renderHistoryDrawer(): Promise<void> {
+    const el = this.historyDrawerEl;
+    if (!el || !this.chatHistory) return;
+
+    el.empty();
+
+    const headEl = el.createEl("div", { cls: "gemmera-history__head" });
+    headEl.createEl("span", { cls: "gemmera-history__title", text: "Chats" });
+
+    const newBtn = headEl.createEl("button", {
+      cls: "gemmera-history__new-btn",
+      text: "+ Ny chatt",
+      attr: { "aria-label": "Start a new chat" },
+    });
+    newBtn.addEventListener("click", () => this.startNewSession());
+
+    const sessions = await this.chatHistory.listSessions();
+    if (sessions.length === 0) {
+      el.createEl("p", { cls: "gemmera-history__empty", text: "Inga sparade chattar." });
+      return;
+    }
+
+    const listEl = el.createEl("ul", { cls: "gemmera-history__list" });
+    for (const session of sessions) {
+      const isActive = session.id === this.currentSessionId;
+      const item = listEl.createEl("li", {
+        cls: `gemmera-history__item${isActive ? " gemmera-history__item--active" : ""}`,
+        attr: { tabindex: "0", role: "button", "aria-pressed": String(isActive) },
+      });
+      item.createEl("span", { cls: "gemmera-history__item-title", text: session.title });
+      const meta = formatSessionMeta(session.updatedAt, session.turns.length);
+      item.createEl("span", { cls: "gemmera-history__item-meta", text: meta });
+
+      item.addEventListener("click", () => this.switchToSession(session).catch(() => {}));
+      item.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          this.switchToSession(session).catch(() => {});
+        }
+      });
+    }
+  }
+
+  private startNewSession(): void {
+    this.history = [];
+    this.currentSessionId = null;
+    this.messagesEl.empty();
+    this.renderHistoryDrawer().catch(() => {});
+  }
+
+  private async switchToSession(
+    session: import("./services/chat-history").ChatSession,
+  ): Promise<void> {
+    this.currentSessionId = session.id;
+    this.history = session.turns.map((t) => ({ role: t.role, content: t.content }));
+    this.messagesEl.empty();
+    for (const turn of session.turns) {
+      this.appendMessage(turn.role, turn.content);
+    }
+    await this.renderHistoryDrawer();
+    this.inputEl.focus();
   }
 
   // ── Disambiguation chip DOM ──────────────────────────────────────────
@@ -824,6 +901,15 @@ export function withContext(
     { role: "assistant", content: "Förstått, jag har läst anteckningarna." },
     ...history,
   ];
+}
+
+function formatSessionMeta(updatedAt: number, turnCount: number): string {
+  const turns = Math.floor(turnCount / 2);
+  const date = new Date(updatedAt).toLocaleDateString("sv-SE", {
+    month: "short",
+    day: "numeric",
+  });
+  return `${date} · ${turns} meddelande${turns === 1 ? "" : "n"}`;
 }
 
 /** Extract unique [[wikilink]] paths from markdown text. */

--- a/src/view.ts
+++ b/src/view.ts
@@ -140,7 +140,7 @@ export class GemmeraChatView extends ItemView {
     });
 
     this.contextPanelEl = bodyEl.createEl("div", { cls: "gemmera-context-panel" });
-    this.historyDrawerEl = this.contextPanelEl;
+    this.historyDrawerEl = this.contextPanelEl.createEl("div", { cls: "gemmera-history" });
 
     const adapter = this.app.vault.adapter as FileSystemAdapter;
     const historyPath = adapter.getFullPath(".coworkmd/chats.json");
@@ -149,8 +149,8 @@ export class GemmeraChatView extends ItemView {
     // panel without sending anything doesn't accumulate empty rows in chats.json.
 
     // Prune stale sessions on open, then render the drawer.
-    this.chatHistory.pruneIfNeeded().catch(() => {}).finally(() => {
-      this.renderHistoryDrawer().catch(() => {});
+    this.chatHistory.pruneIfNeeded().catch((err) => console.error("[gemmera] pruneIfNeeded:", err)).finally(() => {
+      this.renderHistoryDrawer().catch((err) => console.error("[gemmera] renderHistoryDrawer:", err));
     });
   }
 
@@ -598,14 +598,14 @@ export class GemmeraChatView extends ItemView {
         attr: { tabindex: "0", role: "button", "aria-pressed": String(isActive) },
       });
       item.createEl("span", { cls: "gemmera-history__item-title", text: session.title });
-      const meta = formatSessionMeta(session.updatedAt, session.turns.length);
+      const meta = formatSessionMeta(session.updatedAt, session.turns.filter((t) => t.role === "user").length);
       item.createEl("span", { cls: "gemmera-history__item-meta", text: meta });
 
-      item.addEventListener("click", () => this.switchToSession(session).catch(() => {}));
+      item.addEventListener("click", () => this.switchToSession(session).catch((err) => console.error("[gemmera] switchToSession:", err)));
       item.addEventListener("keydown", (e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          this.switchToSession(session).catch(() => {});
+          this.switchToSession(session).catch((err) => console.error("[gemmera] switchToSession:", err));
         }
       });
     }
@@ -622,6 +622,7 @@ export class GemmeraChatView extends ItemView {
     session: import("./services/chat-history").ChatSession,
   ): Promise<void> {
     this.currentSessionId = session.id;
+    this.recentTurns = [];
     this.history = session.turns.map((t) => ({ role: t.role, content: t.content }));
     this.messagesEl.empty();
     for (const turn of session.turns) {
@@ -904,7 +905,7 @@ export function withContext(
 }
 
 function formatSessionMeta(updatedAt: number, turnCount: number): string {
-  const turns = Math.floor(turnCount / 2);
+  const turns = turnCount;
   const date = new Date(updatedAt).toLocaleDateString("sv-SE", {
     month: "short",
     day: "numeric",

--- a/styles.css
+++ b/styles.css
@@ -284,3 +284,82 @@
   color: var(--text-on-accent);
   border: none;
 }
+
+/* ── Chat history drawer (#70) ──────────────────────────────────────────── */
+
+.gemmera-history__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  margin-bottom: 8px;
+}
+
+.gemmera-history__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.gemmera-history__new-btn {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  background: var(--background-modifier-hover);
+  border: 1px solid var(--background-modifier-border);
+}
+
+.gemmera-history__empty {
+  font-size: 0.8rem;
+  color: var(--text-faint);
+  text-align: center;
+  padding: 16px 0;
+}
+
+.gemmera-history__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gemmera-history__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.gemmera-history__item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.gemmera-history__item:focus {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+}
+
+.gemmera-history__item--active {
+  background: var(--background-modifier-active-hover);
+}
+
+.gemmera-history__item-title {
+  font-size: 0.85rem;
+  color: var(--text-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gemmera-history__item-meta {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+}


### PR DESCRIPTION
## Summary
Wires the existing `ChatHistoryStore` (already in place for persistence since the previous sprint) into a visible history drawer in the right-side context panel.

- **Session list**: sorted by last-updated; shows auto-generated title (first 50 chars of user's first message), relative date, and message count
- **Switch session**: clicking a session replays its turns into the message area and rehydrates `this.history` so the next send continues in context
- **New chat**: "+ Ny chatt" button clears the current conversation and resets session state
- **Live updates**: drawer re-renders after each turn so title/count update immediately
- **Retention**: `pruneIfNeeded()` runs on panel open (currently unlimited — configurable via `retentionPolicy()`)
- **Layout**: drawer sits inside the existing `.gemmera-context-panel` which is hidden at < 600px and appears on the right at ≥ 600px (no layout change needed)
- **Storage**: JSON at `vault/.coworkmd/chats.json` (DuckDB-shaped API surface per spec — the store interface doesn't change when the backend is swapped)

## Test plan
- [ ] Send 2–3 messages → session appears in drawer with title derived from first message
- [ ] Reload Obsidian → chat list restored from `chats.json`
- [ ] Click a prior session → messages replay; next send continues that session
- [ ] "+ Ny chatt" → blank slate; prior sessions still visible in drawer
- [ ] Panel hidden at narrow viewport, visible at ≥ 600px
- [ ] `npm test` passes (680 tests)
- [ ] `npm run build` succeeds

Closes #70