### PR TITLE
docs: align current implementation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ Copy `main.js`, `manifest.json`, and `styles.css` to `<your-vault>/.obsidian/plu
 ```bash
 ollama pull gemma3           # chat model (~5 GB)
 ollama pull bge-m3           # embedding model (~1.2 GB)
-ollama pull bge-reranker-v2-m3   # reranker (~600 MB)
 ```
 
 ### First run
 
 On first activation Gemmera indexes your vault in the background — chunking and embedding every note. The chat panel is usable immediately; retrieval improves as indexing completes (~10–30 min for a 5 000-note vault on CPU).
 
-Open the chat panel via the ribbon icon or **Ctrl+P → Gemmera: Öppna chatt**.
+Open the chat panel via the ribbon icon or from the Obsidian command palette.
 
 ## What it does
 
@@ -73,24 +72,24 @@ npm run dev       # watch build for Obsidian hot-reload
 npm run build     # production build → main.js
 ```
 
-Tests cover the full tool-loop state machines, retry policy, classifier, chunker, embedding pipeline, and UI components — 641 tests across 58 files.
+Tests cover the full tool-loop state machines, retry policy, classifier, chunker, embedding pipeline, and UI components. As of the v0.1.1 hardening audit, the suite contains 711 tests across 63 files.
 
-## Tidsplan — 4 veckor
+## Project Timeline — 4 Weeks
 
-### Vecka 1 ✅
-- Plugin-skelett, Ollama-integration, chat-panel med konversationshistorik, Jonas Berg persona
+### Week 1 ✅
+- Plugin skeleton, Ollama integration, chat panel with conversation history, Jonas Berg demo persona
 
-### Vecka 2 ✅
-- Verktyg för filskapande och uppdatering, preview-dialog, vault-sökning med citat
+### Week 2 ✅
+- File creation and update tools, preview dialog, vault search with citations
 
-### Vecka 3 ✅
-- Inkrementell indexering: markdown-chunker, hash-grindad pipeline, BGE-M3 embedder, BM25, reranker, rekonciliering
+### Week 3 ✅
+- Incremental indexing: Markdown chunker, hash-gated pipeline, BGE-M3 embedder, BM25, reconciliation
 
-### Vecka 4 ✅
+### Week 4 ✅
 - Retry policy, Ollama lifecycle, responsive UI, citation chips, v0.1 release
 
 ## Team
 
-Par-projekt. Person A: Ollama-integration, LLM-prompting, verktygsanrop, retrieval-pipeline. Person B: Obsidian-plugin-UI, chat-panel, preview-modal, komponenttestning. Båda deltar i planering varje vecka; review-rollen roterar.
+Course team project. Person A focuses on Ollama integration, LLM prompting, tool calls, and the retrieval pipeline. Person B focuses on Obsidian plugin UI, the chat panel, preview modals, and component testing. The team plans together every week and rotates the reviewer role.
 
-Se [CONTRIBUTING.md](CONTRIBUTING.md) för hur man bidrar.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.

--- a/planning/overview.md
+++ b/planning/overview.md
@@ -9,7 +9,7 @@ This document is the start-here guide to the plan. Specialized docs cover each l
 One chat box, two user behaviors routed by an auto classifier:
 
 - **Capture.** The user drops content with optional instructions ("save this as a meeting note about Q2"). Cowork parses it, checks the vault for duplicates, generates a preview note with title, tags, and frontmatter, and writes it to `Inbox/` after user confirmation.
-- **Ask.** The user asks a question. Cowork retrieves from a hybrid index over the vault, reranks, and answers with citations back to specific notes.
+- **Ask.** The user asks a question. Cowork retrieves from a hybrid index over the vault and answers with citations back to specific notes.
 
 Gemma is the orchestrator for both flows. The vault — plain Markdown files Obsidian already manages — is the canonical long-term store.
 
@@ -19,11 +19,11 @@ What ships in v1:
 
 - Obsidian plugin, desktop-only (`isDesktopOnly: true` in manifest).
 - Local Gemma 4 E4B orchestration via Ollama. The plugin spawns and manages Ollama so users do not need to know it exists.
