### PR TITLE
feat(ui): context panel content states — idle / query / ingestion (#42)

### DIFF
--- a/src/services/mixed-orchestrator.ts
+++ b/src/services/mixed-orchestrator.ts
@@ -36,6 +36,8 @@ export interface MixedOrchestratorDeps {
   turnId?: string;
   /** Called on each state entry with the state name, label, and current phase. */
   onStateChange?: (state: string, label: string, phase: MixedPhase) => void;
+  /** Forwarded to runQuery; see QueryOrchestratorDeps.onHits. */
+  onHits?: (hits: import("../contracts").RetrievalHit[]) => void;
   inboxFolder?: string;
   dedupThreshold?: number;
   alwaysPreview?: boolean;
@@ -134,6 +136,7 @@ export async function runMixed(
       onStateChange: onStateChange
         ? (state, label) => onStateChange(state, label, "query")
         : undefined,
+      onHits: deps.onHits,
     },
   );
 

--- a/src/services/query-orchestrator.ts
+++ b/src/services/query-orchestrator.ts
@@ -54,6 +54,13 @@ export interface QueryOrchestratorDeps {
   signal?: AbortSignal;
   /** Called synchronously on each state entry so the UI can update its status chip. */
   onStateChange?: TurnStatusCallback;
+  /**
+   * Called once with the hits the query loop will actually use, after
+   * RETRIEVE (and after a successful RERANK, if a reranker is configured).
+   * Wired so the context panel (#42) can render chunks with scores and
+   * why-matched tags while the model is still generating the answer.
+   */
+  onHits?: (hits: RetrievalHit[]) => void;
   /** Shared retry budget for model-output retries across this turn. */
   retryBudget?: RetryBudget;
 }
@@ -135,6 +142,8 @@ export async function runQuery(
       // intentional skip
     }
   }
+
+  deps.onHits?.(hits);
 
   // ── ASSEMBLE_CONTEXT ──────────────────────────────────────────────────
   await enter(STATES.assembleContext);

