### PR TITLE
chore(ui): audit and close responsive-layout (#40)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,6 @@
+/* Container query (not viewport media query) — see #40. Layout responds
+ * to the pane's own width so detached / popped-out leaves get the right
+ * mode independently of the window. Single breakpoint at 600 px. */
 .gemmera-view {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Audit-only PR for **#40 — Responsive narrow/wide layout via CSS container query**.

All four acceptance criteria in the issue are already met by current \`dev\`. No behavioural change needed; the diff is a three-line CSS comment that anchors the breakpoint choice (container query vs. viewport media query) back to #40 so future maintainers don't reach for \`matchMedia\` by reflex.

## Audit findings

| Acceptance criterion | Where it's satisfied |
|---|---|
| Container query, not media query | \`container-type: inline-size; container-name: gemmera\` at \`styles.css:6-7\`; \`@container gemmera (min-width: 600px)\` at line ~33 |
| Both modes render shared header + composer | \`gemmera-status\` (header) + \`gemmera-input-area\` (composer) mount inside \`gemmera-main\` at \`view.ts:79-104\` — unconditional |
| Wide mode reserves right column | \`.gemmera-context-panel { display: none }\` by default; \`display: flex; flex: 2\` at ≥600 px; main is \`flex: 3\` → 60/40 split per spec |
| No JS resize listener | \`grep -rn "resize\\|ResizeObserver\\|innerWidth\\|clientWidth" src/\` returns nothing. Only \`matchMedia\` use is \`prefers-reduced-motion\` (a11y) |
| Resize crosses breakpoint without scroll jumps | \`gemmera-body\` is \`overflow: hidden; min-height: 0\`; only \`.gemmera-messages\` and \`.gemmera-context-panel\` scroll. Column collapse doesn't remount nodes |

## Out of scope

The issue mentions a "show sources" expander in narrow mode and the drag-drop target swap (composer row in narrow, full view in wide). Neither is in the formal acceptance bullets, so they're not part of this audit. Drag-drop can land alongside the ingest flow PRs (#52 / #55) if we want it before the milestone closes.

## Test plan

- [x] \`npm test\` — 705 passed
- [x] \`npm run build\` — clean
- [ ] Visual check: drag the Gemmera pane across the 600 px width threshold in Obsidian; layout swaps single-column ↔ two-column without scroll jumps
- [ ] Pop the leaf to a separate window; resize the window across 600 px; layout responds independently of the original main window

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)