-- BGE-M3 embeddings; bge-reranker-v2-m3 reranker.
-- DuckDB index at `vault/.coworkmd/index.duckdb` (vector + BM25 + link graph).
+- BGE-M3 embeddings.
+- Current storage uses JSON state at `vault/.coworkmd/state.json`, binary vectors at `vault/.coworkmd/vectors.bin` plus `vectors.json`, and in-memory BM25/link indexes rebuilt from ingestion events.
 - Responsive chat view, default in the right sidebar, pop-out to main-area tab or OS window.
 - Capture path: paste/drop → parse → dedup check → preview → save to `Inbox/` → index.
-- Ask path: plan → hybrid retrieve → rerank → stream answer with citations.
+- Ask path: classify → hybrid retrieve → assemble payload → answer with validated citations.
 - Full CRUD from Gemma with safety rules:
   - Create / append via `save_note(mode=create|append)`.
   - Read via `search_notes`, `get_note`, `find_related_notes`, `list_folder`.
@@ -32,8 +32,8 @@ What ships in v1:
   - Rename / move via `rename_or_move_note`, which uses Obsidian's `FileManager.renameFile` so links update atomically.
 - Six system prompts: `ingest-parser`, `note-writer`, `intent-classifier`, `dedup-decider`, `retrieval-reasoner`, `synthesis-writer`.
 - `.coworkignore` (gitignore-style globs) for controlling indexing scope.
-- Local event log at `vault/.coworkmd/events.duckdb`.
-- Chat history persistence at `vault/.coworkmd/chats.duckdb`.
+- Current event log is in-memory and surfaced through the dev-mode Turn Inspector.
+- Current chat history persists as JSON at `vault/.coworkmd/chats.json`.
 - Golden-set eval scaffolding for retrieval quality regressions.
 
 Explicitly out of scope for v1:
@@ -41,7 +41,7 @@ Explicitly out of scope for v1:
 - Mobile (desktop-only plugin).
 - Cloud model fallback (local-only; no hosted provider integration).
 - Full-body note rewrites (append is the only body-update mode).
-- Model variants beyond E4B + BGE-M3 + reranker (no 26B MoE, no E2B, no swap ladder).
+- Model variants beyond E4B + BGE-M3 (no 26B MoE, no E2B, no swap ladder).
 - PDF, image, and audio ingestion (plain text and Markdown only in v1).
 - Canvas synthesis outputs.
 - Graph view highlighting of cited notes.
@@ -54,7 +54,7 @@ The system is four layers inside a single Obsidian plugin:
 
 1. **UI layer** — responsive `ItemView` chat, `NotePreviewModal` for pre-save confirmation, a dedicated delete-confirmation modal, standard settings and status surfaces. See `ui-surfaces.md`.
 2. **Tool loop** — Gemma as orchestrator, a small set of well-defined tools, and two main state machines (ingest + query) plus a destructive-operation mini-state-machine. See `tool-loop.md`.
-3. **RAG pipeline** — structure-aware chunking, BGE-M3 embeddings, hybrid retrieval with cross-encoder rerank and Obsidian graph boosts, stored in DuckDB. See `rag.md`.
+3. **RAG pipeline** — structure-aware chunking, BGE-M3 embeddings, hybrid retrieval with BM25 and Obsidian graph boosts. See `rag.md`.
 4. **Runtime** — plugin-managed Ollama lifecycle, `.coworkignore` for indexing scope. See `runtime.md`.
 
 The plugin reuses Obsidian's own `MetadataCache`, `Vault` events, `FileManager`, and `MarkdownRenderer` rather than reimplementing these subsystems. This is the single biggest reason to build as a plugin rather than standalone.
@@ -65,14 +65,13 @@ The plugin reuses Obsidian's own `MetadataCache`, `Vault` events, `FileManager`,
 - Ollama for local model serving (plugin spawns and manages).
 - Gemma 4 E4B for all orchestration (~3 GB).
 - BGE-M3 for embeddings (~2 GB).