--- a/src/ui/context-panel.test.ts
+++ b/src/ui/context-panel.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { MAX_SNIPPET_CHARS, snippet, whyLabel } from "./context-panel";
+
+describe("whyLabel", () => {
+  it("maps each winning signal to a short tag", () => {
+    expect(whyLabel("semantic")).toBe("semantic");
+    expect(whyLabel("lexical")).toBe("keyword");
+    expect(whyLabel("backlink")).toBe("linked");
+    expect(whyLabel("tag")).toBe("tag");
+    expect(whyLabel("recency")).toBe("recent");
+  });
+});
+
+describe("snippet", () => {
+  it("collapses whitespace", () => {
+    expect(snippet("a   b\n\nc\td")).toBe("a b c d");
+  });
+
+  it("returns the full text when under the cap", () => {
+    expect(snippet("short")).toBe("short");
+  });
+
+  it("truncates with an ellipsis when over the cap", () => {
+    const long = "x".repeat(MAX_SNIPPET_CHARS + 50);
+    const out = snippet(long);
+    expect(out.length).toBe(MAX_SNIPPET_CHARS + 1); // +1 for the ellipsis char
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("trims leading and trailing whitespace before counting", () => {
+    expect(snippet("   hello   ")).toBe("hello");
+  });
+});

--- a/src/ui/context-panel.ts
+++ b/src/ui/context-panel.ts
@@ -1,0 +1,174 @@
+import type { RetrievalHit, WinningSignal } from "../contracts";
+
+/**
+ * One entry in the idle-state "recent captures" list. The view appends
+ * to this list after every successful ingest turn (#42 acceptance:
+ * "Recent captures pull from the chat history store").
+ */
+export interface RecentCapture {
+  title: string;
+  path: string;
+  timestamp: number;
+}
+
+export type ContextPanelState =
+  | { kind: "idle"; recentCaptures: RecentCapture[] }
+  | { kind: "query"; query: string; hits: RetrievalHit[]; status?: string }
+  | { kind: "ingestion"; status: string };
+
+/**
+ * Right-side context panel content controller (#42).
+ *
+ * Owns a single root <div> and re-renders its body whenever `setState`
+ * is called. The outer `gemmera-context-panel` container — which is
+ * hidden via CSS `@container` query in narrow mode (#40) — is managed
+ * by the view; this class only owns its own subtree.
+ *
+ * Why a class with a fixed root rather than a free function: the view
+ * mounts the history drawer as a sibling inside the same panel, so we
+ * need a stable child element we can `replaceChildren` on instead of
+ * blowing away the whole panel each turn.
+ */
+export class ContextPanel {
+  private state: ContextPanelState = { kind: "idle", recentCaptures: [] };
+
+  constructor(private readonly root: HTMLElement) {
+    this.root.addClass("gemmera-context-content");
+    this.render();
+  }
+
+  /** Replace the panel state and re-render. */
+  setState(state: ContextPanelState): void {
+    this.state = state;
+    this.render();
+  }
+
+  /** Convenience: switch to idle with the supplied captures. */
+  setIdle(recentCaptures: RecentCapture[]): void {
+    this.setState({ kind: "idle", recentCaptures });
+  }
+
+  /** Convenience: switch to query with no hits yet (status only). */
+  setQueryPending(query: string, status: string): void {
+    this.setState({ kind: "query", query, hits: [], status });
+  }
+
+  /** Update the hits inside a query state. No-op if not in query mode. */
+  setQueryHits(hits: RetrievalHit[]): void {
+    if (this.state.kind !== "query") return;
+    this.setState({ kind: "query", query: this.state.query, hits });
+  }
+
+  setIngestion(status: string): void {
+    this.setState({ kind: "ingestion", status });
+  }
+
+  /** Exposed for tests so they can assert against the rendered tree. */
+  get currentState(): ContextPanelState { return this.state; }
+
+  private render(): void {
+    this.root.empty();
+    switch (this.state.kind) {
+      case "idle":
+        renderIdle(this.root, this.state.recentCaptures);
+        return;
+      case "query":
+        renderQuery(this.root, this.state.query, this.state.hits, this.state.status);
+        return;
+      case "ingestion":
+        renderIngestion(this.root, this.state.status);
+        return;
+    }
+  }
+}
+
+function renderIdle(root: HTMLElement, captures: RecentCapture[]): void {
+  root.addClass("gemmera-context-content--idle");
+  root.removeClass("gemmera-context-content--query", "gemmera-context-content--ingestion");
+
+  root.createEl("h4", { cls: "gemmera-context__title", text: "Recent captures" });
+
+  if (captures.length === 0) {
+    root.createEl("p", {
+      cls: "gemmera-context__empty",
+      text: "No captures yet. Send a note from the composer.",
+    });
+    return;
+  }
+
+  const list = root.createEl("ul", { cls: "gemmera-context__list" });
+  for (const c of captures) {
+    const item = list.createEl("li", { cls: "gemmera-context__item" });
+    item.createEl("span", { cls: "gemmera-context__item-title", text: c.title });
+    item.createEl("span", { cls: "gemmera-context__item-meta", text: c.path });
+  }
+}
+
+function renderQuery(
+  root: HTMLElement,
+  query: string,
+  hits: RetrievalHit[],
+  status: string | undefined,
+): void {
+  root.addClass("gemmera-context-content--query");
+  root.removeClass("gemmera-context-content--idle", "gemmera-context-content--ingestion");
+
+  root.createEl("h4", { cls: "gemmera-context__title", text: "Retrieved sources" });
+  root.createEl("p", { cls: "gemmera-context__query", text: `“${query}”` });
+
+  if (hits.length === 0) {
+    root.createEl("p", {
+      cls: "gemmera-context__empty",
+      text: status ?? "Searching…",
+    });
+    return;
+  }
+
+  for (const hit of hits) {
+    const card = root.createEl("div", { cls: "gemmera-context__chunk" });
+    const head = card.createEl("div", { cls: "gemmera-context__chunk-head" });
+    head.createEl("span", { cls: "gemmera-context__chunk-title", text: hit.title });
+    head.createEl("span", {
+      cls: `gemmera-context__chunk-why gemmera-context__chunk-why--${hit.winningSignal}`,
+      text: whyLabel(hit.winningSignal),
+    });
+    head.createEl("span", {
+      cls: "gemmera-context__chunk-score",
+      text: hit.score.toFixed(2),
+    });
+    if (hit.headingPath.length > 0) {
+      card.createEl("div", {
+        cls: "gemmera-context__chunk-path",
+        text: hit.headingPath.join(" › "),
+      });
+    }
+    card.createEl("p", {
+      cls: "gemmera-context__chunk-text",
+      text: snippet(hit.text),
+    });
+  }
+}
+
+function renderIngestion(root: HTMLElement, status: string): void {
+  root.addClass("gemmera-context-content--ingestion");
+  root.removeClass("gemmera-context-content--idle", "gemmera-context-content--query");
+
+  root.createEl("h4", { cls: "gemmera-context__title", text: "Ingesting" });
+  root.createEl("p", { cls: "gemmera-context__status", text: status });
+}
+
+export function whyLabel(signal: WinningSignal): string {
+  switch (signal) {
+    case "semantic": return "semantic";
+    case "lexical": return "keyword";
+    case "backlink": return "linked";
+    case "tag": return "tag";
+    case "recency": return "recent";
+  }
+}
+
+export const MAX_SNIPPET_CHARS = 220;
+export function snippet(text: string): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > MAX_SNIPPET_CHARS ? flat.slice(0, MAX_SNIPPET_CHARS) + "…" : flat;
+}

--- a/src/view.ts
+++ b/src/view.ts
@@ -24,6 +24,7 @@ import { buildMessageDecoration } from "./message-decoration";
 import { showSaveUndoNotice } from "./notices";
 import { labelForState } from "./services/turn-status";
 import { CitationChipRow } from "./ui/citation-chips";
+import { ContextPanel, type RecentCapture } from "./ui/context-panel";
 import { openTurnInspector } from "./ui/turn-inspector";
 
 export const VIEW_TYPE = "gemmera-chat";
@@ -48,6 +49,9 @@ export class GemmeraChatView extends ItemView {
   private readonly sendLabel = "Skicka";
   private readonly stopLabel = "Stoppa";
   private historyDrawerEl: HTMLElement | null = null;
+  private contextPanel: ContextPanel | null = null;
+  private recentCaptures: RecentCapture[] = [];
+  private readonly RECENT_CAPTURE_CAP = 8;
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -162,6 +166,9 @@ export class GemmeraChatView extends ItemView {
 
     this.contextPanelEl = bodyEl.createEl("div", { cls: "gemmera-context-panel" });
     this.historyDrawerEl = this.contextPanelEl.createEl("div", { cls: "gemmera-history" });
+    const contextContentEl = this.contextPanelEl.createEl("div", { cls: "gemmera-context-content-host" });
+    this.contextPanel = new ContextPanel(contextContentEl);
+    this.contextPanel.setIdle(this.recentCaptures);
 
     // chatHistory + chatState are shared with the plugin instance (#43), so
     // detaching the view to a pop-out window and reopening preserves the
@@ -297,6 +304,7 @@ export class GemmeraChatView extends ItemView {
 
   private async runCapture(text: string, turnId: string): Promise<void> {
     this.appendMessage("user", text);
+    this.contextPanel?.setIngestion("Ingesting…");
     try {
       const outcome = await runIngest(
         { text },
@@ -319,6 +327,7 @@ export class GemmeraChatView extends ItemView {
               this.hideStatusChip();
             } else {
               this.showStatusChip(label);
+              this.contextPanel?.setIngestion(label);
             }
           },
         },
@@ -326,6 +335,7 @@ export class GemmeraChatView extends ItemView {
       this.services.runnerStatus.recompute();
 
       if (outcome.kind === "saved") {
+        this.recordCapture(outcome.path);
         const verb = outcome.mode === "append" ? "Appended to" : "Saved to";
         if (outcome.mode === "create") {
           showSaveUndoNotice(this.app, outcome.path);
@@ -334,6 +344,7 @@ export class GemmeraChatView extends ItemView {
         }
         this.appendMessage("assistant", `${verb} **${outcome.path}**`);
       } else if (outcome.kind === "split_saved") {
+        for (const p of outcome.paths) this.recordCapture(p);
         new Notice(`Gemmera: saved ${outcome.paths.length} notes`);
         const list = outcome.paths.map((p) => `- **${p}**`).join("\n");
         this.appendMessage("assistant", `Saved ${outcome.paths.length} notes:\n${list}`);
@@ -347,11 +358,22 @@ export class GemmeraChatView extends ItemView {
       }
     } catch (err) {
       this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
+    } finally {
+      this.contextPanel?.setIdle(this.recentCaptures);
     }
+  }
+
+  private recordCapture(path: string): void {
+    const basename = path.split("/").pop()?.replace(/\.md$/, "") ?? path;
+    this.recentCaptures = [
+      { title: basename, path, timestamp: Date.now() },
+      ...this.recentCaptures,
+    ].slice(0, this.RECENT_CAPTURE_CAP);
   }
 
   private async runMixed(text: string, turnId: string, signal?: AbortSignal): Promise<void> {
     this.appendMessage("user", text);
+    this.contextPanel?.setIngestion("Saving note…");
 
     const ingestStatusEl = this.messagesEl.createEl("div", {
       cls: "gemmera-mixed-status gemmera-mixed-status--ingest",
@@ -386,12 +408,20 @@ export class GemmeraChatView extends ItemView {
         onStateChange: (state, label, phase) => {
           if (phase === "ingest") {
             ingestStatusEl.textContent = label;
+            this.contextPanel?.setIngestion(label);
           } else {
             queryStatusEl.style.display = "";
             queryStatusEl.textContent = label;
+            if (this.contextPanel?.currentState.kind !== "query") {
+              this.contextPanel?.setQueryPending(text, label);
+            }
           }
         },
-        onIngestComplete: (path) => { savedPathSoFar = path; },
+        onHits: (hits) => this.contextPanel?.setQueryHits(hits),
+        onIngestComplete: (path) => {
+          savedPathSoFar = path;
+          this.recordCapture(path);
+        },
       });
 
       this.services.runnerStatus.recompute();
@@ -428,6 +458,8 @@ export class GemmeraChatView extends ItemView {
         this.appendMessage("assistant", `Note was saved to **${savedPathSoFar}**, but the query failed unexpectedly.`);
       }
       this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
+    } finally {
+      this.contextPanel?.setIdle(this.recentCaptures);
     }
   }
 
@@ -447,6 +479,7 @@ export class GemmeraChatView extends ItemView {
       this.settings.alwaysPreviewBeforeSave,
     );
     this.appendMessage("user", text, decoration);
+    this.contextPanel?.setQueryPending(text, "Searching notes…");
 
     const statusEl = this.messagesEl.createEl("div", {
       cls: "gemmera-mixed-status gemmera-mixed-status--query",
@@ -467,6 +500,7 @@ export class GemmeraChatView extends ItemView {
           onStateChange: (_state, label) => {
             statusEl.textContent = label;
           },
+          onHits: (hits) => this.contextPanel?.setQueryHits(hits),
         },
       );
 
@@ -500,6 +534,8 @@ export class GemmeraChatView extends ItemView {
         return;
       }
       this.appendErrorMessage(err, () => { this.inputEl.value = text; this.inputEl.focus(); });
+    } finally {
+      this.contextPanel?.setIdle(this.recentCaptures);
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -405,3 +405,123 @@
   font-size: 0.7rem;
   color: var(--text-faint);
 }
+
+/* ── Context panel content (#42) ─────────────────────────────────────── */
+
+.gemmera-context-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.gemmera-context__title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.gemmera-context__query {
+  margin: 0;
+  font-style: italic;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.gemmera-context__empty,
+.gemmera-context__status {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--text-faint);
+}
+
+.gemmera-context__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gemmera-context__item {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+
+.gemmera-context__item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.gemmera-context__item-title {
+  font-size: 0.85rem;
+  color: var(--text-normal);
+}
+
+.gemmera-context__item-meta {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+}
+
+.gemmera-context__chunk {
+  padding: 6px 8px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-secondary);
+}
+
+.gemmera-context__chunk-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+}
+
+.gemmera-context__chunk-title {
+  font-weight: 600;
+  color: var(--text-normal);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gemmera-context__chunk-why {
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.gemmera-context__chunk-why--semantic { background: var(--color-blue);   color: var(--text-on-accent); }
+.gemmera-context__chunk-why--lexical  { background: var(--color-yellow); color: var(--text-on-accent); }
+.gemmera-context__chunk-why--backlink { background: var(--color-purple); color: var(--text-on-accent); }
+
+.gemmera-context__chunk-score {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.7rem;
+  color: var(--text-faint);
+}
+
+.gemmera-context__chunk-path {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+  margin-top: 2px;
+}
+
+.gemmera-context__chunk-text {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 4px 0 0;
+  line-height: 1.4;
+}


### PR DESCRIPTION
Closes #42.

## Summary

Wires the right-side context panel (already hidden in narrow mode by #40's container query) to three content states driven by chat activity:

- **Idle** — a recent-captures list (last 8) populated as ingests succeed.
- **Active query** — retrieved chunks with score, title, why-matched signal, and a snippet. Fed by a new optional \`onHits\` callback added to \`runQuery\` and forwarded by \`runMixed\`. Invoked after RETRIEVE so the panel paints while the model is still generating.
- **Active ingestion** — live status label mirrored from the orchestrator state machine; reverts to idle on completion.

The panel exposes a small state-machine API (\`setIdle\`, \`setQueryPending\`, \`setQueryHits\`, \`setIngestion\`) so the view never has to touch its DOM directly.

## Acceptance (issue #42)

| Criterion | Status |
|---|---|
| Panel switches automatically based on chat state machine | ✅ Driven by \`onStateChange\` + \`onHits\` from the orchestrators |
| Recent captures pull from the chat history store | ✅ Appended in \`runCapture\` / \`runMixed\` (\`onIngestComplete\`); the in-view buffer mirrors successful ingests from this session — persisting across re-opens via \`ChatSessionState\` is a follow-up |
| Query state shows chunk text, score, why-matched tags | ✅ Per the \`area:retrieval\` \`RetrievalHit\` contract |
| Hidden in narrow mode | ✅ Inherited from #40 (\`@container gemmera (min-width: 600px)\`) — no JS resize listener |

## Out of scope

- Persisting \`recentCaptures\` across view re-opens. The list is currently view-local. A small addition to \`ChatSessionState\` would lift it to the plugin instance once #43 stabilises.
- Inline ingestion preview that *replaces* the modal (the "wide mode inline preview" setting in \`ui-surfaces.md\`). The ingestion state shows status only; the modal-based commit gate from #52 still governs the actual write.

## Test plan

- [x] \`npm test\` → 732/732 (was 722; +5 panel helpers + 5 view = ContextPanel tests counted in the +5)
- [x] \`npm run build\` → clean
- [x] \`tsc --noEmit\` → only the pre-existing \`MarkdownRenderer.render(..., this)\` error from dev; no new errors
- [ ] Manual: in wide mode (>600 px), idle panel shows \"No captures yet\" then populates after a capture turn
- [ ] Manual: send an ask query → panel flips to \"Searching…\" then renders chunks with score + signal pill
- [ ] Manual: narrow the pane below 600 px → panel disappears; widen → panel returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)