### PR TITLE
fix(build): add typecheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -11,7 +11,13 @@ export class FileSystemAdapter {
 export class Plugin {}
 export class WorkspaceLeaf {}
 export class ItemView {}
-export class MarkdownRenderer {}
+export class Component {
+  load(): void {}
+  unload(): void {}
+}
+export class MarkdownRenderer {
+  static async render(): Promise<void> {}
+}
 
 // Minimal stand-ins for tests that reference UI types but don't actually
 // render. Real Obsidian provides full implementations at runtime.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "node esbuild.config.mjs production",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "eval:classifier": "tsx eval/runner/classify.ts",

--- a/src/ui/note-preview-modal.ts
+++ b/src/ui/note-preview-modal.ts
@@ -1,4 +1,4 @@
-import { MarkdownRenderer, Modal, type App } from "obsidian";
+import { Component, MarkdownRenderer, Modal, type App } from "obsidian";
 
 export interface NotePreviewOpts {
   title: string;
@@ -36,6 +36,7 @@ export function openNotePreview(
 
 class NotePreviewModal extends Modal {
   private resolved = false;
+  private readonly renderOwner = new Component();
 
   constructor(
     app: App,
@@ -46,6 +47,7 @@ class NotePreviewModal extends Modal {
   }
 
   onOpen(): void {
+    this.renderOwner.load();
     const { contentEl } = this;
     contentEl.empty();
     contentEl.addClass("gemmera-note-preview");
@@ -73,7 +75,7 @@ class NotePreviewModal extends Modal {
     // Body preview
     contentEl.createEl("p", { text: "Preview", cls: "gemmera-note-preview__label" });
     const previewEl = contentEl.createEl("div", { cls: "gemmera-note-preview__body" });
-    MarkdownRenderer.render(this.app, this.opts.body, previewEl, "", this).catch(() => {
+    MarkdownRenderer.render(this.app, this.opts.body, previewEl, "", this.renderOwner).catch(() => {
       previewEl.textContent = this.opts.body;
     });
 
@@ -123,6 +125,7 @@ class NotePreviewModal extends Modal {
   }
 
   onClose(): void {
+    this.renderOwner.unload();
     if (!this.resolved) {
       this.resolved = true;
       this.onDone(null);


### PR DESCRIPTION
## What

- Adds `npm run typecheck` as a dedicated `tsc --noEmit` check.
- Runs typecheck in CI before tests.
- Fixes `NotePreviewModal` Markdown rendering by passing a real Obsidian `Component` owner to `MarkdownRenderer.render` and unloading it with the modal.
- Updates the Obsidian test mock for `Component` and `MarkdownRenderer.render`.

## Why

`npm run build` uses esbuild and can pass while TypeScript errors remain hidden. The current failure was in the note preview modal's Markdown renderer owner argument.

Closes #146

## How to test

- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run eval:retrieval:ci`
