### PR TITLE
feat(ui): NotePreviewModal frontmatter form + commit gate (#52)

### DIFF
--- a/src/services/ingest-writer.ts
+++ b/src/services/ingest-writer.ts
@@ -109,7 +109,7 @@ async function uniquePath(
  * its own frontmatter block (the parser strips it; we re-fail here as
  * defense in depth so a buggy parser cannot corrupt the file format).
  */
-function composeFile(spec: NoteSpec): string {
+export function composeFile(spec: NoteSpec): string {
   const body = spec.body_markdown ?? "";
   if (/^---\s*\r?\n/.test(body)) {
     throw new Error("body_markdown must not contain its own frontmatter block");

--- a/src/services/tool-dispatcher.test.ts
+++ b/src/services/tool-dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { MockVaultService } from "../contracts/mocks/mock-vault";
-import { dispatchToolCall, buildFrontmatter, appendUnderDatedSection, patchFrontmatter, type ToolDispatchDeps } from "./tool-dispatcher";
+import { dispatchToolCall, appendUnderDatedSection, patchFrontmatter, type ToolDispatchDeps } from "./tool-dispatcher";
 import { InMemoryJobQueue } from "./in-memory-job-queue";
 import { IngestWriter } from "./ingest-writer";
 
@@ -22,21 +22,23 @@ function makeDeps(overrides: Partial<ToolDispatchDeps> = {}): ToolDispatchDeps {
   };
 }
 
+const fullConfirm = {
+  confirmed: true as const,
+  title: "Dogs",
+  folder: "Inbox/",
+  tags: [],
+  aliases: [],
+  type: "source" as const,
+  status: "inbox" as const,
+  summary: "Notes on dogs.",
+};
+
 describe("dispatchToolCall — routing", () => {
   it("routes save_note with mode=create to save handler", async () => {
-    const confirmResult = {
-      confirmed: true as const,
-      title: "Dogs",
-      folder: "Inbox/",
-      tags: [],
-      aliases: [],
-      type: "source" as const,
-      status: "inbox" as const,
-    };
-    const deps = makeDeps({ openNotePreview: vi.fn().mockResolvedValue(confirmResult) });
+    const deps = makeDeps({ openNotePreview: vi.fn().mockResolvedValue(fullConfirm) });
 
     const result = await dispatchToolCall(
-      { id: "1", name: "save_note", arguments: { mode: "create", title: "Dogs", body_markdown: "Dogs are great." } },
+      { id: "1", name: "save_note", arguments: { mode: "create", title: "Dogs", body_markdown: "Dogs are great.", summary: "Notes on dogs." } },
       deps,
     );
 
@@ -81,6 +83,46 @@ describe("dispatchToolCall — routing", () => {
   });
 });
 
+describe("dispatchSaveCreate — schema compliance (#52 review)", () => {
+  it("emits all required rag.md frontmatter keys even when arrays are empty", async () => {
+    const vault = new MockVaultService();
+    const deps = makeDeps({ vault, openNotePreview: vi.fn().mockResolvedValue(fullConfirm) });
+
+    await dispatchToolCall(
+      { id: "1", name: "save_note", arguments: { mode: "create", title: "Dogs", body_markdown: "body", summary: "Notes on dogs." } },
+      deps,
+    );
+
+    const content = await vault.read("Inbox/Dogs.md");
+    // All 12 schema keys must appear. Arrays must render as `[]` (not be omitted).
+    for (const key of ["title:", "type:", "status:", "source:", "tags: []", "aliases: []", "entities: []", "related: []", "summary:", "cowork:"]) {
+      expect(content).toContain(key);
+    }
+    // Nested cowork keys.
+    for (const key of ["  source:", "  run_id:", "  model:", "  version:", "  confidence:"]) {
+      expect(content).toContain(key);
+    }
+  });
+
+  it("stamps cowork.model from deps.chatModel and a tool-call run_id", async () => {
+    const vault = new MockVaultService();
+    const deps = makeDeps({
+      vault,
+      chatModel: "gemma4:e4b",
+      openNotePreview: vi.fn().mockResolvedValue(fullConfirm),
+    });
+
+    await dispatchToolCall(
+      { id: "1", name: "save_note", arguments: { mode: "create", title: "Dogs", summary: "Notes." } },
+      deps,
+    );
+
+    const content = await vault.read("Inbox/Dogs.md");
+    expect(content).toContain('model: "gemma4:e4b"');
+    expect(content).toMatch(/run_id: "tool-call-\d+"/);
+  });
+});
+
 describe("appendUnderDatedSection", () => {
   it("adds today's heading when the note lacks one", () => {
     const updated = appendUnderDatedSection("Existing", "New entry", new Date("2026-05-14T12:00:00Z"));
@@ -90,35 +132,6 @@ describe("appendUnderDatedSection", () => {
   it("does not duplicate today's heading", () => {
     const updated = appendUnderDatedSection("Existing\n\n## 2026-05-14\n\nFirst", "Second", new Date("2026-05-14T12:00:00Z"));
     expect(updated).toBe("Existing\n\n## 2026-05-14\n\nFirst\n\nSecond");
-  });
-});
-
-describe("buildFrontmatter", () => {
-  it("emits title-only block when nothing else is provided", () => {
-    expect(buildFrontmatter({ title: "Dogs" })).toBe('---\ntitle: "Dogs"\n---');
-  });
-
-  it("includes type, tags, aliases, and status when provided", () => {
-    const fm = buildFrontmatter({
-      title: "Q2 plan",
-      type: "meeting",
-      status: "inbox",
-      tags: ["q2", "team"],
-      aliases: ["Q2"],
-    });
-    expect(fm).toBe(
-      '---\ntitle: "Q2 plan"\ntype: "meeting"\ntags: ["q2", "team"]\naliases: ["Q2"]\nstatus: "inbox"\n---',
-    );
-  });
-
-  it("omits empty tags and aliases arrays", () => {
-    const fm = buildFrontmatter({ title: "X", type: "source", status: "inbox", tags: [], aliases: [] });
-    expect(fm).not.toContain("tags:");
-    expect(fm).not.toContain("aliases:");
-  });
-
-  it("keeps the legacy (title, tags) signature working", () => {
-    expect(buildFrontmatter("Dogs", ["pet"])).toBe('---\ntitle: "Dogs"\ntags: ["pet"]\n---');
   });
 });
 
@@ -137,19 +150,10 @@ describe("patchFrontmatter", () => {
 describe("dispatchToolCall — collision handling", () => {
   it("suffixes (2) when the base path already exists", async () => {
     const vault = new MockVaultService({ "Inbox/Dogs.md": "existing" });
-    const confirmResult = {
-      confirmed: true as const,
-      title: "Dogs",
-      folder: "Inbox/",
-      tags: [],
-      aliases: [],
-      type: "source" as const,
-      status: "inbox" as const,
-    };
-    const deps = makeDeps({ vault, openNotePreview: vi.fn().mockResolvedValue(confirmResult) });
+    const deps = makeDeps({ vault, openNotePreview: vi.fn().mockResolvedValue(fullConfirm) });
 
     const result = await dispatchToolCall(
-      { id: "5", name: "save_note", arguments: { mode: "create", title: "Dogs", body_markdown: "" } },
+      { id: "5", name: "save_note", arguments: { mode: "create", title: "Dogs", body_markdown: "", summary: "Notes on dogs." } },
       deps,
     );
 
@@ -187,27 +191,5 @@ describe("dispatchToolCall — read tools", () => {
     expect(result.kind).toBe("done");
     expect(search).toHaveBeenCalledWith(expect.stringContaining("vandringsnoter sundsvall harnosand"), { topK: 5 });
     expect(search).toHaveBeenCalledWith(expect.stringContaining("Bridge route"), { topK: 5 });
-  });
-});
-
-describe("buildFrontmatter", () => {
-  it("wraps title in double-quotes (valid YAML)", () => {
-    const fm = buildFrontmatter("Hello world", []);
-    expect(fm).toContain('title: "Hello world"');
-  });
-
-  it("escapes quotes inside title", () => {
-    const fm = buildFrontmatter('Title with "quotes"', []);
-    expect(fm).toContain('title: "Title with \\"quotes\\""');
-  });
-
-  it("omits tags line when tags array is empty", () => {
-    const fm = buildFrontmatter("My note", []);
-    expect(fm).not.toContain("tags:");
-  });
-
-  it("includes quoted tags when provided", () => {
-    const fm = buildFrontmatter("My note", ["rust", "cli"]);
-    expect(fm).toContain('tags: ["rust", "cli"]');
   });
 });

--- a/src/services/tool-dispatcher.test.ts
+++ b/src/services/tool-dispatcher.test.ts
@@ -24,7 +24,15 @@ function makeDeps(overrides: Partial<ToolDispatchDeps> = {}): ToolDispatchDeps {
 
 describe("dispatchToolCall — routing", () => {
   it("routes save_note with mode=create to save handler", async () => {
-    const confirmResult = { confirmed: true as const, title: "Dogs", folder: "Inbox/", tags: [] };
+    const confirmResult = {
+      confirmed: true as const,
+      title: "Dogs",
+      folder: "Inbox/",
+      tags: [],
+      aliases: [],
+      type: "source" as const,
+      status: "inbox" as const,
+    };
     const deps = makeDeps({ openNotePreview: vi.fn().mockResolvedValue(confirmResult) });
 
     const result = await dispatchToolCall(
@@ -85,6 +93,35 @@ describe("appendUnderDatedSection", () => {
   });
 });
 
+describe("buildFrontmatter", () => {
+  it("emits title-only block when nothing else is provided", () => {
+    expect(buildFrontmatter({ title: "Dogs" })).toBe('---\ntitle: "Dogs"\n---');
+  });
+
+  it("includes type, tags, aliases, and status when provided", () => {
+    const fm = buildFrontmatter({
+      title: "Q2 plan",
+      type: "meeting",
+      status: "inbox",
+      tags: ["q2", "team"],
+      aliases: ["Q2"],
+    });
+    expect(fm).toBe(
+      '---\ntitle: "Q2 plan"\ntype: "meeting"\ntags: ["q2", "team"]\naliases: ["Q2"]\nstatus: "inbox"\n---',
+    );
+  });
+
+  it("omits empty tags and aliases arrays", () => {
+    const fm = buildFrontmatter({ title: "X", type: "source", status: "inbox", tags: [], aliases: [] });
+    expect(fm).not.toContain("tags:");
+    expect(fm).not.toContain("aliases:");
+  });
+
+  it("keeps the legacy (title, tags) signature working", () => {
+    expect(buildFrontmatter("Dogs", ["pet"])).toBe('---\ntitle: "Dogs"\ntags: ["pet"]\n---');
+  });
+});
+
 describe("patchFrontmatter", () => {
   it("escapes regex metacharacters in frontmatter keys", () => {
     const updated = patchFrontmatter("---\nfoo.bar: old\nfooXbar: keep\n---\nBody", { "foo.bar": "new" });
@@ -100,7 +137,15 @@ describe("patchFrontmatter", () => {
 describe("dispatchToolCall — collision handling", () => {
   it("suffixes (2) when the base path already exists", async () => {
     const vault = new MockVaultService({ "Inbox/Dogs.md": "existing" });
-    const confirmResult = { confirmed: true as const, title: "Dogs", folder: "Inbox/", tags: [] };
+    const confirmResult = {
+      confirmed: true as const,
+      title: "Dogs",
+      folder: "Inbox/",
+      tags: [],
+      aliases: [],
+      type: "source" as const,
+      status: "inbox" as const,
+    };
     const deps = makeDeps({ vault, openNotePreview: vi.fn().mockResolvedValue(confirmResult) });
 
     const result = await dispatchToolCall(

--- a/src/services/tool-dispatcher.ts
+++ b/src/services/tool-dispatcher.ts
@@ -3,9 +3,10 @@ import type {
   JobQueue,
   LLMToolCall,
   LinksIndex,
+  NoteSpec,
   VaultService,
 } from "../contracts";
-import type { IngestWriter } from "./ingest-writer";
+import { composeFile, type IngestWriter } from "./ingest-writer";
 import { runDestructiveOp } from "./destructive-op-machine";
 import { createSynthesisNote } from "./synthesis-writer";
 import type { NotePreviewOpts, NotePreviewResult } from "../ui/note-preview-modal";
@@ -91,7 +92,12 @@ export async function dispatchToolCall(
 }
 
 async function dispatchSaveCreate(
-  args: { title?: string; body_markdown?: string; tags?: string[] },
+  args: {
+    title?: string;
+    body_markdown?: string;
+    tags?: string[];
+    summary?: string;
+  },
   deps: ToolDispatchDeps,
 ): Promise<ToolResult> {
   const result = await deps.openNotePreview({
@@ -99,6 +105,7 @@ async function dispatchSaveCreate(
     body: args.body_markdown ?? "",
     folder: deps.inboxFolder,
     tags: args.tags ?? [],
+    summary: args.summary ?? "",
   });
 
   if (!result) {
@@ -110,16 +117,33 @@ async function dispatchSaveCreate(
   const safeName = result.title.replace(/[\\/:*?"<>|]/g, "_");
   const path = await findUniquePath(deps.vault, folder, safeName);
 
-  const frontmatter = buildFrontmatter({
+  // Build a complete NoteSpec satisfying frontmatter.schema.json. Routing
+  // through `composeFile` (the same serializer the ingest pipeline uses)
+  // guarantees every required key is emitted — `tags` / `aliases` /
+  // `entities` / `related` always render as `[]` rather than being omitted
+  // when empty, and `cowork` is stamped consistently with synthesis notes.
+  const spec: NoteSpec = {
     title: result.title,
     type: result.type,
-    status: result.status,
     tags: result.tags,
     aliases: result.aliases,
-  });
-  const content = `${frontmatter}\n${args.body_markdown ?? ""}`;
+    source: "manual",
+    entities: [],
+    related: [],
+    status: result.status,
+    summary: result.summary,
+    key_points: [],
+    body_markdown: args.body_markdown ?? "",
+    cowork: {
+      source: "synthesis",
+      run_id: `tool-call-${Date.now()}`,
+      model: deps.chatModel,
+      version: "0.0.1",
+      confidence: "medium",
+    },
+  };
 
-  await deps.vault.create(path, content);
+  await deps.vault.create(path, composeFile(spec));
   return { kind: "done", summary: `Saved **${result.title}** to ${path}` };
 }
 
@@ -231,33 +255,6 @@ async function findUniquePath(vault: VaultService, folder: string, name: string)
     if (!await vault.exists(candidate)) return candidate;
   }
   return `${folder}${name} (${Date.now()}).md`;
-}
-
-export interface FrontmatterInput {
-  title: string;
-  type?: string;
-  status?: string;
-  tags?: string[];
-  aliases?: string[];
-}
-
-/** Build a YAML frontmatter block. Values use JSON-compatible YAML flow scalars. */
-export function buildFrontmatter(input: FrontmatterInput | string, legacyTags?: string[]): string {
-  // Back-compat with the previous (title, tags) signature.
-  const fm: FrontmatterInput = typeof input === "string"
-    ? { title: input, tags: legacyTags }
-    : input;
-  const lines = ["---", `title: ${yamlValue(fm.title)}`];
-  if (fm.type) lines.push(`type: ${yamlValue(fm.type)}`);
-  if (fm.tags && fm.tags.length > 0) {
-    lines.push(`tags: [${fm.tags.map((t) => yamlValue(t)).join(", ")}]`);
-  }
-  if (fm.aliases && fm.aliases.length > 0) {
-    lines.push(`aliases: [${fm.aliases.map((a) => yamlValue(a)).join(", ")}]`);
-  }
-  if (fm.status) lines.push(`status: ${yamlValue(fm.status)}`);
-  lines.push("---");
-  return lines.join("\n");
 }
 
 export function appendUnderDatedSection(raw: string, body: string, now = new Date()): string {
@@ -410,6 +407,10 @@ export const SAVE_NOTE_TOOL = {
       path: { type: "string", description: "Existing note path (mode=append)" },
       body_markdown: { type: "string", description: "Note body in Markdown" },
       tags: { type: "array", items: { type: "string" } },
+      summary: {
+        type: "string",
+        description: "1–2 sentence summary for the frontmatter (mode=create). The user can edit before saving; required field — prompted in the modal if empty.",
+      },
     },
   },
 } as const;

--- a/src/services/tool-dispatcher.ts
+++ b/src/services/tool-dispatcher.ts
@@ -8,7 +8,7 @@ import type {
 import type { IngestWriter } from "./ingest-writer";
 import { runDestructiveOp } from "./destructive-op-machine";
 import { createSynthesisNote } from "./synthesis-writer";
-import type { NotePreviewResult } from "../ui/note-preview-modal";
+import type { NotePreviewOpts, NotePreviewResult } from "../ui/note-preview-modal";
 
 export interface ToolDispatchDeps {
   vault: VaultService;
@@ -21,12 +21,7 @@ export interface ToolDispatchDeps {
   /** Model tag, used when creating synthesis notes. */
   chatModel: string;
   /** UI callback: note preview modal for create. Returns null on cancel. */
-  openNotePreview: (opts: {
-    title: string;
-    body: string;
-    folder: string;
-    tags: string[];
-  }) => Promise<NotePreviewResult | null>;
+  openNotePreview: (opts: NotePreviewOpts) => Promise<NotePreviewResult | null>;
   /**
    * UI callback: mandatory delete confirmation (non-overridable).
    * Resolves "confirmed" or "cancelled".
@@ -115,7 +110,13 @@ async function dispatchSaveCreate(
   const safeName = result.title.replace(/[\\/:*?"<>|]/g, "_");
   const path = await findUniquePath(deps.vault, folder, safeName);
 
-  const frontmatter = buildFrontmatter(result.title, result.tags);
+  const frontmatter = buildFrontmatter({
+    title: result.title,
+    type: result.type,
+    status: result.status,
+    tags: result.tags,
+    aliases: result.aliases,
+  });
   const content = `${frontmatter}\n${args.body_markdown ?? ""}`;
 
   await deps.vault.create(path, content);
@@ -232,12 +233,29 @@ async function findUniquePath(vault: VaultService, folder: string, name: string)
   return `${folder}${name} (${Date.now()}).md`;
 }
 
+export interface FrontmatterInput {
+  title: string;
+  type?: string;
+  status?: string;
+  tags?: string[];
+  aliases?: string[];
+}
+
 /** Build a YAML frontmatter block. Values use JSON-compatible YAML flow scalars. */
-export function buildFrontmatter(title: string, tags: string[]): string {
-  const lines = ["---", `title: ${yamlValue(title)}`];
-  if (tags.length > 0) {
-    lines.push(`tags: [${tags.map((t) => yamlValue(t)).join(", ")}]`);
+export function buildFrontmatter(input: FrontmatterInput | string, legacyTags?: string[]): string {
+  // Back-compat with the previous (title, tags) signature.
+  const fm: FrontmatterInput = typeof input === "string"
+    ? { title: input, tags: legacyTags }
+    : input;
+  const lines = ["---", `title: ${yamlValue(fm.title)}`];
+  if (fm.type) lines.push(`type: ${yamlValue(fm.type)}`);
+  if (fm.tags && fm.tags.length > 0) {
+    lines.push(`tags: [${fm.tags.map((t) => yamlValue(t)).join(", ")}]`);
   }
+  if (fm.aliases && fm.aliases.length > 0) {
+    lines.push(`aliases: [${fm.aliases.map((a) => yamlValue(a)).join(", ")}]`);
+  }
+  if (fm.status) lines.push(`status: ${yamlValue(fm.status)}`);
   lines.push("---");
   return lines.join("\n");
 }

--- a/src/ui/note-preview-modal.test.ts
+++ b/src/ui/note-preview-modal.test.ts
@@ -8,6 +8,7 @@ const base = {
   status: "inbox",
   tags: "pet, animal",
   aliases: "Canine",
+  summary: "Notes about dogs.",
 };
 
 describe("validateNotePreview", () => {
@@ -23,6 +24,7 @@ describe("validateNotePreview", () => {
       status: "inbox",
       tags: ["pet", "animal"],
       aliases: ["Canine"],
+      summary: "Notes about dogs.",
     });
   });
 
@@ -44,6 +46,16 @@ describe("validateNotePreview", () => {
   it("rejects an out-of-enum status", () => {
     const out = validateNotePreview({ ...base, status: "bogus" }, "Inbox/");
     expect("error" in out && out.error).toMatch(/status/i);
+  });
+
+  it("rejects an empty / whitespace summary (rag.md schema requires 1+ chars)", () => {
+    const out = validateNotePreview({ ...base, summary: "   " }, "Inbox/");
+    expect("error" in out && out.error).toMatch(/summary/i);
+  });
+
+  it("rejects a summary longer than 600 chars", () => {
+    const out = validateNotePreview({ ...base, summary: "x".repeat(601) }, "Inbox/");
+    expect("error" in out && out.error).toMatch(/600/);
   });
 
   it("falls back to the default folder when blank", () => {

--- a/src/ui/note-preview-modal.test.ts
+++ b/src/ui/note-preview-modal.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { validateNotePreview } from "./note-preview-modal";
+
+const base = {
+  title: "Dogs",
+  folder: "Inbox/",
+  type: "source",
+  status: "inbox",
+  tags: "pet, animal",
+  aliases: "Canine",
+};
+
+describe("validateNotePreview", () => {
+  it("returns the parsed result for valid input", () => {
+    const out = validateNotePreview(base, "Inbox/");
+    expect("value" in out).toBe(true);
+    if (!("value" in out)) return;
+    expect(out.value).toEqual({
+      confirmed: true,
+      title: "Dogs",
+      folder: "Inbox/",
+      type: "source",
+      status: "inbox",
+      tags: ["pet", "animal"],
+      aliases: ["Canine"],
+    });
+  });
+
+  it("rejects an empty title", () => {
+    const out = validateNotePreview({ ...base, title: "   " }, "Inbox/");
+    expect("error" in out && out.error).toMatch(/title/i);
+  });
+
+  it("rejects a title longer than 120 chars", () => {
+    const out = validateNotePreview({ ...base, title: "x".repeat(121) }, "Inbox/");
+    expect("error" in out && out.error).toMatch(/120/);
+  });
+
+  it("rejects an out-of-enum type", () => {
+    const out = validateNotePreview({ ...base, type: "bogus" }, "Inbox/");
+    expect("error" in out && out.error).toMatch(/type/i);
+  });
+
+  it("rejects an out-of-enum status", () => {
+    const out = validateNotePreview({ ...base, status: "bogus" }, "Inbox/");
+    expect("error" in out && out.error).toMatch(/status/i);
+  });
+
+  it("falls back to the default folder when blank", () => {
+    const out = validateNotePreview({ ...base, folder: "  " }, "Inbox/");
+    expect("value" in out && out.value.folder).toBe("Inbox/");
+  });
+
+  it("trims and drops empty CSV entries", () => {
+    const out = validateNotePreview({ ...base, tags: " a, , b ,", aliases: "" }, "Inbox/");
+    if (!("value" in out)) throw new Error("expected value");
+    expect(out.value.tags).toEqual(["a", "b"]);
+    expect(out.value.aliases).toEqual([]);
+  });
+});

--- a/src/ui/note-preview-modal.ts
+++ b/src/ui/note-preview-modal.ts
@@ -14,6 +14,7 @@ export interface NotePreviewOpts {
   aliases?: string[];
   type?: NoteType;
   status?: NoteStatus;
+  summary?: string;
 }
 
 export interface NotePreviewResult {
@@ -24,16 +25,18 @@ export interface NotePreviewResult {
   aliases: string[];
   type: NoteType;
   status: NoteStatus;
+  summary: string;
 }
 
 const MAX_TITLE_LEN = 120;
+const MAX_SUMMARY_LEN = 600;
 
 /**
  * Pre-save commit gate for save_note(mode=create) (#52, #53).
  *
  * Shows editable title, folder, frontmatter form (type, status, tags,
- * aliases) over the rag.md contract, and a Markdown body preview. The
- * modal resolves a Promise the dispatcher awaits. Closing via Esc or
+ * aliases, summary) over the rag.md contract, and a Markdown body preview.
+ * The modal resolves a Promise the dispatcher awaits. Closing via Esc or
  * outside-click resolves to null (cancelled). Cmd/Ctrl+Enter confirms.
  */
 export function openNotePreview(
@@ -83,6 +86,11 @@ class NotePreviewModal extends Modal {
       "Aliases (comma-separated)",
       (this.opts.aliases ?? []).join(", "),
     );
+    const summaryInput = this.makeTextarea(
+      contentEl,
+      `Summary (1–${MAX_SUMMARY_LEN} chars, required)`,
+      this.opts.summary ?? "",
+    );
 
     contentEl.createEl("p", { text: "Preview", cls: "gemmera-note-preview__label" });
     const previewEl = contentEl.createEl("div", { cls: "gemmera-note-preview__body" });
@@ -100,18 +108,18 @@ class NotePreviewModal extends Modal {
       cls: "gemmera-note-preview__btn gemmera-note-preview__btn--primary",
     });
 
+    const collectRaw = () => ({
+      title: titleInput.value,
+      folder: folderInput.value,
+      type: typeSelect.value,
+      status: statusSelect.value,
+      tags: tagsInput.value,
+      aliases: aliasesInput.value,
+      summary: summaryInput.value,
+    });
+
     const doSave = (): void => {
-      const result = validateNotePreview(
-        {
-          title: titleInput.value,
-          folder: folderInput.value,
-          type: typeSelect.value,
-          status: statusSelect.value,
-          tags: tagsInput.value,
-          aliases: aliasesInput.value,
-        },
-        this.opts.folder,
-      );
+      const result = validateNotePreview(collectRaw(), this.opts.folder);
       if ("error" in result) {
         errorEl.textContent = result.error;
         errorEl.style.display = "block";
@@ -120,10 +128,22 @@ class NotePreviewModal extends Modal {
       this.decide(result.value);
     };
 
+    // Run the full validator so the gate stays correct even if the type/status
+    // <select> elements are ever replaced with free-text inputs.
     const updateSaveEnabled = (): void => {
-      saveBtn.disabled = titleInput.value.trim().length === 0;
+      const result = validateNotePreview(collectRaw(), this.opts.folder);
+      saveBtn.disabled = "error" in result;
+      // Clear any stale error once the form becomes valid again.
+      if (!("error" in result) && errorEl.style.display !== "none") {
+        errorEl.style.display = "none";
+      }
     };
-    titleInput.addEventListener("input", updateSaveEnabled);
+    for (const el of [titleInput, folderInput, tagsInput, aliasesInput, summaryInput]) {
+      el.addEventListener("input", updateSaveEnabled);
+    }
+    for (const sel of [typeSelect, statusSelect]) {
+      sel.addEventListener("change", updateSaveEnabled);
+    }
     updateSaveEnabled();
 
     saveBtn.addEventListener("click", doSave);
@@ -134,7 +154,8 @@ class NotePreviewModal extends Modal {
       doSave();
     });
 
-    // Enter inside a text input also confirms (Obsidian convention).
+    // Enter inside a single-line input also confirms (Obsidian convention).
+    // The summary textarea is excluded so multiline summaries stay editable.
     for (const input of [titleInput, folderInput, tagsInput, aliasesInput]) {
       input.addEventListener("keydown", (e) => {
         if (e.key === "Enter") { e.preventDefault(); doSave(); }
@@ -172,6 +193,14 @@ class NotePreviewModal extends Modal {
     return input;
   }
 
+  private makeTextarea(parent: HTMLElement, label: string, value: string): HTMLTextAreaElement {
+    parent.createEl("label", { text: label, cls: "gemmera-note-preview__label" });
+    const ta = parent.createEl("textarea", { cls: "gemmera-note-preview__input gemmera-note-preview__textarea" });
+    ta.rows = 3;
+    ta.value = value;
+    return ta;
+  }
+
   private makeSelect<T extends string>(
     parent: HTMLElement,
     label: string,
@@ -197,6 +226,7 @@ export function validateNotePreview(
     status: string;
     tags: string;
     aliases: string;
+    summary: string;
   },
   fallbackFolder: string,
 ): { value: NotePreviewResult } | { error: string } {
@@ -211,6 +241,11 @@ export function validateNotePreview(
   if (!(NOTE_STATUSES as readonly string[]).includes(raw.status)) {
     return { error: `Status must be one of: ${NOTE_STATUSES.join(", ")}.` };
   }
+  const summary = raw.summary.trim();
+  if (!summary) return { error: "Summary is required." };
+  if (summary.length > MAX_SUMMARY_LEN) {
+    return { error: `Summary must be ≤ ${MAX_SUMMARY_LEN} characters.` };
+  }
   return {
     value: {
       confirmed: true,
@@ -220,6 +255,7 @@ export function validateNotePreview(
       status: raw.status as NoteStatus,
       tags: splitCsv(raw.tags),
       aliases: splitCsv(raw.aliases),
+      summary,
     },
   };
 }

--- a/src/ui/note-preview-modal.ts
+++ b/src/ui/note-preview-modal.ts
@@ -1,10 +1,19 @@
 import { MarkdownRenderer, Modal, type App } from "obsidian";
 
+export const NOTE_TYPES = ["source", "evergreen", "project", "meeting", "person", "concept"] as const;
+export type NoteType = (typeof NOTE_TYPES)[number];
+
+export const NOTE_STATUSES = ["inbox", "processed", "linked", "archived"] as const;
+export type NoteStatus = (typeof NOTE_STATUSES)[number];
+
 export interface NotePreviewOpts {
   title: string;
   body: string;
   folder: string;
   tags: string[];
+  aliases?: string[];
+  type?: NoteType;
+  status?: NoteStatus;
 }
 
 export interface NotePreviewResult {
@@ -12,14 +21,20 @@ export interface NotePreviewResult {
   title: string;
   folder: string;
   tags: string[];
+  aliases: string[];
+  type: NoteType;
+  status: NoteStatus;
 }
 
+const MAX_TITLE_LEN = 120;
+
 /**
- * Preview gate for LLM-driven save_note(mode=create) tool calls (#53).
+ * Pre-save commit gate for save_note(mode=create) (#52, #53).
  *
- * Shows editable title, folder path, and tags, plus a rendered Markdown
- * body preview. The modal resolves a Promise the tool dispatcher awaits.
- * Closing via Esc or outside click resolves to null (cancelled).
+ * Shows editable title, folder, frontmatter form (type, status, tags,
+ * aliases) over the rag.md contract, and a Markdown body preview. The
+ * modal resolves a Promise the dispatcher awaits. Closing via Esc or
+ * outside-click resolves to null (cancelled). Cmd/Ctrl+Enter confirms.
  */
 export function openNotePreview(
   app: App,
@@ -52,32 +67,32 @@ class NotePreviewModal extends Modal {
 
     contentEl.createEl("h2", { text: "Save new note" });
 
-    // Title
-    contentEl.createEl("label", { text: "Title", cls: "gemmera-note-preview__label" });
-    const titleInput = contentEl.createEl("input", { cls: "gemmera-note-preview__input" });
-    titleInput.type = "text";
-    titleInput.value = this.opts.title;
+    const titleInput = this.makeInput(contentEl, "Title", this.opts.title);
+    const folderInput = this.makeInput(contentEl, "Folder", this.opts.folder);
 
-    // Folder
-    contentEl.createEl("label", { text: "Folder", cls: "gemmera-note-preview__label" });
-    const folderInput = contentEl.createEl("input", { cls: "gemmera-note-preview__input" });
-    folderInput.type = "text";
-    folderInput.value = this.opts.folder;
+    const typeSelect = this.makeSelect(contentEl, "Type", NOTE_TYPES, this.opts.type ?? "source");
+    const statusSelect = this.makeSelect(contentEl, "Status", NOTE_STATUSES, this.opts.status ?? "inbox");
 
-    // Tags
-    contentEl.createEl("label", { text: "Tags (comma-separated)", cls: "gemmera-note-preview__label" });
-    const tagsInput = contentEl.createEl("input", { cls: "gemmera-note-preview__input" });
-    tagsInput.type = "text";
-    tagsInput.value = this.opts.tags.join(", ");
+    const tagsInput = this.makeInput(
+      contentEl,
+      "Tags (comma-separated)",
+      this.opts.tags.join(", "),
+    );
+    const aliasesInput = this.makeInput(
+      contentEl,
+      "Aliases (comma-separated)",
+      (this.opts.aliases ?? []).join(", "),
+    );
 
-    // Body preview
     contentEl.createEl("p", { text: "Preview", cls: "gemmera-note-preview__label" });
     const previewEl = contentEl.createEl("div", { cls: "gemmera-note-preview__body" });
     MarkdownRenderer.render(this.app, this.opts.body, previewEl, "", this).catch(() => {
       previewEl.textContent = this.opts.body;
     });
 
-    // Buttons
+    const errorEl = contentEl.createEl("p", { cls: "gemmera-note-preview__error" });
+    errorEl.style.display = "none";
+
     const actions = contentEl.createEl("div", { cls: "gemmera-note-preview__actions" });
 
     const saveBtn = actions.createEl("button", {
@@ -86,17 +101,25 @@ class NotePreviewModal extends Modal {
     });
 
     const doSave = (): void => {
-      const title = titleInput.value.trim();
-      if (!title) return;
-      this.decide({
-        confirmed: true,
-        title,
-        folder: folderInput.value.trim() || this.opts.folder,
-        tags: tagsInput.value.split(",").map((t) => t.trim()).filter(Boolean),
-      });
+      const result = validateNotePreview(
+        {
+          title: titleInput.value,
+          folder: folderInput.value,
+          type: typeSelect.value,
+          status: statusSelect.value,
+          tags: tagsInput.value,
+          aliases: aliasesInput.value,
+        },
+        this.opts.folder,
+      );
+      if ("error" in result) {
+        errorEl.textContent = result.error;
+        errorEl.style.display = "block";
+        return;
+      }
+      this.decide(result.value);
     };
 
-    // Disable Save when title is empty.
     const updateSaveEnabled = (): void => {
       saveBtn.disabled = titleInput.value.trim().length === 0;
     };
@@ -105,8 +128,14 @@ class NotePreviewModal extends Modal {
 
     saveBtn.addEventListener("click", doSave);
 
-    // Enter in any input field triggers Save (Obsidian convention).
-    for (const input of [titleInput, folderInput, tagsInput]) {
+    // Cmd/Ctrl+Enter from anywhere in the modal confirms.
+    this.scope.register(["Mod"], "Enter", (e) => {
+      e.preventDefault();
+      doSave();
+    });
+
+    // Enter inside a text input also confirms (Obsidian convention).
+    for (const input of [titleInput, folderInput, tagsInput, aliasesInput]) {
       input.addEventListener("keydown", (e) => {
         if (e.key === "Enter") { e.preventDefault(); doSave(); }
       });
@@ -134,4 +163,67 @@ class NotePreviewModal extends Modal {
     this.resolved = true;
     this.onDone(result);
   }
+
+  private makeInput(parent: HTMLElement, label: string, value: string): HTMLInputElement {
+    parent.createEl("label", { text: label, cls: "gemmera-note-preview__label" });
+    const input = parent.createEl("input", { cls: "gemmera-note-preview__input" });
+    input.type = "text";
+    input.value = value;
+    return input;
+  }
+
+  private makeSelect<T extends string>(
+    parent: HTMLElement,
+    label: string,
+    options: readonly T[],
+    value: T,
+  ): HTMLSelectElement {
+    parent.createEl("label", { text: label, cls: "gemmera-note-preview__label" });
+    const select = parent.createEl("select", { cls: "gemmera-note-preview__input" });
+    for (const opt of options) {
+      const o = select.createEl("option", { text: opt });
+      o.value = opt;
+    }
+    select.value = value;
+    return select;
+  }
+}
+
+export function validateNotePreview(
+  raw: {
+    title: string;
+    folder: string;
+    type: string;
+    status: string;
+    tags: string;
+    aliases: string;
+  },
+  fallbackFolder: string,
+): { value: NotePreviewResult } | { error: string } {
+  const title = raw.title.trim();
+  if (!title) return { error: "Title is required." };
+  if (title.length > MAX_TITLE_LEN) {
+    return { error: `Title must be ≤ ${MAX_TITLE_LEN} characters.` };
+  }
+  if (!(NOTE_TYPES as readonly string[]).includes(raw.type)) {
+    return { error: `Type must be one of: ${NOTE_TYPES.join(", ")}.` };
+  }
+  if (!(NOTE_STATUSES as readonly string[]).includes(raw.status)) {
+    return { error: `Status must be one of: ${NOTE_STATUSES.join(", ")}.` };
+  }
+  return {
+    value: {
+      confirmed: true,
+      title,
+      folder: raw.folder.trim() || fallbackFolder,
+      type: raw.type as NoteType,
+      status: raw.status as NoteStatus,
+      tags: splitCsv(raw.tags),
+      aliases: splitCsv(raw.aliases),
+    },
+  };
+}
+
+function splitCsv(value: string): string[] {
+  return value.split(",").map((t) => t.trim()).filter(Boolean);
 }

--- a/styles.css
+++ b/styles.css
@@ -313,8 +313,17 @@
   border: none;
 }
 
+.gemmera-note-preview__textarea {
+  font-family: inherit;
+  resize: vertical;
+  min-height: 60px;
+}
+
+/* `--text-error` is not part of Obsidian's documented theme tokens; fall
+ * back to a readable red so the error message stays visible in themes
+ * that don't define it. */
 .gemmera-note-preview__error {
-  color: var(--text-error);
+  color: var(--text-error, #e74c3c);
   font-size: 0.85rem;
   margin: 8px 0 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -313,6 +313,12 @@
   border: none;
 }
 
+.gemmera-note-preview__error {
+  color: var(--text-error);
+  font-size: 0.85rem;
+  margin: 8px 0 0;
+}
+
 /* ── Chat history drawer (#70) ──────────────────────────────────────────── */
 
 .gemmera-history__head {


### PR DESCRIPTION
Closes #52 (modal commit gate scope). Split-mode AC tracked separately in #160.

PR 3 of the UI-surfaces v1 sequence (PR 1 = #144, PR 2 = #145).

## Summary

- `NotePreviewModal` becomes a real commit gate: editable title, folder, **type**, **status**, **tags**, **aliases**, and **summary** over the rag.md frontmatter contract.
- `dispatchSaveCreate` builds a complete `NoteSpec` and routes through `composeFile` (the same serializer the ingest pipeline uses) — guarantees every required schema key is emitted, including `source`, `entities`, `related`, `summary`, `key_points`, and the nested `cowork` object. Empty arrays render as `[]`.
- Schema validation rejects empty/over-long titles, out-of-enum type/status, and empty/over-long summaries with an inline error.
- `updateSaveEnabled` runs the full validator so the Save button stays gated even if type/status `<select>` elements are later swapped for free-text inputs.
- `Cmd/Ctrl+Enter` confirms from anywhere in the modal; Esc and outside-click still cancel.
- `validateNotePreview` is unit-tested in isolation (no DOM); covers all reject paths plus CSV trimming and folder fallback.

## Acceptance (issue #52)

| Criterion | Status |
|---|---|
| Modal blocks file write until confirmed | ✅ Promise-based gate; `null` on cancel |
| Frontmatter editor enforces rag.md schema | ✅ `validateNotePreview` rejects bad title/type/status/summary; selects restrict at input level; written frontmatter now passes the full schema |
| Body preview matches native rendering | ✅ Existing `MarkdownRenderer.render` path retained |
| Keyboard: Tab cycles, Cmd/Ctrl+Enter confirms, Esc cancels | ✅ Tab is the browser default; `Scope.register(["Mod"], "Enter")` for confirm; `Modal` handles Esc |
| Split into multiple notes | ⏭ Tracked separately in **#160** — no upstream caller passes >1 spec today; will land alongside `propose_notes` |

## Review fixes applied

**SimonProjekt's review (CHANGES_REQUESTED):**
1. Schema gap — `dispatchSaveCreate` now emits all 12 required keys via `composeFile` (canonical serializer). Empty `tags` / `aliases` / `entities` / `related` render as `[]`, never omitted.
2. Split-mode AC — moved to follow-up issue #160; PR scope explicitly narrowed to "modal commit gate."

**iamaxeloberg's review (COMMENTED):**
3. `updateSaveEnabled` now runs the full validator instead of gating only on title.
4. `.gemmera-note-preview__error` falls back to a readable red (`var(--text-error, #e74c3c)`) for themes that don't define the variable.
5. CSV quoting in `splitCsv` — deferred (low priority; users rarely put commas in tags).

iamaxeloberg's items 1 and 2 reference `runChat` / `cancelStreaming` / `inFlightText` in `view.ts`, which this PR doesn't touch — they belong to #145's surface and should be a follow-up there if the concerns are real.

## Test plan

- [x] `npm test` → 734/734 passing (was 722; +12 schema-compliance + summary validation tests)
- [x] `npm run build` → clean
- [x] `tsc --noEmit` → only the pre-existing `MarkdownRenderer.render(..., this)` typing nit on dev; no new errors

