### PR TITLE
fix(chat): post-merge polish for #46 + #43 reviews

### DIFF
--- a/src/services/chat-history.ts
+++ b/src/services/chat-history.ts
@@ -82,6 +82,12 @@ export class ChatHistoryStore {
    * Rename a session. Returns the updated session, or `null` if the session
    * doesn't exist or the title is empty/whitespace. Long titles are clamped
    * to 200 chars so the drawer doesn't overflow. #43.
+   *
+   * NOTE: rename intentionally bumps `updatedAt`, which moves the chat to
+   * the top of `listSessions()`. The renamed chat is "recently touched."
+   * If a user is organizing old chats, expecting them to stay in place,
+   * surface this — the UI re-orders. The ordering test pins the behavior;
+   * any change here also requires updating that test. #152 review.
    */
   async renameSession(id: string, title: string): Promise<ChatSession | null> {
     const trimmed = title.trim();

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,4 +1,4 @@
-import { Notice, PluginSettingTab, Setting, type App, type Plugin } from "obsidian";
+import { Notice, PluginSettingTab, Setting, type App, type Plugin, type TextComponent } from "obsidian";
 import type { DriftReport, IngestionStore } from "../contracts";
 import { HARD_STOPS } from "../contracts/hard-stops";
 import type { OllamaLifecycle } from "../services/ollama-lifecycle";
@@ -214,9 +214,13 @@ export class GemmeraSettingsTab extends PluginSettingTab {
       .setDesc(
         "Drop chats older than this many days. 0 = unlimited (default). Takes effect on the next prune (chat open).",
       )
-      .addText((text: { setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown; setPlaceholder?: (s: string) => unknown }) => {
-        text.setPlaceholder?.("0");
+      .addText((text: TextComponent) => {
+        text.setPlaceholder("0");
         text.setValue(String(this.settings.chatRetentionMaxDays));
+        // type="number" min="0" gives browser-native clamp + spinner so
+        // a typo can't silently coerce to 0 (= unlimited). #152 review.
+        text.inputEl.type = "number";
+        text.inputEl.min = "0";
         text.onChange(async (value: string) => {
           const n = parseInt(value, 10);
           this.settings.chatRetentionMaxDays = Number.isFinite(n) && n >= 0 ? n : 0;
@@ -229,9 +233,11 @@ export class GemmeraSettingsTab extends PluginSettingTab {
       .setDesc(
         "Keep at most N chats; oldest pruned first. 0 = unlimited (default). Takes effect on the next prune (chat open).",
       )
-      .addText((text: { setValue: (v: string) => unknown; onChange: (cb: (v: string) => void) => unknown; setPlaceholder?: (s: string) => unknown }) => {
-        text.setPlaceholder?.("0");
+      .addText((text: TextComponent) => {
+        text.setPlaceholder("0");
         text.setValue(String(this.settings.chatRetentionMaxSessions));
+        text.inputEl.type = "number";
+        text.inputEl.min = "0";
         text.onChange(async (value: string) => {
           const n = parseInt(value, 10);
           this.settings.chatRetentionMaxSessions = Number.isFinite(n) && n >= 0 ? n : 0;

--- a/src/view.ts
+++ b/src/view.ts
@@ -166,6 +166,12 @@ export class GemmeraChatView extends ItemView {
     // chatHistory + chatState are shared with the plugin instance (#43), so
     // detaching the view to a pop-out window and reopening preserves the
     // live conversation. Replay any buffered turns into the new DOM.
+    //
+    // KNOWN LIMITATION (#152 review): replay is text-only. Route chips,
+    // classifier-decision badges, silent-save indicators, and citation
+    // chips are dropped on pop-out. Restoring them needs decorations
+    // stored alongside each turn in ChatSessionState — follow-up.
+    // Conversation continuity is preserved; visual polish is not.
     for (const turn of this.history) {
       this.appendMessage(turn.role === "user" ? "user" : "assistant", turn.content);
     }
@@ -727,17 +733,30 @@ export class GemmeraChatView extends ItemView {
       titleEl.setText(original);
     };
 
-    titleEl.addEventListener("blur", () => { void commit(); }, { once: true });
-    titleEl.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        titleEl.blur();
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        cancel();
-        titleEl.blur();
-      }
-    });
+    // Tie both listeners to one AbortController so commit/cancel guarantees
+    // the keydown handler is removed too. Without this, dblclick → Escape →
+    // dblclick on the same node would stack a second keydown handler since
+    // the node isn't rebuilt until renderHistoryDrawer runs. #152 review.
+    const ac = new AbortController();
+    titleEl.addEventListener(
+      "blur",
+      () => { ac.abort(); void commit(); },
+      { once: true },
+    );
+    titleEl.addEventListener(
+      "keydown",
+      (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          titleEl.blur();
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          cancel();
+          titleEl.blur();
+        }
+      },
+      { signal: ac.signal },
+    );
   }
 
   private startNewSession(): void {
@@ -969,6 +988,10 @@ export class GemmeraChatView extends ItemView {
     if (restoreText) {
       this.inputEl.value = restoreText;
     }
+    // Clear inFlightText so any early-exit path through the next handleSend
+    // (empty composer, etc.) can't see a stale value from the cancelled
+    // turn — the textarea is now the source of truth for the retry. #145.
+    this.inFlightText = null;
     this.setStreaming(false);
     this.inputEl.focus();
   }


### PR DESCRIPTION
Three reviewer items on PRs #145 (#46 streaming + Stop) and #152 (#43 plugin-level chat state) landed after both PRs had already been squash-merged. Consolidating the polish here in one follow-up so the comments don't sit unaddressed.

## Summary

**view.ts**
- \`cancelStreaming\` clears \`inFlightText\`. (iamaxeloberg on #145)
- Inline-rename listeners (blur + keydown) tied to a single \`AbortController\` so commit/cancel removes both atomically. Fixes a stacked-handler leak on dblclick → Escape → dblclick. (heimdallSWE + iamaxeloberg on #152)
- Pop-out replay limitation documented inline: text-only — route chips, classifier badges, silent-save indicators, citation chips drop. Restoring needs decorations alongside turns, follow-up. (heimdallSWE on #152)

**chat-history.ts**
- \`renameSession\` docstring spells out the intentional \`updatedAt\` bump so future maintainers don't fight the ordering test. (both reviewers on #152)

**settings-tab.ts**
- Retention inputs typed as \`TextComponent\` instead of the ad-hoc structural shape. (both reviewers on #152)
- \`inputEl.type = "number"; min = "0"\` — browser-native clamp + spinner so a typo can't silently coerce to 0 (= unlimited). (both reviewers on #152)

## Deferred (both reviewers agreed)

- Serialize \`ChatHistoryStore\` writes via in-memory mutex — race surface widened by #43 sharing one store across views, but pre-existing.
- View-level integration test for cancel / replay / rename — needs a minimal Obsidian DOM mock.

## Test plan

- [x] \`npm test\` → 727/727
- [x] \`npm run build\` → clean
- [ ] Manual: rapid dblclick → Escape → dblclick on a chat title; only one handler fires
- [ ] Manual: Stop a turn, clear composer, send empty → no errors, no stale state
- [ ] Manual: type \`abc\` in retention input → browser rejects, no settings mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)