-- bge-reranker-v2-m3 for rerank (~0.6 GB).
-- DuckDB with the `vss` extension for vectors and `fts` for BM25.
+- JSON metadata, binary vector files, and in-memory BM25/link indexes for the current implementation. DuckDB remains a possible future storage backend, not the shipped v0.1 storage layer.
 - MIT license.
 - Distribution: BRAT during beta, Obsidian Community Plugins at GA.
 
 ## Milestones
 
-**M1 — working local loop.** Plugin installs and manages Ollama, pulls the three required models, registers a right-sidebar chat view, and completes one end-to-end capture and ask cycle on plain text / Markdown content. Day-one acceptance tests (see below) pass.
+**M1 — working local loop.** Plugin installs and manages Ollama, verifies the required local models, registers a right-sidebar chat view, and completes one end-to-end capture and ask cycle on plain text / Markdown content. Day-one acceptance tests (see below) pass.
 
 **M2 — richer capture and full CRUD.** Dedup detection and the `ASK_USER_DEDUP` branch. `PROPOSE_APPEND`, `PROPOSE_SPLIT`, `PROPOSE_NEW_WITH_LINKS`. `delete_note` and `rename_or_move_note`. Frontmatter editing in the preview modal. Wide-mode tab layout with inline preview. Pop-out windows. `create_synthesis_note`.
 
@@ -105,7 +104,7 @@ Scripted tests that must pass before moving past M1:
 - `overview.md` — this file. MVP scope, architecture summary, milestones, doc map.
 - `tool-loop.md` — tool inventory, state machine requirements, state machines, retry policy, hard stops, intent classifier scope, prompt library.
 - `classifier.md` — intent classifier: taxonomy, input/output contract, skip conditions, confidence thresholds, disambiguation UX, evaluation.
-- `rag.md` — chunking parameters, embeddings, hybrid retrieval, reranker, DuckDB schema, frontmatter contract, cold-start vs steady-state behavior, evaluation.
+- `rag.md` — target RAG architecture, including chunking parameters, embeddings, optional reranking, DuckDB schema ideas, frontmatter contract, cold-start vs steady-state behavior, and evaluation.
 - `ui-surfaces.md` — chat view, preview modal, settings tab, status bar, ribbon, commands, context menus, notices, keyboard flow, accessibility.
 - `runtime.md` — Ollama lifecycle and `.coworkignore` semantics.
 
@@ -119,7 +118,7 @@ Future docs (not yet needed):
 - Plugin architecture on top of Obsidian (not a standalone app).
 - Desktop-only.
 - Local-only: no cloud model fallback in v1.
-- Single model set: Gemma 4 E4B + BGE-M3 + bge-reranker-v2-m3. No variants.
+- Single current model set: Gemma 4 E4B + BGE-M3. No variants.
 - Append-only body updates in v1. No full-body replacement tool.
 - Gemma can create, read, append, rename, move, and delete notes. Delete always requires an explicit, non-overridable confirmation.
 - Responsive chat view. Default to right sidebar. Pop-out to tab or OS window supported from day one.

--- a/planning/projektbeskrivning.md
+++ b/planning/projektbeskrivning.md
@@ -1,231 +1,43 @@
-# Personlig kunskapsbas — projektbeskrivning
+# Historical Project Description
 
-**DD1349 VT26 — Projektuppgift i introduktion till datalogi**
+This document is kept as historical planning context for the original DD1349 course pitch. It no longer describes the current Gemmera implementation.
 
-## Kort beskrivning
+The current product is a TypeScript Obsidian plugin with local Ollama/Gemma orchestration, incremental indexing, retrieval, write tools, citation chips, and chat history. Use these files as the authoritative planning sources:
 
-Ett Python-CLI som förvandlar en Obsidian-vault till en lokal, privat kunskapsbas driven av Gemma 4. Användaren släpper råa dokument i `raw/`, kör ett kommando som låter Gemma kompilera dem till sammanlänkade wiki-sidor med `[[wikilinks]]` och backlinks, och kan sedan ställa frågor mot sin kunskapsbas — allt utan att data lämnar datorn. Verktyget levereras med en genererad fejkperson ("Jonas Berg") som inbyggd demo-korpus så allt fungerar direkt efter kloning.
+- [README.md](../README.md) for user-facing setup and feature status.
+- [planning/overview.md](overview.md) for the current plugin architecture.
+- [planning/runtime.md](runtime.md), [planning/rag.md](rag.md), [planning/tool-loop.md](tool-loop.md), [planning/ui-surfaces.md](ui-surfaces.md), and [planning/classifier.md](classifier.md) for subsystem details.
 
