### PR TITLE
feat(chat): token streaming + Stop button with immediate cancellation (#46)

### DIFF
--- a/src/services/streaming-state.test.ts
+++ b/src/services/streaming-state.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { isAbortError, StreamingState } from "./streaming-state";
+
+describe("StreamingState", () => {
+  it("starts idle", () => {
+    const s = new StreamingState();
+    expect(s.isStreaming()).toBe(false);
+  });
+
+  it("begin() returns an AbortSignal and marks streaming", () => {
+    const s = new StreamingState();
+    const signal = s.begin();
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+    expect(s.isStreaming()).toBe(true);
+  });
+
+  it("cancel() aborts the signal and returns true", () => {
+    const s = new StreamingState();
+    const signal = s.begin();
+    expect(s.cancel()).toBe(true);
+    expect(signal.aborted).toBe(true);
+    expect(s.isStreaming()).toBe(false);
+  });
+
+  it("cancel() on idle returns false and is a no-op", () => {
+    const s = new StreamingState();
+    expect(s.cancel()).toBe(false);
+  });
+
+  it("end() clears streaming without aborting the signal", () => {
+    const s = new StreamingState();
+    const signal = s.begin();
+    s.end();
+    expect(s.isStreaming()).toBe(false);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("begin() while already streaming aborts the previous controller", () => {
+    const s = new StreamingState();
+    const first = s.begin();
+    const second = s.begin();
+    expect(first.aborted).toBe(true);
+    expect(second.aborted).toBe(false);
+    expect(s.isStreaming()).toBe(true);
+  });
+
+  it("subsequent cancel() after begin/cancel is a no-op", () => {
+    const s = new StreamingState();
+    s.begin();
+    s.cancel();
+    expect(s.cancel()).toBe(false);
+  });
+});
+
+describe("isAbortError", () => {
+  it("recognizes DOMException AbortError", () => {
+    const err = new DOMException("Aborted", "AbortError");
+    expect(isAbortError(err)).toBe(true);
+  });
+
+  it("recognizes an Error with name=AbortError", () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    expect(isAbortError(err)).toBe(true);
+  });
+
+  it("rejects non-AbortError errors", () => {
+    expect(isAbortError(new Error("boom"))).toBe(false);
+    expect(isAbortError(new TypeError("nope"))).toBe(false);
+    expect(isAbortError("string")).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
+  });
+});

--- a/src/services/streaming-state.ts
+++ b/src/services/streaming-state.ts
@@ -1,0 +1,47 @@
+/**
+ * Tracks whether the chat view is currently streaming a response. Owns the
+ * `AbortController` so the Stop button can cancel the in-flight LLM call (and
+ * any orchestrator that threads the same `AbortSignal`).
+ *
+ * Lives as a tiny module so the view's send/stop button toggling can be
+ * exercised in isolation — view-level UI is otherwise untested.
+ */
+export class StreamingState {
+  private controller: AbortController | null = null;
+
+  isStreaming(): boolean {
+    return this.controller !== null;
+  }
+
+  /** Begin a new streaming turn and return its `AbortSignal`. */
+  begin(): AbortSignal {
+    if (this.controller) {
+      // Defensive: caller didn't end the previous turn. Abort it so the user
+      // never has two concurrent in-flight calls racing into the same view.
+      this.controller.abort();
+    }
+    this.controller = new AbortController();
+    return this.controller.signal;
+  }
+
+  /** Cancel the in-flight turn. Returns true if anything was cancelled. */
+  cancel(): boolean {
+    if (!this.controller) return false;
+    this.controller.abort();
+    this.controller = null;
+    return true;
+  }
+
+  /** Mark the turn as finished cleanly (no abort). */
+  end(): void {
+    this.controller = null;
+  }
+}
+
+/**
+ * Pattern shared with `classifier-llm.ts` and `retry-policy.ts` — DOMException
+ * with name "AbortError" plus stdlib errors that carry the same name.
+ */
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}

--- a/src/view.ts
+++ b/src/view.ts
@@ -237,7 +237,7 @@ export class GemmeraChatView extends ItemView {
 
     // ── Mixed (#47) ───────────────────────────────────────────────────
     if (intent === "mixed") {
-      const signal = this.setStreaming(true)!;
+      const signal = this.setStreaming(true);
       try {
         await this.runMixed(text, turnId, signal);
       } finally {
@@ -252,7 +252,7 @@ export class GemmeraChatView extends ItemView {
 
     // ── Ask (#14) — vault-grounded query through the RAG tool loop ────
     if (intent === "ask") {
-      const signal = this.setStreaming(true)!;
+      const signal = this.setStreaming(true);
       try {
         await this.runAsk(text, turnId, route ?? null, signal);
       } finally {
@@ -266,7 +266,7 @@ export class GemmeraChatView extends ItemView {
     }
 
     // ── Chat (meta / fallback, no retrieval) ──────────────────────────
-    const signal = this.setStreaming(true)!;
+    const signal = this.setStreaming(true);
     try {
       await this.runChat(text, intent, turnId, route ?? null, signal);
     } finally {
@@ -577,11 +577,12 @@ export class GemmeraChatView extends ItemView {
     } catch (err) {
       if (isAbortError(err)) {
         // Preserve any partial tokens already rendered into textEl and mark
-        // the turn as cancelled. Pop the assistant entry from history because
-        // we never received a complete reply; the user text stays so the next
-        // turn keeps the right context.
+        // the turn as cancelled. No assistant entry was pushed to history
+        // yet — that only happens after `services.llm.chat` resolves — so
+        // there's nothing to pop here. The user message stays so the next
+        // turn keeps the right context, which is what we want for an
+        // edit-and-retry that references the cancelled question.
         this.markMessageCancelled(assistantEl, textEl);
-        this.history.pop();
       } else {
         assistantEl.remove();
         this.history.pop();
@@ -761,10 +762,23 @@ export class GemmeraChatView extends ItemView {
    * Toggle the composer between idle (Send) and streaming (Stop). The Send
    * button stays enabled while streaming so the user can interrupt; only the
    * textarea is disabled so they can't queue a second turn.
+   *
+   * Overloaded so callers never need to non-null-assert the return value:
+   * `setStreaming(true)` is statically typed to return `AbortSignal`,
+   * `setStreaming(false)` returns `void`.
+   *
+   * KNOWN GAP: Stop is unreachable while the classifier-orchestrator is
+   * deciding the intent (handleSend awaits classifyTurn before the
+   * setStreaming(true) call below). Classify is a single small LLM call so
+   * this is acceptable in practice; threading the signal into
+   * classifier-orchestrator is a follow-up (touches its public API and
+   * tests across the classifier stack).
    */
-  private setStreaming(active: boolean, signal?: AbortSignal): AbortSignal | undefined {
+  private setStreaming(active: true): AbortSignal;
+  private setStreaming(active: false): void;
+  private setStreaming(active: boolean): AbortSignal | void {
     if (active) {
-      const s = signal ?? this.streaming.begin();
+      const s = this.streaming.begin();
       this.inputEl.disabled = true;
       this.sendBtn.disabled = false;
       this.sendBtn.setText(this.stopLabel);
@@ -778,7 +792,6 @@ export class GemmeraChatView extends ItemView {
     this.sendBtn.setText(this.sendLabel);
     this.sendBtn.setAttribute("aria-label", "Send message");
     this.sendBtn.removeClass("gemmera-send--stop");
-    return undefined;
   }
 
   /**

--- a/src/view.ts
+++ b/src/view.ts
@@ -10,6 +10,7 @@ import { toDisambiguationRow } from "./services/classifier-events";
 import { runIngest } from "./services/ingest-orchestrator";
 import { runMixed } from "./services/mixed-orchestrator";
 import { runQuery } from "./services/query-orchestrator";
+import { isAbortError, StreamingState } from "./services/streaming-state";
 import { createSynthesisNote } from "./services/synthesis-writer";
 import { dispatchToolCall, SAVE_NOTE_TOOL, type ToolDispatchDeps } from "./services/tool-dispatcher";
 import { DisambiguationChip } from "./disambiguation-chip";
@@ -43,6 +44,10 @@ export class GemmeraChatView extends ItemView {
   private escCleared = false;
   private prefersReducedMotion = false;
   private lastTurnId: string | undefined;
+  private streaming = new StreamingState();
+  private inFlightText: string | null = null;
+  private readonly sendLabel = "Skicka";
+  private readonly stopLabel = "Stoppa";
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -114,10 +119,15 @@ export class GemmeraChatView extends ItemView {
     });
     this.sendBtn = this.inputAreaEl.createEl("button", {
       cls: "gemmera-send",
-      text: "Skicka",
+      text: this.sendLabel,
       attr: { "aria-label": "Send message" },
     });
-    this.sendBtn.addEventListener("click", () => this.handleSend());
+    // Single handler: dispatch to send when idle, abort when streaming.
+    // Keeps the button always-enabled during a turn so Stop is reachable.
+    this.sendBtn.addEventListener("click", () => {
+      if (this.streaming.isStreaming()) this.cancelStreaming(this.inFlightText ?? undefined);
+      else void this.handleSend();
+    });
     this.inputEl.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
         if (this.inputEl.value.trim().length > 0 && !this.escCleared) {
@@ -179,6 +189,9 @@ export class GemmeraChatView extends ItemView {
 
     const turnId = crypto.randomUUID();
     this.lastTurnId = turnId;
+    // Track the in-flight text so the Stop button can refill the composer
+    // for an edit-and-retry that lands as a brand new turn.
+    this.inFlightText = text;
 
     // ── Classify ──────────────────────────────────────────────────────
     let route: RouteDecision | null = null;
@@ -224,7 +237,13 @@ export class GemmeraChatView extends ItemView {
 
     // ── Mixed (#47) ───────────────────────────────────────────────────
     if (intent === "mixed") {
-      await this.runMixed(text, turnId);
+      const signal = this.setStreaming(true)!;
+      try {
+        await this.runMixed(text, turnId, signal);
+      } finally {
+        this.setStreaming(false);
+        this.inFlightText = null;
+      }
       this.recentTurns = [...this.recentTurns.slice(-2), { text, intent: "mixed" }];
       this.setInputDisabled(false);
       this.inputEl.focus();
@@ -233,7 +252,13 @@ export class GemmeraChatView extends ItemView {
 
     // ── Ask (#14) — vault-grounded query through the RAG tool loop ────
     if (intent === "ask") {
-      await this.runAsk(text, turnId, route ?? null);
+      const signal = this.setStreaming(true)!;
+      try {
+        await this.runAsk(text, turnId, route ?? null, signal);
+      } finally {
+        this.setStreaming(false);
+        this.inFlightText = null;
+      }
       this.recentTurns = [...this.recentTurns.slice(-2), { text, intent: "ask" }];
       this.setInputDisabled(false);
       this.inputEl.focus();
@@ -241,7 +266,13 @@ export class GemmeraChatView extends ItemView {
     }
 
     // ── Chat (meta / fallback, no retrieval) ──────────────────────────
-    await this.runChat(text, intent, turnId, route ?? null);
+    const signal = this.setStreaming(true)!;
+    try {
+      await this.runChat(text, intent, turnId, route ?? null, signal);
+    } finally {
+      this.setStreaming(false);
+      this.inFlightText = null;
+    }
   }
 
   private async runCapture(text: string, turnId: string): Promise<void> {
@@ -299,7 +330,7 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  private async runMixed(text: string, turnId: string): Promise<void> {
+  private async runMixed(text: string, turnId: string, signal?: AbortSignal): Promise<void> {
     this.appendMessage("user", text);
 
     const ingestStatusEl = this.messagesEl.createEl("div", {
@@ -330,6 +361,8 @@ export class GemmeraChatView extends ItemView {
         inboxFolder: this.settings.inboxFolder,
         dedupThreshold: this.settings.dedupThreshold,
         alwaysPreview: this.settings.alwaysPreviewBeforeSave,
+        ingestSignal: signal,
+        querySignal: signal,
         onStateChange: (state, label, phase) => {
           if (phase === "ingest") {
             ingestStatusEl.textContent = label;
@@ -366,6 +399,11 @@ export class GemmeraChatView extends ItemView {
     } catch (err) {
       ingestStatusEl.remove();
       queryStatusEl.remove();
+      if (isAbortError(err)) {
+        const suffix = savedPathSoFar ? ` Note was saved to **${savedPathSoFar}**.` : "";
+        this.appendCancelledMessage(`Stopped.${suffix}`);
+        return;
+      }
       if (savedPathSoFar) {
         this.appendMessage("assistant", `Note was saved to **${savedPathSoFar}**, but the query failed unexpectedly.`);
       }
@@ -381,6 +419,7 @@ export class GemmeraChatView extends ItemView {
     text: string,
     turnId: string,
     route: RouteDecision | null = null,
+    signal?: AbortSignal,
   ): Promise<void> {
     const decoration = buildMessageDecoration(
       route,
@@ -404,6 +443,7 @@ export class GemmeraChatView extends ItemView {
           eventLog: this.services.eventLog,
           turnId,
           model: this.settings.chatModel,
+          signal,
           onStateChange: (_state, label) => {
             statusEl.textContent = label;
           },
@@ -435,6 +475,10 @@ export class GemmeraChatView extends ItemView {
       }
     } catch (err) {
       statusEl.remove();
+      if (isAbortError(err)) {
+        this.appendCancelledMessage("Stopped.");
+        return;
+      }
       this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
     }
   }
@@ -444,6 +488,7 @@ export class GemmeraChatView extends ItemView {
     intent: IntentLabel,
     turnId: string,
     route: RouteDecision | null = null,
+    signal?: AbortSignal,
   ): Promise<void> {
     const decoration = buildMessageDecoration(
       route,
@@ -474,6 +519,7 @@ export class GemmeraChatView extends ItemView {
         model: this.settings.chatModel,
         messages,
         tools: [SAVE_NOTE_TOOL],
+        signal,
         onToken: (token) => {
           textEl.textContent += token;
           this.scrollToBottom();
@@ -529,9 +575,18 @@ export class GemmeraChatView extends ItemView {
         this.renderCitationChips(assistantEl, citations);
       }
     } catch (err) {
-      assistantEl.remove();
-      this.history.pop();
-      this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
+      if (isAbortError(err)) {
+        // Preserve any partial tokens already rendered into textEl and mark
+        // the turn as cancelled. Pop the assistant entry from history because
+        // we never received a complete reply; the user text stays so the next
+        // turn keeps the right context.
+        this.markMessageCancelled(assistantEl, textEl);
+        this.history.pop();
+      } else {
+        assistantEl.remove();
+        this.history.pop();
+        this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
+      }
     } finally {
       silentSaveEl?.remove();
       this.setInputDisabled(false);
@@ -702,11 +757,77 @@ export class GemmeraChatView extends ItemView {
     this.sendBtn.disabled = disabled;
   }
 
+  /**
+   * Toggle the composer between idle (Send) and streaming (Stop). The Send
+   * button stays enabled while streaming so the user can interrupt; only the
+   * textarea is disabled so they can't queue a second turn.
+   */
+  private setStreaming(active: boolean, signal?: AbortSignal): AbortSignal | undefined {
+    if (active) {
+      const s = signal ?? this.streaming.begin();
+      this.inputEl.disabled = true;
+      this.sendBtn.disabled = false;
+      this.sendBtn.setText(this.stopLabel);
+      this.sendBtn.setAttribute("aria-label", "Stop generation");
+      this.sendBtn.addClass("gemmera-send--stop");
+      return s;
+    }
+    this.streaming.end();
+    this.inputEl.disabled = false;
+    this.sendBtn.disabled = false;
+    this.sendBtn.setText(this.sendLabel);
+    this.sendBtn.setAttribute("aria-label", "Send message");
+    this.sendBtn.removeClass("gemmera-send--stop");
+    return undefined;
+  }
+
+  /**
+   * Refill the composer with the in-flight user text so the user can edit and
+   * resend as a *new* turn (each Send creates a fresh turnId / userTs, so the
+   * cancelled turn is preserved in history alongside the retry).
+   */
+  private cancelStreaming(restoreText?: string): void {
+    if (!this.streaming.cancel()) return;
+    if (restoreText) {
+      this.inputEl.value = restoreText;
+    }
+    this.setStreaming(false);
+    this.inputEl.focus();
+  }
+
   private scrollToBottom(): void {
     this.messagesEl.scrollTo({
       top: this.messagesEl.scrollHeight,
       behavior: this.prefersReducedMotion ? "auto" : "smooth",
     });
+  }
+
+  /**
+   * Mark a streaming assistant message as cancelled. Preserves any partial
+   * tokens already appended to `textEl` and adds a small "[cancelled]" tag so
+   * the user can tell the turn didn't finish on its own.
+   */
+  private markMessageCancelled(el: HTMLElement, textEl: HTMLElement): void {
+    el.addClass("gemmera-message--cancelled");
+    if (!textEl.textContent || textEl.textContent.trim().length === 0) {
+      textEl.textContent = "(no output)";
+    }
+    const tag = el.createEl("span", { cls: "gemmera-message__cancelled", text: "stopped" });
+    tag.setAttribute("aria-label", "Turn cancelled");
+  }
+
+  /**
+   * Append a fresh "stopped" message for paths that hadn't started streaming
+   * yet (runAsk / runMixed during the retrieval phase).
+   */
+  private appendCancelledMessage(text: string): void {
+    const el = this.messagesEl.createEl("div", {
+      cls: "gemmera-message gemmera-message--assistant gemmera-message--cancelled",
+    });
+    el.createEl("span", { cls: "gemmera-message__role", text: "Gemma" });
+    el.createEl("p", { cls: "gemmera-message__text", text });
+    el.createEl("span", { cls: "gemmera-message__cancelled", text: "stopped" });
+    this.scrollToBottom();
   }
 
   private appendStreamingMessage(): { el: HTMLElement; textEl: HTMLElement } {

--- a/styles.css
+++ b/styles.css
@@ -161,6 +161,34 @@
   align-self: flex-end;
 }
 
+/* Send button doubles as Stop during streaming (#46). */
+.gemmera-send--stop {
+  background: var(--background-modifier-error);
+  color: var(--text-on-accent);
+}
+
+/* Cancelled-turn marker (#46). Distinct from error styling — this was a
+ * user-initiated stop, not a failure, so it's muted rather than red. */
+.gemmera-message--cancelled .gemmera-message__text {
+  opacity: 0.7;
+  border-left: 2px solid var(--text-muted);
+  padding-left: 8px;
+  font-style: italic;
+}
+
+.gemmera-message__cancelled {
+  display: inline-block;
+  margin-top: 2px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .gemmera-status-chip {
   font-size: 0.75rem;
   padding: 4px 10px;


### PR DESCRIPTION
Closes #46. PR 2 of the UI-surfaces v1 sequence (PR 1 = #144 / audit-only #40).

## Summary

- Adds `StreamingState` service (owns the `AbortController` for the in-flight turn) plus 9 unit tests
- Send button doubles as Stop during a turn (`Skicka` ↔ `Stoppa`); single click handler dispatches by state
- `AbortSignal` threaded into `runChat`, `runAsk`, and `runMixed` (orchestrators were already plumbed)
- Cancelled turn renders a "stopped" marker with muted styling and preserves any partial tokens already streamed
- In-flight text captured on send → Stop refills the composer for edit-and-retry → retry produces a *new* turnId, never overwrites

## Acceptance (issue #46)

| Criterion | Status |
|---|---|
| Tokens render as they arrive with no perceptible buffering | ✅ Existing `ollama-llm.ts` streaming preserved; runChat's `onToken` appends to textEl |
| Stop interrupts within ~100 ms of click | ✅ AbortController.abort() is synchronous; fetch read-loop sees the signal on the next chunk boundary |
| Cancelled turn is visually distinct and labelled | ✅ `gemmera-message--cancelled` class (muted + italic + left-border), inline `[stopped]` tag |
| Edit-and-retry produces a new turn | ✅ Each Send creates a fresh `turnId`; the cancelled turn stays in the DOM/history alongside the retry |

## Out of scope

In-flight tool calls intentionally complete on their existing semantics — mixed-orchestrator drops query results when `querySignal` fires; ingest already-written notes stay (reversible via existing Undo). The issue's "in-flight tool calls complete but their results are dropped" matches this behaviour.

## Test plan

- [x] `npm test` → 715/715 (up from 705)
- [x] `npm run build` → clean
- [ ] Manual: send a long-ish query, click Stop, verify the partial answer stays with the stopped tag and Send is restored
- [ ] Manual: stop a turn → composer refills → edit one word → send → new turn appears below the cancelled one
- [ ] Manual: stop during \`runAsk\` (\"Searching notes…\" status) → status replaced by stopped marker; no error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)