### PR TITLE
feat(tools): gate schemas by route intent

### DIFF
--- a/src/services/tool-dispatcher.test.ts
+++ b/src/services/tool-dispatcher.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
+import type { RouteDecision } from "../contracts";
 import { MockVaultService } from "../contracts/mocks/mock-vault";
-import { dispatchToolCall, appendUnderDatedSection, patchFrontmatter, type ToolDispatchDeps } from "./tool-dispatcher";
+import {
+  ALL_TOOLS,
+  READ_TOOLS,
+  WRITE_TOOLS,
+  appendUnderDatedSection,
+  dispatchToolCall,
+  patchFrontmatter,
+  selectToolsForIntent,
+  type ToolDispatchDeps,
+} from "./tool-dispatcher";
 import { InMemoryJobQueue } from "./in-memory-job-queue";
 import { IngestWriter } from "./ingest-writer";
 
@@ -32,6 +42,48 @@ const fullConfirm = {
   status: "inbox" as const,
   summary: "Notes on dogs.",
 };
+
+function toolNames(tools: readonly { name: string }[]): string[] {
+  return tools.map((tool) => tool.name);
+}
+
+function selectionRoute(
+  overrides: Partial<Pick<RouteDecision, "needsDisambiguation">> & {
+    fallbackReason?: RouteDecision["decision"]["fallbackReason"];
+  } = {},
+): { needsDisambiguation: boolean; decision: Pick<RouteDecision["decision"], "fallbackReason"> } {
+  return {
+    needsDisambiguation: overrides.needsDisambiguation ?? false,
+    decision: { fallbackReason: overrides.fallbackReason ?? null },
+  };
+}
+
+describe("selectToolsForIntent", () => {
+  it("selects read tools for ask turns", () => {
+    expect(toolNames(selectToolsForIntent("ask"))).toEqual(toolNames(READ_TOOLS));
+  });
+
+  it("selects write tools for capture turns", () => {
+    expect(toolNames(selectToolsForIntent("capture"))).toEqual(toolNames(WRITE_TOOLS));
+  });
+
+  it("selects read and write tools for mixed turns", () => {
+    expect(toolNames(selectToolsForIntent("mixed"))).toEqual(toolNames(ALL_TOOLS));
+  });
+
+  it("withholds tools for meta and unknown routes", () => {
+    expect(selectToolsForIntent("meta")).toEqual([]);
+    expect(selectToolsForIntent(null)).toEqual([]);
+  });
+
+  it("withholds tools while the route needs disambiguation", () => {
+    expect(selectToolsForIntent("ask", selectionRoute({ needsDisambiguation: true }))).toEqual([]);
+  });
+
+  it("withholds tools after classifier fallbacks", () => {
+    expect(selectToolsForIntent("capture", selectionRoute({ fallbackReason: "unparseable" }))).toEqual([]);
+  });
+});
 
 describe("dispatchToolCall — routing", () => {
   it("routes save_note with mode=create to save handler", async () => {

--- a/src/services/tool-dispatcher.ts
+++ b/src/services/tool-dispatcher.ts
@@ -1,9 +1,12 @@
 import type {
+  ClassifierDecision,
   IndexService,
+  IntentLabel,
   JobQueue,
   LLMToolCall,
   LinksIndex,
   NoteSpec,
+  Tool,
   VaultService,
 } from "../contracts";
 import { composeFile, type IngestWriter } from "./ingest-writer";
@@ -41,6 +44,41 @@ export type ToolResult =
   | { kind: "done"; summary: string; citations?: string[] }
   | { kind: "cancelled"; message: string }
   | { kind: "unknown_tool" };
+
+export interface ToolSelectionRoute {
+  needsDisambiguation?: boolean;
+  decision?: Pick<ClassifierDecision, "fallbackReason">;
+}
+
+/**
+ * Selects the tool schemas to pass to the LLM for a given intent.
+ *
+ * Currently called only from `runChat` (the meta / fallback path). The ask,
+ * capture, and mixed intents route through their own orchestrators
+ * (runAsk / runCapture / runMixed) which do not call llm.chat with tools,
+ * so those branches are ready for a future unified turn runner.
+ */
+export function selectToolsForIntent(
+  intent: IntentLabel | null | undefined,
+  route?: ToolSelectionRoute | null,
+): Tool[] {
+  if (route?.needsDisambiguation || route?.decision?.fallbackReason) {
+    return [];
+  }
+
+  switch (intent) {
+    case "ask":
+      return [...READ_TOOLS];
+    case "capture":
+      return [...WRITE_TOOLS];
+    case "mixed":
+      return [...ALL_TOOLS];
+    case "meta":
+      return [];
+    default:
+      return [];
+  }
+}
 
 export async function dispatchToolCall(
   call: LLMToolCall,

--- a/src/view.ts
+++ b/src/view.ts
@@ -13,7 +13,7 @@ import { runMixed } from "./services/mixed-orchestrator";
 import { runQuery } from "./services/query-orchestrator";
 import { isAbortError, StreamingState } from "./services/streaming-state";
 import { createSynthesisNote } from "./services/synthesis-writer";
-import { dispatchToolCall, ALL_TOOLS, type ToolDispatchDeps } from "./services/tool-dispatcher";
+import { dispatchToolCall, selectToolsForIntent, type ToolDispatchDeps } from "./services/tool-dispatcher";
 import { DisambiguationChip } from "./disambiguation-chip";
 import { IndexingPill } from "./ui/indexing-pill";
 import { openIngestPreview } from "./ui/ingest-preview-modal";
@@ -580,7 +580,7 @@ export class GemmeraChatView extends ItemView {
       const reply = await this.services.llm.chat({
         model: this.settings.chatModel,
         messages,
-        tools: [...ALL_TOOLS],
+        tools: selectToolsForIntent(intent, route),
         signal,
         onToken: (token) => {
           textEl.textContent += token;


### PR DESCRIPTION
## What
- Adds a route-aware tool schema selector.
- Sends read tools for ask turns, write tools for capture turns, and both tool sets for mixed turns.
- Withholds tools for meta, unknown, disambiguation, and classifier fallback routes.
- Adds focused tests for tool selection behavior.

## Why
Gemma should not spend prompt budget on tool schemas that cannot be relevant to the selected route. Unknown or low-confidence routes stay conservative until the user-visible route decision is resolved.

Closes #149

## How to test
- npm test -- --run src/services/tool-dispatcher.test.ts src/view.test.ts
- npm test
- npm run build
- npm run eval:retrieval:ci
- npm run eval:classifier:ci (currently fails on dev because #150 is not merged yet; #156 fixes the six existing classifier golden failures)
- npx tsc --noEmit (currently blocked on dev by #146; #154 fixes the NotePreviewModal Component owner issue)