-Projektet tillämpar samma säkerhets- och privacyprinciper som en fullständig Obsidian-plugin-version som planeras separat (se `planning/overview.md` för den långsiktiga arkitekturen). Denna CLI är en skalad-ned variant som kan byggas av ett par studenter på fyra veckor.
+## Original Scope
 
-## Problem vi löser
+The first course proposal was a smaller Python CLI:
 
-Andrej Karpathy beskrev ett kraftfullt mönster för personliga kunskapsbaser i en gist från april 2026, men lämnade paketering och interaktion öppet. Samtidigt använder alla befintliga implementationer externa API:er — vilket betyder att din mest personliga data skickas till Anthropic eller OpenAI. Vi bygger den version av mönstret som faktiskt kan användas för privat material: lokalt via Gemma 4, med Obsidian som gränssnitt, och gratis att köra efter installation.
+- `kb compile` would read raw files and generate Obsidian-compatible wiki pages.
+- `kb ask` would answer questions from the generated vault.
+- `kb lint` would detect contradictions, orphan pages, and unsupported claims.
+- The demo corpus would use the fictional Jonas Berg persona.
+- All inference would run locally through Ollama with no cloud fallback.
 
-## Målgrupp
+That proposal was intentionally scoped for a four-week Python course project. The repository has since moved to the fuller Obsidian plugin architecture described in the other planning documents.
 
-Personer som redan använder eller vill börja använda Obsidian för att samla anteckningar, artiklar, dagboksinlägg eller forskningsmaterial — och som vill ha AI-driven struktur och sökning utan att lämna ifrån sig sin data. Sekundärt: utvecklare som vill ha en färdigpaketerad implementation av Karpathy-mönstret att bygga vidare på.
+## Principles That Still Apply
 
-## MVP — vad som levereras i slutet av vecka 2
+- Local-first execution; no cloud fallback.
+- Markdown files remain the canonical user-owned storage.
+- Preview before writes by default.
+- Append-only body updates for v1.
+- Explicit confirmation before destructive actions.
+- MIT license.
 
-En Obsidian-vault med tre mappar:
+## Major Differences From The Current Implementation
 
-- `raw/` — råa filer som användaren lägger in
-- `wiki/` — LLM-kompilerade och sammanlänkade sidor
-- `outputs/` — svar på frågor och intermediär data
+| Original CLI proposal | Current Gemmera implementation |
+|---|---|
+| Python CLI commands | TypeScript Obsidian plugin |
+| User manually runs `kb compile` / `kb ask` | User interacts through an Obsidian chat view |
+| File-only retrieval | Hybrid retrieval with embeddings, BM25, and link-graph signals |
+| No intent classifier | Classifier routes capture, ask, mixed, and meta turns |
+| No tool loop state machines | Ingest/query/tool-loop state machines with retries and event logging |
+| User manages Ollama manually | Plugin monitors and can restart the local Ollama runtime |
 
-En CLI med tre kommandon:
-
-- `kb compile` — Gemma 4 E4B läser allt i `raw/` och bygger eller uppdaterar wiki-sidorna med Obsidian-kompatibla `[[wikilinks]]`, taggar och backlinks. Preview visas innan skrivning.
-- `kb ask "fråga"` — svarar på frågor med citat och hänvisningar till specifika wiki- och raw-filer.
-- `kb lint` — hittar motsägelser, orphan-sidor (utan inkommande länkar) och påståenden utan källa.
-
-Fejkpersonen "Jonas Berg" medföljer i repot som komplett demo-vault: dagboksinlägg, brev, bokrecensioner, projektanteckningar. Persona-datan genereras med hjälp av Claude API (engångskörning) och genereringsscriptet ingår i repot så att användare kan skapa egna personor med andra egenskaper.
-
-Obsidians inbyggda graf-vy visar automatiskt hur wiki-sidorna hänger ihop.
-
-## Säkerhetsprinciper
-
-Dessa principer är ärvda från den större plugin-planeringen och tillämpas även i denna CLI-version:
-
-- **Preview-innan-skriv är default.** `kb compile` visar alla föreslagna wiki-sidor innan filerna skrivs till disk. Användaren godkänner explicit (eller kör `--yes` för automatisk acceptans i CI).
-- **Append-only vid uppdatering.** Om en wiki-sida redan finns läggs nytt innehåll till under ett daterat avsnitt, aldrig ovanpå befintligt. Det finns ingen full-body-replace-funktion i v1.
-- **Uttrycklig bekräftelse vid radering.** Destruktiva operationer (`kb lint --prune-orphans` eller motsvarande) kräver både flagga och interaktiv y/N-prompt. Aldrig tyst radering.
-- **Lokalt, ingen cloud.** Allt inferensarbete via Ollama lokalt. Inget cloud-API-fallback i någon situation.
-- **MIT-licens** för att tillåta återanvändning och vidareutveckling.
-
-## Uttalade icke-mål
-
-- Ingen egen markdown-editor eller frontend — Obsidian är vårt gränssnitt.
-- Ingen egen graf-visualisering — vi använder Obsidians inbyggda graf-vy.
-- Ingen användarautentisering eller multi-user-stöd.
-- Ingen vektor-databas eller embeddings — vi följer Karpathys filbaserade approach. (Den fullskaliga plugin-versionen använder embeddings; denna CLI gör inte det.)
-- Ingen finjustering av modeller.
-- Ingen mobilapp (Obsidian Mobile finns redan för den som vill läsa sin vault på telefonen).
-- Ingen deploy till produktion — localhost räcker för demo.
-- Ingen Obsidian-plugin-implementation i denna kursversion (plugin-versionen är ett separat, långsiktigt projekt).
-- Inget cloud-API-fallback. Allt körs lokalt. E4B eller inget.
-- Inga större Gemma-varianter (26B MoE, 31B Dense). E4B är den enda modellen vi stödjer.
-
-## Arkitektur i korthet
-
-Systemet är tre lager:
-
-1. **Kompileringspipeline** — Gemma 4 E4B tar råa dokument, identifierar koncept, extraherar relationer, och genererar wiki-sidor med `[[wikilinks]]`. Prompt-strukturen är versionerad och JSON-schema-tvingad via Ollama `format: "json"`.
-2. **Fråge-pipeline** — Gemma E4B får råa plus wiki-sidor som kontext, svarar på frågan, och producerar svar med citat till källfiler. Citat valideras mot tillgängliga filer; hallucinerade länkar avvisas.
-3. **Vault-struktur** — plain Markdown på disk med frontmatter och Obsidian-kompatibla wikilinks. Ingen databas, ingen synk, ingen vendor lock-in.
-
-Gemma-integration sker via Ollama som körs lokalt. CLI:n antar att Ollama är installerad (lägger det som krav i installationsguiden) — till skillnad från plugin-versionen spawnar vi inte Ollama automatiskt.
-
-## Teknisk stack
-
-- Python 3.11+
-- Gemma 4 E4B lokalt via Ollama (~3 GB första gången)
-- Obsidian som gränssnitt (gratis, finns för alla plattformar)
-- Markdown-filer med Obsidian-kompatibla `[[wikilinks]]` som primär lagring
-- Typer för CLI (modernt, typsäkert, Click-kompatibelt)
-- Claude API för engångsgenerering av fejkpersonens data
-- pytest för tester
-- GitHub Actions för CI om tiden räcker
-- MIT-licens
-
-Avsiktliga avvägningar jämfört med plugin-versionen:
-
-- Ingen DuckDB eller embeddings — Karpathys filbaserade approach passar kursens tidsram.
-- Ingen reranker.
-- Ingen state machine — raka async-funktioner räcker för CLI-komplexiteten.
-- Ingen intent classifier — användaren väljer kommando explicit (`compile`, `ask`, `lint`).
-
-## Tidsplan — 4 veckor, konkret
-
-### Vecka 1: grund
-
-Dag 1–2: Repo-setup, beroenden (Typer, pytest, python-ollama-klient), CLI-skelett med tomma `kb compile`, `kb ask`, `kb lint`. `.kbignore`-format definierat (gitignore-stil).
-
-Dag 3–4: Vault-struktur bestämd (`raw/`, `wiki/`, `outputs/`). Fejkpersona "Jonas Berg" genereras via Claude API med repeterbart script. Minst 15 dokument i `raw/`.
-
-Dag 5–7: `kb compile` fungerar på ett enstaka dokument — läser en fil från `raw/`, anropar Gemma E4B via Ollama med versionerad prompt, producerar en wiki-sida med korrekta `[[wikilinks]]` efter preview-godkännande.
-
-**Acceptans vecka 1**: en användare klonar repot, följer installationsguiden, kör `kb compile` på en fil, godkänner preview, och ser en giltig wiki-sida i `wiki/` som öppnas snyggt i Obsidian.
-
-### Vecka 2: full MVP
-
-Dag 8–10: `kb compile` fungerar på hela Jonas-korpusen (ca 20 filer). Cross-referenser mellan wiki-sidor via `[[wikilinks]]`. Append-only uppdatering om en wiki-sida redan finns (under daterat avsnitt).
-
-Dag 11–12: `kb ask "fråga"` implementerad. Svar med citat till källfiler; citat valideras mot faktiska filer, hallucinerade länkar avvisas. Output skrivs till `outputs/` med tidsstämpel.
-
-Dag 13–14: `kb lint` implementerad (motsägelser, orphan-sidor, påståenden utan källa). Tester skrivna för alla tre kommandon. Destruktiva lint-operationer kräver `--confirm` + y/N-prompt.
-
-**Acceptans vecka 2**: hela Jonas-korpusen kompilerar utan fel. Minst 15 av 20 testfrågor besvaras korrekt med rätt citat. Lintern hittar minst 80% av medvetet injicerade motsägelser. Graf-vyn i Obsidian visar sammanhängande kluster.
-
-### Vecka 3: utvald utökning
-
-Vi väljer en av följande alternativ baserat på vecka-2-retrospektivet och kvarvarande tid. Valet sker vid slutet av vecka 2.
-
-**Alternativ A — Röstinmatning.** Tala in en tanke, transkriberas lokalt (whisper.cpp eller motsvarande), texten sparas som ny `raw/`-fil och vävs in vid nästa `kb compile`.
-
-**Alternativ B — Inkrementell kompilering.** Bara kompilera om det som ändrats sedan senaste körningen (content-hash per fil), istället för hela vaulten. Speedup för stora vaults.
-
-**Alternativ C — Tunn Obsidian-plugin-brygga.** Lägger till `Kompilera`- och `Fråga`-knappar i sidofältet som anropar CLI:n via IPC. Inte den fullskaliga plugin-versionen, utan en minimalbrygga för bättre demo-UX.
-
-### Vecka 4: polering och demo
-
-Dag 22–24: Utvärdering mot de 20 testfrågorna dokumenteras. Kvantitativa resultat sammanfattas. Kvalitativ analys av vilka frågor som fungerar och vilka som kollapsar.
-
-Dag 25–26: README skrivs med installationsguide (Ollama + Gemma 4 E4B pull), skärmdumpar från Obsidian inklusive graf-vyn, exempel-kommandon, troubleshooting.
-
-Dag 27–28: Demo-förberedelse: körordning, backup-plan om Ollama kraschar, förberedd scripted demo som körs offline om live-körning fallerar.
-
-**Slutacceptans**: en ny person kan klona repot, följa README, och ha `kb ask` fungerande inom 20 minuter på en typisk 8 GB-bärbar.
-
-## Acceptanstester
-
-Dessa körs manuellt vid slutet av varje vecka och automatiseras med pytest där möjligt.
-
-1. Klona repot på en ren dator, följ installationsguiden, kör `kb ask "vem är Jonas?"` och få ett meningsfullt svar med giltiga citat.
-2. Kör `kb compile` på Jonas-korpusen, öppna vaulten i Obsidian, se att graf-vyn visar sammanhängande kluster.
-3. Kör `kb lint` på en modifierad version av Jonas-korpusen där vi medvetet injicerat motsägelser — lintern flaggar minst 80% av dem.
-4. Kör `kb compile` två gånger på samma input. Andra körningen detekterar att inget ändrats och hoppar över de oförändrade filerna (kräver vecka-3 alternativ B om vi inte valt det).
-5. Avbryt `kb compile` mitt i körningen med Ctrl+C. Inga halvskrivna filer kvar i vault; eventuella pågående preview-godkännanden kastas.
-
-## Risker och motåtgärder
-
-| Risk | Sannolikhet | Påverkan | Motåtgärd |
-|---|---|---|---|
-| Gemma 4 E4B för svag för strukturerad extraktion | Medel | Hög | JSON-schema-tvingad dekodning (Ollama `format: "json"`). Förenkla extraktion-schemat om kvaliteten brister. Om fortfarande otillräckligt efter vecka 1 — utvärdera en större lokal modell, men håll fast vid inget cloud-fallback. |
-| Hallucinerade wikilinks till sidor som inte finns | Hög | Medel | Validera alla `[[wikilinks]]` i output mot befintliga filer. Okända länkar markeras som förslag i preview, inte auto-skrivs. |
-| Ollama installationsfriktion för testare | Medel | Medel | Installationsguide för macOS, Linux, Windows. Första-gången-script som verifierar Ollama och modell-pull innan första `kb compile`. |
-| 4-veckors tidsram är knapp | Medel | Hög | Vecka 3-utökningen är optional — MVP levereras vid slutet av vecka 2. Vecka 4 är alltid polering oavsett vecka-3-resultat. |
-| Persona-generering kostar för mycket Claude API-kredit | Låg | Låg | Engångskörning, ca 50 Claude-anrop totalt. Cachad output i repot så att kloning inte triggar ny generering. |
-| Testfrågor för lätta eller för svåra | Medel | Medel | Iterera på frågesetet efter första körningen. Balansera svårighetsgrad mellan direkta fakta och flerstegsslutsatser. |
-| Gemma-pull på 3 GB tar tid på svag uppkoppling | Låg | Låg | Förvarna i installationsguiden. Erbjud kachad tar.gz-backup för demo-datorer. |
-
-## Beslut som är fastslagna
-
-- Python CLI, inte Obsidian-plugin, i denna kursversion.
-- Gemma 4 E4B som enda modell. Ingen 26B MoE, 31B Dense, eller annan variant.
-- Ollama som lokal runtime. Användaren installerar själv; CLI:n spawnar inte Ollama.
-- Filbaserad approach (Karpathy-mönstret). Ingen DuckDB, ingen embeddings, ingen reranker.
-- Append-only uppdateringar av wiki-sidor. Ingen full-body-replace-funktion.
-- Preview-innan-skriv som default för `kb compile`.
-- Radering kräver explicit `--confirm` plus interaktiv y/N-bekräftelse.
-- Inget cloud-API-fallback någonsin.
-- MIT-licens.
-- Typer för CLI.
-- pytest för tester.
-
-## Öppna frågor (parkerade, inte blockerande)
-
-- Exakt prompt-formulering för kompileringspipeline och frågebesvaring — skrivs under vecka 1.
-- Valet av vecka-3-utökning (A/B/C) — sker efter vecka-2-retrospektiv.
-- Om whisper.cpp eller något annat är rätt val för röstinmatning (alternativ A) — utreds innan beslutet.
-- Vilken version av Ollama vi ska kräva som minimum i installationsguiden — bestäms när vi verifierat API-stabiliteten.
-
-## Utvärdering
-
-Vi skriver 20 förberedda frågor om Jonas med kända svar (till exempel "när träffade han senast sin bror?", "vilka böcker läste han i januari?") och mäter hur ofta systemet svarar korrekt. Vi dokumenterar även vilka typer av frågor som fungerar bra och vilka som kollapsar.
-
-Lintern utvärderas genom att medvetet injicera motsägelser i Jonas data och mäta hur stor andel som upptäcks.
-
-Vi utvärderar också kvaliteten på de genererade wikilinks — hur ofta länkar de rätt, och hur användbar blir graf-vyn i Obsidian?
-
-Mätvärden i slutrapporten:
-
-- **Svarsandel**: andel av de 20 frågorna som besvaras korrekt.
-- **Citat-korrekthet**: andel svar där citaten faktiskt backar upp påståendet.
-- **Lint precision och recall** på injicerade motsägelser.
-- **Wikilink-kvalitet**: andel länkar som pekar på rätt sida.
-- **Körtid**: `kb compile` på hela korpusen (P50 och P95), `kb ask` per fråga.
-
-## Vår egen edge
-
-Karpathy beskrev ett datamönster, inte en produkt. Vi paketerar mönstret på tre avgörande sätt:
-
-1. **Lokalt via Gemma 4 E4B** — ingen data lämnar din dator, vilket är hela poängen med en "personlig" kunskapsbas. Privacy-vinkeln är vårt starkaste argument.
-2. **Obsidian som gränssnitt** — istället för att bygga en egen frontend utnyttjar vi ett verktyg som miljontals redan använder. Graf-vy, backlinks, sökning och taggning kommer gratis. Vi fokuserar på det AI:n gör, inte på att bygga UI.
-3. **Inbyggd demo-persona som gör att verktyget fungerar direkt efter kloning.** Öppna vaulten i Obsidian, kör ett kommando, klar. Genereringsscriptet låter vem som helst skapa sin egen fejkperson.
-
-## Teamupplägg
-
-Par-projekt. Vi delar upp arbetet så att båda kan förklara alla delar.
-
-- **Person A** fokuserar primärt på kompileringspipelinen och LLM-prompting (hur Gemma 4 extraherar koncept och skapar wikilinks).
-- **Person B** fokuserar primärt på CLI-ergonomi, vault-struktur och fejkpersona-generering.
-
-Varje vecka roterar den som driver review-cykeln (öppnar pull requests, granskar den andres PR). Båda deltar i planeringen varje vecka.
-
-## Planerade utökningar om tid finns (utöver vecka 3)
-
-- **Auto-taggning** och upptäckt av duplicerade koncept mellan wiki-sidor.
-- **Import av webbartiklar** via Obsidian Web Clipper direkt till `raw/`.
-- **CI med GitHub Actions** som kör pytest på varje push om det inte hunnits med under vecka 1.
-
-## Koppling till den större plugin-planeringen
-
-Denna CLI är en bantad version av en större Obsidian-plugin-arkitektur som planeras separat i `planning/overview.md`. Principer som delas:
-
-- Lokalt först, ingen cloud-fallback.
-- Gemma 4 E4B som enda modell.
-- Obsidian som långsiktig lagring (bara Markdown på disk).
-- Preview-innan-skriv, append-only, uttrycklig bekräftelse vid radering.
-- MIT-licens.
-
-Skillnader från plugin-versionen:
-
-- CLI istället för Obsidian-plugin — kursen är i Python, och fyra veckor räcker inte för en fullständig TypeScript-plugin.
-- Filbaserad retrieval (Karpathy-mönstret) istället för DuckDB + embeddings + reranker.
-- Raka async-funktioner istället för state machines.
-- Ingen intent classifier — användaren väljer kommando explicit.
-- Användaren installerar Ollama själv istället för att plugin:en spawnar det.
-
-Plugin-versionen är ett separat, långsiktigt projekt. Denna kurs är ett första steg på vägen och validerar kärnprinciperna i en mindre, snabbare form.
+This file should not be used to decide new implementation work. Treat it as an archived snapshot of the early concept.


### PR DESCRIPTION
## What

- Updates README development status and test counts.
- Converts remaining Swedish README sections to English.
- Removes current-implementation claims for the unimplemented reranker requirement.
- Aligns `planning/overview.md` with the current JSON/binary/in-memory storage implementation.
- Replaces the old Swedish CLI course proposal with an English archived summary that points to the current plugin planning docs.

## Why

The docs had drifted from the actual TypeScript Obsidian plugin implementation and still described pieces such as DuckDB-backed storage and required reranker setup as if they were already shipped.

Closes #147

## How to test

- `npm test`
- `npm run build`
- Checked README/planning docs for the Swedish sections called out in #147.
