### PR TITLE
fix(chat): fix O(n²) streaming, pin gemma3:4b, harden demo vault

### DIFF
--- a/.github/workflows/classifier-regression.yml
+++ b/.github/workflows/classifier-regression.yml
@@ -1,0 +1,35 @@
+name: Classifier regression check
+
+on:
+  pull_request:
+    paths:
+      - "src/contracts/classifier.ts"
+      - "src/services/ollama-classifier.ts"
+      - "src/services/mock-classifier.ts"
+      - "eval/classifier-golden/**"
+
+jobs:
+  regression:
+    name: Mock eval — P0 regression gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run classifier eval (mock) and compare to baseline
+        run: npm run eval:classifier:ci
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: classifier-eval-report
+          path: eval/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ demo-vault/raw/.obsidian/appearance.json
 demo-vault/raw/.obsidian/graph.json
 demo-vault/raw/.obsidian/plugins/
 
+# Eval run output (generated at runtime — commit the golden set, not the runs)
+eval/runs/
+
 # Dev
 .hotreload
 .venv/

--- a/demo-vault/raw/.obsidian/app.json
+++ b/demo-vault/raw/.obsidian/app.json
@@ -1,3 +1,3 @@
 {
-  "promptDelete": false
+  "spellcheck": false
 }

--- a/demo-vault/raw/.obsidian/core-plugins.json
+++ b/demo-vault/raw/.obsidian/core-plugins.json
@@ -7,8 +7,7 @@
   "canvas": true,
   "outgoing-link": true,
   "tag-pane": true,
-  "footnotes": false,
-  "properties": true,
+  "properties": false,
   "page-preview": true,
   "daily-notes": true,
   "templates": true,
@@ -28,6 +27,7 @@
   "file-recovery": true,
   "publish": false,
   "sync": true,
-  "bases": true,
-  "webviewer": false
+  "webviewer": false,
+  "footnotes": false,
+  "bases": true
 }

--- a/eval/classifier-golden/baseline-mock.json
+++ b/eval/classifier-golden/baseline-mock.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Committed mock-classifier baseline. Regenerate with: npm run eval:classifier:mock -- --save-baseline eval/classifier-golden/baseline-mock.json",
+  "model": "mock",
+  "generatedAt": "2026-05-07T13:21:04.637Z",
+  "totalExamples": 30,
+  "totalAsk": 8,
+  "askCaptureFalsePositives": 0,
+  "askCaptureFpr": 0.0,
+  "accuracy": 0.5666666666666667,
+  "capturePrecision": 0.5,
+  "captureRecall": 0.3333333333333333
+}

--- a/eval/classifier-golden/examples.json
+++ b/eval/classifier-golden/examples.json
@@ -1,0 +1,343 @@
+[
+  {
+    "id": "c001",
+    "input": {
+      "messageText": "Spara detta som en mötesanteckning om Q2-planering",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Explicit save instruction with content type and purpose"
+  },
+  {
+    "id": "c002",
+    "input": {
+      "messageText": "Lägg till det här i min läslogg",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Explicit add-to-vault instruction with named destination"
+  },
+  {
+    "id": "c003",
+    "input": {
+      "messageText": "Kan du skapa en ny anteckning om min löpning idag? 10 km på 52 minuter, personbästa.",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Create-note request with concrete data to save"
+  },
+  {
+    "id": "c004",
+    "input": {
+      "messageText": "Arkivera det här mejlet som en anteckning i projektet",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Archive/save framing, Swedish"
+  },
+  {
+    "id": "c005",
+    "input": {
+      "messageText": "",
+      "attachmentKinds": ["pdf"],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Attachment-only with no text — skip path routes to capture"
+  },
+  {
+    "id": "c006",
+    "input": {
+      "messageText": "Notera att jag träffade Erik idag vid kaffeautomaten. Han funderar på att byta jobb.",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Note-taking / journaling framing"
+  },
+  {
+    "id": "c007",
+    "input": {
+      "messageText": "Skriv ner det här om bokhylleprojektet: fix för list-kommandot är klar, sortering funkar nu.",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "capture",
+    "notes": "Write-down instruction with project context and specific content"
+  },
+  {
+    "id": "c008",
+    "input": {
+      "messageText": "spara det istället",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad vet jag om bokhylleprojektet?", "label": "ask" },
+        { "userText": "berätta mer", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "capture",
+    "notes": "Follow-up capture after two ask turns — 'save that instead'"
+  },
+  {
+    "id": "a001",
+    "input": {
+      "messageText": "Vad vet jag om bokhylleprojektet?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Direct vault query, Swedish"
+  },
+  {
+    "id": "a002",
+    "input": {
+      "messageText": "Vad har jag skrivit om min pappa?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Personal vault recall query"
+  },
+  {
+    "id": "a003",
+    "input": {
+      "messageText": "Berätta om min vandring i Sundsvall",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Recall / retrieve from vault"
+  },
+  {
+    "id": "a004",
+    "input": {
+      "messageText": "Vilka böcker har jag läst i år?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "List query over vault content"
+  },
+  {
+    "id": "a005",
+    "input": {
+      "messageText": "? Vad tänkte jag om The Dispossessed?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Leading ? — skip path routes to ask"
+  },
+  {
+    "id": "a006",
+    "input": {
+      "messageText": "Vad handlar det öppna dokumentet om?",
+      "attachmentKinds": [],
+      "activeFileName": "dagbok_2026-03-02",
+      "activeFileTitle": "2 mars 2026",
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "Query with active-file context — asking about currently open note"
+  },
+  {
+    "id": "a007",
+    "input": {
+      "messageText": "mer detaljer om det",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad har jag skrivit om min pappa?", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "ask",
+    "notes": "Follow-up ask using prior-turn context — 'more detail'"
+  },
+  {
+    "id": "a008",
+    "input": {
+      "messageText": "What did I write about my father?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "ask",
+    "notes": "English vault query — same intent as a004 but different language"
+  },
+  {
+    "id": "m001",
+    "input": {
+      "messageText": "Spara dessa mötesanteckningar och berätta vad vi beslutade förra veckan",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Explicit save + recall in one message"
+  },
+  {
+    "id": "m002",
+    "input": {
+      "messageText": "Lägg till det här och sök sedan efter relaterade anteckningar om projektet",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Save + search request chained"
+  },
+  {
+    "id": "m003",
+    "input": {
+      "messageText": "Arkivera detta och sammanfatta sedan vad jag vet om migrationsuppdraget",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Archive + summarize existing knowledge"
+  },
+  {
+    "id": "m004",
+    "input": {
+      "messageText": "Save this meeting note and also show me what I know about David",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "English mixed — explicit save + retrieve"
+  },
+  {
+    "id": "m005",
+    "input": {
+      "messageText": "Notera det här och hitta sedan liknande anteckningar i vaulten",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Note + find-similar pattern"
+  },
+  {
+    "id": "m006",
+    "input": {
+      "messageText": "Lägg in detta i min läslogg och ge mig en översikt av allt jag har om Le Guin",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "mixed",
+    "notes": "Add to log + retrieve existing — named author makes retrieval half clear"
+  },
+  {
+    "id": "x001",
+    "input": {
+      "messageText": "Hur använder jag Gemmera?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Classic how-to-use-the-app question"
+  },
+  {
+    "id": "x002",
+    "input": {
+      "messageText": "Vad kan du göra?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Capability question about the assistant"
+  },
+  {
+    "id": "x003",
+    "input": {
+      "messageText": "Hur raderar jag en anteckning?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Feature/UI question about the app"
+  },
+  {
+    "id": "x004",
+    "input": {
+      "messageText": "Vad är skillnaden mellan att spara och att fråga?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Conceptual question about the app's two modes"
+  },
+  {
+    "id": "x005",
+    "input": {
+      "messageText": "Hur fungerar sökningen i min vault?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Feature question about retrieval mechanism"
+  },
+  {
+    "id": "e001",
+    "input": {
+      "messageText": "Kan du hjälpa mig?",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": []
+    },
+    "expectedLabel": "meta",
+    "notes": "Ambiguous: could be meta or ask — best label is meta since there is no vault query"
+  },
+  {
+    "id": "e002",
+    "input": {
+      "messageText": "det där",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad vet jag om bokhylleprojektet?", "label": "ask" },
+        { "userText": "mer detaljer", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "ask",
+    "notes": "Minimal follow-up referencing prior ask — classifier must use recentTurns context"
+  },
+  {
+    "id": "e003",
+    "input": {
+      "messageText": "spara det",
+      "attachmentKinds": [],
+      "activeFileName": null,
+      "recentTurns": [
+        { "userText": "Vad tänkte jag om The Dispossessed?", "label": "ask" }
+      ]
+    },
+    "expectedLabel": "capture",
+    "notes": "Ambiguous short follow-up — 'save it' after an ask turn; prior turn context resolves to capture"
+  }
+]

--- a/eval/classifier-golden/loader.ts
+++ b/eval/classifier-golden/loader.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ClassifyOptions, IntentLabel } from "../../src/contracts/classifier";
+
+export interface GoldenExample {
+  id: string;
+  input: {
+    messageText: string;
+    attachmentKinds?: string[];
+    activeFileName?: string | null;
+    activeFileTitle?: string | null;
+    recentTurns?: Array<{ userText: string; label: IntentLabel }>;
+  };
+  expectedLabel: IntentLabel;
+  notes?: string;
+}
+
+export function loadGoldenSet(): GoldenExample[] {
+  const raw = readFileSync(join(__dirname, "examples.json"), "utf-8");
+  return JSON.parse(raw) as GoldenExample[];
+}
+
+export function toClassifyOptions(ex: GoldenExample, model?: string): ClassifyOptions {
+  return {
+    messageText: ex.input.messageText,
+    model,
+    attachmentKinds: ex.input.attachmentKinds ?? [],
+    activeFileName: ex.input.activeFileName ?? undefined,
+    activeFileTitle: ex.input.activeFileTitle ?? undefined,
+    recentTurns: ex.input.recentTurns ?? [],
+  };
+}

--- a/eval/runner/classify.ts
+++ b/eval/runner/classify.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env tsx
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { IntentLabel } from "../../src/contracts/classifier";
+import { MockClassifierService } from "../../src/services/mock-classifier";
+import { OllamaClassifierService } from "../../src/services/ollama-classifier";
+import { loadGoldenSet, toClassifyOptions } from "../classifier-golden/loader";
+
+const LABELS: IntentLabel[] = ["capture", "ask", "mixed", "meta"];
+
+// ── CLI args ──────────────────────────────────────────────────────────────────
+
+const useMock = process.argv.includes("--mock");
+const modelArg = process.argv.find((a) => a.startsWith("--model="))?.split("=")[1];
+const model = modelArg ?? "gemma3:latest";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Result {
+  id: string;
+  expected: IntentLabel;
+  actual: IntentLabel;
+  confidence: number;
+  latencyMs: number;
+  passed: boolean;
+  notes?: string;
+  rationale: string;
+  source: string;
+}
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const svc = useMock ? new MockClassifierService() : new OllamaClassifierService();
+  const examples = loadGoldenSet();
+
+  console.log(`\nClassifier eval — ${examples.length} examples, model: ${useMock ? "mock" : model}\n`);
+
+  const results: Result[] = [];
+
+  for (const ex of examples) {
+    process.stdout.write(`  ${ex.id} … `);
+    const decision = await svc.classify(toClassifyOptions(ex, model));
+    const passed = decision.label === ex.expectedLabel;
+    results.push({
+      id: ex.id,
+      expected: ex.expectedLabel,
+      actual: decision.label,
+      confidence: decision.confidence,
+      latencyMs: decision.latencyMs,
+      passed,
+      notes: ex.notes,
+      rationale: decision.rationale,
+      source: decision.source,
+    });
+    console.log(passed ? `✓ ${decision.label}` : `✗ got ${decision.label}, expected ${ex.expectedLabel}`);
+  }
+
+  report(results);
+}
+
+// ── Metrics + report ──────────────────────────────────────────────────────────
+
+function report(results: Result[]): void {
+  const total = results.length;
+  const passedCount = results.filter((r) => r.passed).length;
+
+  // confusion[actual][expected]
+  const confusion: Record<IntentLabel, Record<IntentLabel, number>> = {
+    capture: { capture: 0, ask: 0, mixed: 0, meta: 0 },
+    ask:     { capture: 0, ask: 0, mixed: 0, meta: 0 },
+    mixed:   { capture: 0, ask: 0, mixed: 0, meta: 0 },
+    meta:    { capture: 0, ask: 0, mixed: 0, meta: 0 },
+  };
+  for (const r of results) confusion[r.actual][r.expected]++;
+
+  function precision(label: IntentLabel): number {
+    const tp = confusion[label][label];
+    const denom = LABELS.reduce((s, l) => s + confusion[label][l], 0);
+    return denom === 0 ? 0 : tp / denom;
+  }
+
+  function recall(label: IntentLabel): number {
+    const tp = confusion[label][label];
+    const denom = LABELS.reduce((s, l) => s + confusion[l][label], 0);
+    return denom === 0 ? 0 : tp / denom;
+  }
+
+  function f1(label: IntentLabel): number {
+    const p = precision(label);
+    const r = recall(label);
+    return p + r === 0 ? 0 : (2 * p * r) / (p + r);
+  }
+
+  const latencies = results.map((r) => r.latencyMs).sort((a, b) => a - b);
+  function percentile(p: number): number {
+    const idx = Math.ceil((p / 100) * latencies.length) - 1;
+    return latencies[Math.max(0, idx)];
+  }
+
+  function pct(n: number): string {
+    return `${Math.round(n * 100)}%`;
+  }
+
+  const failures = results.filter((r) => !r.passed);
+  const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const outDir = join(__dirname, "..", "runs", ts);
+  mkdirSync(outDir, { recursive: true });
+
+  // Markdown
+  const md: string[] = [
+    `# Classifier Eval — ${new Date().toISOString()}`,
+    "",
+    `**Model:** ${useMock ? "mock" : model}  `,
+    `**Examples:** ${total}  `,
+    `**Passed:** ${passedCount} / ${total} (${pct(passedCount / total)})`,
+    "",
+    "## Confusion matrix",
+    "",
+    "Rows = predicted, columns = expected.",
+    "",
+    `|           | ${LABELS.map((l) => l.padEnd(7)).join(" | ")} |`,
+    `|-----------|${LABELS.map(() => "---------").join("|")}|`,
+    ...LABELS.map(
+      (actual) =>
+        `| ${actual.padEnd(9)} | ${LABELS.map((expected) => String(confusion[actual][expected]).padEnd(7)).join(" | ")} |`,
+    ),
+    "",
+    "## Per-class metrics",
+    "",
+    `| Class   | Precision | Recall | F1   |`,
+    `|---------|-----------|--------|------|`,
+    ...LABELS.map(
+      (l) =>
+        `| ${l.padEnd(7)} | ${pct(precision(l)).padEnd(9)} | ${pct(recall(l)).padEnd(6)} | ${pct(f1(l)).padEnd(4)} |`,
+    ),
+    "",
+    "## Latency",
+    "",
+    `- P50: ${percentile(50)}ms`,
+    `- P95: ${percentile(95)}ms`,
+    `- Min: ${latencies[0]}ms`,
+    `- Max: ${latencies[latencies.length - 1]}ms`,
+  ];
+
+  if (failures.length > 0) {
+    md.push("", "## Failures", "");
+    for (const r of failures) {
+      md.push(
+        `**${r.id}** — expected \`${r.expected}\`, got \`${r.actual}\` (${pct(r.confidence)})  `,
+        `> ${r.rationale}`,
+        r.notes ? `> *${r.notes}*` : "",
+        "",
+      );
+    }
+  }
+
+  // JSON
+  const json = {
+    timestamp: new Date().toISOString(),
+    model: useMock ? "mock" : model,
+    total,
+    passed: passedCount,
+    accuracy: passedCount / total,
+    confusion,
+    perClass: Object.fromEntries(
+      LABELS.map((l) => [l, { precision: precision(l), recall: recall(l), f1: f1(l) }]),
+    ),
+    latency: {
+      p50: percentile(50),
+      p95: percentile(95),
+      min: latencies[0],
+      max: latencies[latencies.length - 1],
+    },
+    failures: failures.map((r) => ({
+      id: r.id,
+      expected: r.expected,
+      actual: r.actual,
+      confidence: r.confidence,
+      rationale: r.rationale,
+      notes: r.notes,
+    })),
+    results,
+  };
+
+  writeFileSync(join(outDir, "report.md"), md.join("\n"));
+  writeFileSync(join(outDir, "report.json"), JSON.stringify(json, null, 2));
+
+  console.log(`\nResults → ${outDir}/`);
+  console.log(`Accuracy: ${passedCount}/${total} (${pct(passedCount / total)})`);
+  console.log(`P50: ${percentile(50)}ms  P95: ${percentile(95)}ms`);
+  if (failures.length > 0) {
+    console.log(`\nFailures (${failures.length}):`);
+    for (const r of failures) {
+      console.log(`  ${r.id}: expected ${r.expected}, got ${r.actual} — "${r.notes ?? r.rationale}"`);
+    }
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/eval/runner/classify.ts
+++ b/eval/runner/classify.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
-import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import type { IntentLabel } from "../../src/contracts/classifier";
 import { MockClassifierService } from "../../src/services/mock-classifier";
 import { OllamaClassifierService } from "../../src/services/ollama-classifier";
@@ -13,6 +13,10 @@ const LABELS: IntentLabel[] = ["capture", "ask", "mixed", "meta"];
 const useMock = process.argv.includes("--mock");
 const modelArg = process.argv.find((a) => a.startsWith("--model="))?.split("=")[1];
 const model = modelArg ?? "gemma3:latest";
+const compareArg = process.argv.find((a) => a.startsWith("--compare="))?.split("=")[1]
+  ?? (process.argv.includes("--compare") ? process.argv[process.argv.indexOf("--compare") + 1] : undefined);
+const saveBaselineArg = process.argv.find((a) => a.startsWith("--save-baseline="))?.split("=")[1]
+  ?? (process.argv.includes("--save-baseline") ? process.argv[process.argv.indexOf("--save-baseline") + 1] : undefined);
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -183,8 +187,31 @@ function report(results: Result[]): void {
     results,
   };
 
+  // Derived metrics used for baseline comparison
+  const totalAsk = results.filter((r) => r.expected === "ask").length;
+  const askCaptureFalsePositives = confusion["capture"]["ask"];
+  const askCaptureFpr = totalAsk === 0 ? 0 : askCaptureFalsePositives / totalAsk;
+
   writeFileSync(join(outDir, "report.md"), md.join("\n"));
   writeFileSync(join(outDir, "report.json"), JSON.stringify(json, null, 2));
+
+  // Save baseline if requested
+  if (saveBaselineArg) {
+    const baseline = {
+      _comment: "Committed mock-classifier baseline. Regenerate with: npm run eval:classifier:mock -- --save-baseline eval/classifier-golden/baseline-mock.json",
+      model: useMock ? "mock" : model,
+      generatedAt: new Date().toISOString(),
+      totalExamples: total,
+      totalAsk,
+      askCaptureFalsePositives,
+      askCaptureFpr,
+      accuracy: passedCount / total,
+      capturePrecision: precision("capture"),
+      captureRecall: recall("capture"),
+    };
+    writeFileSync(resolve(saveBaselineArg), JSON.stringify(baseline, null, 2));
+    console.log(`\nBaseline saved → ${saveBaselineArg}`);
+  }
 
   console.log(`\nResults → ${outDir}/`);
   console.log(`Accuracy: ${passedCount}/${total} (${pct(passedCount / total)})`);
@@ -193,6 +220,35 @@ function report(results: Result[]): void {
     console.log(`\nFailures (${failures.length}):`);
     for (const r of failures) {
       console.log(`  ${r.id}: expected ${r.expected}, got ${r.actual} — "${r.notes ?? r.rationale}"`);
+    }
+  }
+
+  // Regression check
+  if (compareArg) {
+    const baseline = JSON.parse(readFileSync(resolve(compareArg), "utf-8")) as {
+      askCaptureFpr: number;
+      accuracy: number;
+    };
+
+    let p0 = false;
+    if (askCaptureFpr > baseline.askCaptureFpr) {
+      console.error(
+        `\n[P0 REGRESSION] ask→capture false-positive rate rose: ${pct(baseline.askCaptureFpr)} → ${pct(askCaptureFpr)}`,
+      );
+      p0 = true;
+    }
+
+    const accuracyDrop = baseline.accuracy - passedCount / total;
+    if (accuracyDrop > 0.05) {
+      console.warn(
+        `\n[P1 REGRESSION] Overall accuracy dropped ${pct(accuracyDrop)} vs baseline (${pct(baseline.accuracy)} → ${pct(passedCount / total)})`,
+      );
+    }
+
+    if (!p0) {
+      console.log("\n✓ No P0 regressions detected.");
+    } else {
+      process.exit(1);
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "builtin-modules": "4.0.0",
         "esbuild": "0.24.2",
         "obsidian": "latest",
+        "tsx": "^4.19.2",
         "typescript": "5.6.3",
         "vitest": "^2.1.9"
       }
@@ -398,6 +399,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
@@ -573,9 +591,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -590,9 +605,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -607,9 +619,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -624,9 +633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -641,9 +647,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,9 +661,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -675,9 +675,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -692,9 +689,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,9 +703,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -726,9 +717,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,9 +731,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +745,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -777,9 +759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1199,6 +1178,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1318,6 +1310,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -1446,6 +1448,493 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "eval:classifier": "tsx eval/runner/classify.ts",
-    "eval:classifier:mock": "tsx eval/runner/classify.ts --mock"
+    "eval:classifier:mock": "tsx eval/runner/classify.ts --mock",
+    "eval:classifier:ci": "tsx eval/runner/classify.ts --mock --compare eval/classifier-golden/baseline-mock.json"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "node esbuild.config.mjs",
     "build": "node esbuild.config.mjs production",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "eval:classifier": "tsx eval/runner/classify.ts",
+    "eval:classifier:mock": "tsx eval/runner/classify.ts --mock"
   },
   "dependencies": {},
   "devDependencies": {
@@ -16,6 +18,7 @@
     "esbuild": "0.24.2",
     "typescript": "5.6.3",
     "builtin-modules": "4.0.0",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "tsx": "^4.19.2"
   }
 }

--- a/planning/classifier.md
+++ b/planning/classifier.md
@@ -74,14 +74,20 @@ Three fields. No trailing prose. `confidence` is a raw model-reported probabilit
 
 The exact threshold numbers are tuned during build against the classifier golden set. The shape is asymmetric: `capture` requires a higher confidence than `ask` because misclassifying `ask` as `capture` is costlier (a silent note may get written) than the reverse.
 
-Starting points to anchor the eval work, not committed values:
+**Committed values (v1.0, 2026-05-07):**
 
-- `ask` threshold: 0.70.
-- `capture` threshold: 0.85.
-- `mixed` threshold: 0.75.
-- `meta` threshold: 0.70.
+| Label     | Threshold | Rationale |
+|-----------|-----------|-----------|
+| `capture` | 0.85      | Highest threshold — misrouting `ask` as `capture` causes silent writes, which is the costliest error. |
+| `mixed`   | 0.75      | Mid-range — mixed turns that fall below this are safer to route via disambiguation than to guess. |
+| `ask`     | 0.70      | Lower threshold — misrouting `capture` as `ask` is recoverable; user sees the answer and can re-save. |
+| `meta`    | 0.70      | Lower threshold — meta fallback to `ask` is safe; user gets a vault answer instead of help text, low cost. |
 
-Below threshold, the disambiguation chip appears. Committed values land after the first golden-set run during M1.
+These values are encoded in `src/contracts/classifier.ts` (`DEFAULT_THRESHOLDS`) and are guarded by the CI regression check. Update the code constant and the baseline when re-tuning.
+
+**Tuning process:** run `npm run eval:classifier` (requires Ollama) against the 30-example golden set. Adjust thresholds to maintain `capture` > `ask` asymmetry and maximise `capture` precision without sacrificing `ask` recall. Re-generate the mock baseline with `npm run eval:classifier:mock -- --save-baseline eval/classifier-golden/baseline-mock.json` after any golden set changes.
+
+Below threshold, the disambiguation chip appears.
 
 ## Disambiguation UX
 
@@ -133,7 +139,8 @@ A classifier golden set, distinct from the retrieval golden set.
 - **Initial size**: 30 hand-labeled examples covering all four labels and the main edge cases (attachments, follow-ups, ambiguous phrasing, meta questions).
 - **Growth**: to 100+ during beta. The disambiguation chip is a built-in labeled-example factory — every user correction becomes a labeled example.
 - **Metrics**: per-class precision and recall, full confusion matrix, P50 and P95 latency.
-- **Regression policy**: any drop in `ask → capture` precision is a P0 regression. Other regressions are P1.
+- **Regression policy**: any increase in the `ask → capture` false-positive rate (asks misrouted as capture) is a **P0 regression** — the CI gate in `.github/workflows/classifier-regression.yml` fails the build. A drop in overall accuracy of more than 5 percentage points vs the committed baseline is a **P1 regression** — logged as a warning, does not fail CI. All other metric changes are informational.
+- **CI gate**: `npm run eval:classifier:ci` runs the mock classifier against the golden set and compares to `eval/classifier-golden/baseline-mock.json`. Triggers on PRs touching `src/contracts/classifier.ts`, `src/services/ollama-classifier.ts`, `src/services/mock-classifier.ts`, or `eval/classifier-golden/**`.
 
 ## Prompt structure
 

--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -8,6 +8,8 @@ export interface ClassifierDecision {
   skipReason?: string;
   latencyMs: number;
   promptVersion: string;
+  /** True when the classifier failed (timeout/parse error) and fell back to the default label. */
+  failed?: boolean;
 }
 
 export interface ClassifyOptions {

--- a/src/contracts/classifier.ts
+++ b/src/contracts/classifier.ts
@@ -1,0 +1,38 @@
+export type IntentLabel = "capture" | "ask" | "mixed" | "meta";
+
+export interface ClassifierDecision {
+  label: IntentLabel;
+  confidence: number;
+  rationale: string;
+  source: "llm" | "skip";
+  skipReason?: string;
+  latencyMs: number;
+  promptVersion: string;
+}
+
+export interface ClassifyOptions {
+  messageText: string;
+  model?: string;
+  attachmentKinds?: string[];
+  activeFileName?: string;
+  activeFileTitle?: string;
+  recentTurns?: Array<{ userText: string; label: IntentLabel }>;
+}
+
+export interface ClassifierThresholds {
+  ask: number;
+  capture: number;
+  mixed: number;
+  meta: number;
+}
+
+export const DEFAULT_THRESHOLDS: ClassifierThresholds = {
+  ask: 0.70,
+  capture: 0.85,
+  mixed: 0.75,
+  meta: 0.70,
+};
+
+export interface ClassifierService {
+  classify(opts: ClassifyOptions): Promise<ClassifierDecision>;
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -7,3 +7,4 @@ export * from "./jobs";
 export * from "./vault-events";
 export * from "./vector-store";
 export * from "./embedder";
+export * from "./classifier";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
 import { FileSystemAdapter, Notice, type App } from "obsidian";
 import type {
+  ClassifierService,
   IndexService,
   IngestionPipeline,
   IngestionStore,
@@ -12,6 +13,8 @@ import type {
 } from "../contracts";
 import type { GemmeraSettings } from "../settings";
 import { MockLLMService } from "./mock-llm";
+import { MockClassifierService } from "./mock-classifier";
+import { OllamaClassifierService } from "./ollama-classifier";
 import { OllamaLLMService } from "./ollama-llm";
 import { ObsidianVaultService } from "./real-vault";
 import { VaultLinearIndexService } from "./vault-index";
@@ -30,6 +33,7 @@ import { EmbeddingService } from "./embedding-service";
 
 export interface Services {
   llm: LLMService;
+  classifier: ClassifierService;
   vault: VaultService;
   index: IndexService;
   jobQueue: JobQueue;
@@ -61,6 +65,16 @@ export async function createLLMService(
     return new MockLLMService();
   }
   return ollama;
+}
+
+export function createClassifierService(
+  backend: GemmeraSettings["llmBackend"],
+  llm: LLMService,
+): ClassifierService {
+  if (backend === "mock" || llm instanceof MockLLMService) {
+    return new MockClassifierService();
+  }
+  return new OllamaClassifierService();
 }
 
 export async function createServices(app: App, settings: GemmeraSettings): Promise<Services> {
@@ -104,8 +118,10 @@ export async function createServices(app: App, settings: GemmeraSettings): Promi
     ingestionStore,
   );
 
+  const llm = await createLLMService(settings.llmBackend);
   return {
-    llm: await createLLMService(settings.llmBackend),
+    llm,
+    classifier: createClassifierService(settings.llmBackend, llm),
     vault,
     index: new VaultLinearIndexService(vault),
     jobQueue,
@@ -121,6 +137,8 @@ export async function createServices(app: App, settings: GemmeraSettings): Promi
 }
 
 export { OllamaLLMService } from "./ollama-llm";
+export { OllamaClassifierService } from "./ollama-classifier";
+export { MockClassifierService } from "./mock-classifier";
 export { ObsidianVaultService } from "./real-vault";
 export { VaultLinearIndexService } from "./vault-index";
 export { InMemoryJobQueue } from "./in-memory-job-queue";

--- a/src/services/mock-classifier.test.ts
+++ b/src/services/mock-classifier.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { MockClassifierService } from "./mock-classifier";
+
+describe("MockClassifierService", () => {
+  const svc = new MockClassifierService();
+
+  it("routes leading ? to ask with high confidence", async () => {
+    const d = await svc.classify({ messageText: "? vad vet jag om X?" });
+    expect(d.label).toBe("ask");
+    expect(d.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("routes save keywords to capture", async () => {
+    const d = await svc.classify({ messageText: "spara detta som en anteckning" });
+    expect(d.label).toBe("capture");
+  });
+
+  it("routes help questions to meta", async () => {
+    const d = await svc.classify({ messageText: "hur använder jag Gemmera?" });
+    expect(d.label).toBe("meta");
+  });
+
+  it("defaults to ask for unrecognized input", async () => {
+    const d = await svc.classify({ messageText: "lite slumpmässig text" });
+    expect(d.label).toBe("ask");
+  });
+
+  it("returns source llm and a promptVersion", async () => {
+    const d = await svc.classify({ messageText: "anything" });
+    expect(d.source).toBe("llm");
+    expect(typeof d.promptVersion).toBe("string");
+    expect(typeof d.latencyMs).toBe("number");
+  });
+});

--- a/src/services/mock-classifier.ts
+++ b/src/services/mock-classifier.ts
@@ -1,0 +1,57 @@
+import type {
+  ClassifierDecision,
+  ClassifierService,
+  ClassifyOptions,
+  IntentLabel,
+} from "../contracts/classifier";
+
+export interface ScriptedClassification {
+  match: (text: string) => boolean;
+  label: IntentLabel;
+  confidence: number;
+  rationale: string;
+}
+
+const DEFAULT_SCRIPT: ScriptedClassification[] = [
+  {
+    match: (t) => t.startsWith("?"),
+    label: "ask",
+    confidence: 1.0,
+    rationale: "Leading question mark prefix.",
+  },
+  {
+    match: (t) => /spara|save|lagra|anteckna/i.test(t),
+    label: "capture",
+    confidence: 0.90,
+    rationale: "Message contains explicit save keyword.",
+  },
+  {
+    match: (t) => /hur|hjälp|vad kan|how|help|what can/i.test(t),
+    label: "meta",
+    confidence: 0.85,
+    rationale: "Message appears to be about the app itself.",
+  },
+  {
+    match: () => true,
+    label: "ask",
+    confidence: 0.80,
+    rationale: "Default: treating as a question.",
+  },
+];
+
+export class MockClassifierService implements ClassifierService {
+  constructor(private readonly script: ScriptedClassification[] = DEFAULT_SCRIPT) {}
+
+  async classify(opts: ClassifyOptions): Promise<ClassifierDecision> {
+    const text = opts.messageText.trim();
+    const entry = this.script.find((s) => s.match(text)) ?? this.script[this.script.length - 1];
+    return {
+      label: entry.label,
+      confidence: entry.confidence,
+      rationale: entry.rationale,
+      source: "llm",
+      latencyMs: 0,
+      promptVersion: "mock",
+    };
+  }
+}

--- a/src/services/ollama-classifier.ts
+++ b/src/services/ollama-classifier.ts
@@ -1,0 +1,192 @@
+import type {
+  ClassifierDecision,
+  ClassifierService,
+  ClassifierThresholds,
+  ClassifyOptions,
+  IntentLabel,
+} from "../contracts/classifier";
+import { DEFAULT_THRESHOLDS } from "../contracts/classifier";
+
+const PROMPT_VERSION = "v1.0";
+const TIMEOUT_MS = 500;
+const DEFAULT_BASE = "http://127.0.0.1:11434";
+const DEFAULT_MODEL = "gemma3:latest";
+
+const SYSTEM_PROMPT = `You are an intent classifier for a personal knowledge-base assistant.
+
+Classify the user's message into exactly one of these four intents:
+- capture: The user wants to save content to their knowledge base (e.g. "save this", "add a note", pasting text to store).
+- ask: The user wants to retrieve information or get an answer from their knowledge base (e.g. "what did I write about X?", "find my notes on Y").
+- mixed: The user wants both — save something AND get an answer in the same turn.
+- meta: The user is asking about the app itself, not the knowledge base content (e.g. "how do I use this?", "what can you do?").
+
+Return ONLY a JSON object with exactly three fields:
+- "label": one of "capture", "ask", "mixed", "meta"
+- "confidence": a float in [0.0, 1.0]
+- "rationale": one sentence explaining the classification
+
+Examples:
+
+User: "Save this as my weekly review for last week."
+{"label":"capture","confidence":0.95,"rationale":"Explicit request to save content with a named category."}
+
+User: "What do I know about the book Thinking Fast and Slow?"
+{"label":"ask","confidence":0.92,"rationale":"Direct question about knowledge base content."}
+
+User: "How do I delete a note?"
+{"label":"meta","confidence":0.90,"rationale":"Question about the app's functionality, not vault content."}
+
+User: "Save these meeting notes and tell me what decisions we made last week."
+{"label":"mixed","confidence":0.82,"rationale":"Requests both saving new content and querying existing content."}
+
+User: "more detail please"
+{"label":"ask","confidence":0.78,"rationale":"Follow-up requesting elaboration, likely continuing a prior query."}
+
+User: "[image.png] add to my design references"
+{"label":"capture","confidence":0.91,"rationale":"Attachment with an explicit save instruction."}`;
+
+interface OllamaResponse {
+  message?: { content: string };
+  done: boolean;
+}
+
+interface ClassifierOutput {
+  label: string;
+  confidence: number;
+  rationale: string;
+}
+
+const VALID_LABELS = new Set<string>(["capture", "ask", "mixed", "meta"]);
+
+function parseOutput(raw: string): ClassifierOutput | null {
+  try {
+    const obj = JSON.parse(raw) as Partial<ClassifierOutput>;
+    if (
+      typeof obj.label === "string" &&
+      VALID_LABELS.has(obj.label) &&
+      typeof obj.confidence === "number" &&
+      obj.confidence >= 0 &&
+      obj.confidence <= 1 &&
+      typeof obj.rationale === "string"
+    ) {
+      return { label: obj.label, confidence: obj.confidence, rationale: obj.rationale };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function buildUserContent(opts: ClassifyOptions): string {
+  const lines: string[] = [`Message: ${opts.messageText.slice(0, 8000)}`];
+
+  if (opts.attachmentKinds && opts.attachmentKinds.length > 0) {
+    lines.push(`Attachments: ${opts.attachmentKinds.join(", ")}`);
+  }
+  if (opts.activeFileName) {
+    const title = opts.activeFileTitle ? ` ("${opts.activeFileTitle}")` : "";
+    lines.push(`Active file: ${opts.activeFileName}${title}`);
+  }
+  if (opts.recentTurns && opts.recentTurns.length > 0) {
+    const turns = opts.recentTurns
+      .slice(-3)
+      .map((t) => `  [${t.label}] ${t.userText.slice(0, 200)}`)
+      .join("\n");
+    lines.push(`Recent turns:\n${turns}`);
+  }
+
+  return lines.join("\n");
+}
+
+function makeSkipDecision(label: IntentLabel, skipReason: string): ClassifierDecision {
+  return {
+    label,
+    confidence: 1.0,
+    rationale: skipReason,
+    source: "skip",
+    skipReason,
+    latencyMs: 0,
+    promptVersion: PROMPT_VERSION,
+  };
+}
+
+export class OllamaClassifierService implements ClassifierService {
+  constructor(
+    private readonly thresholds: ClassifierThresholds = DEFAULT_THRESHOLDS,
+    private readonly baseUrl: string = DEFAULT_BASE,
+  ) {}
+
+  async classify(opts: ClassifyOptions): Promise<ClassifierDecision> {
+    const start = Date.now();
+    const text = opts.messageText.trim();
+
+    if (!text && (!opts.attachmentKinds || opts.attachmentKinds.length === 0)) {
+      return makeSkipDecision("ask", "empty");
+    }
+    if (text.startsWith("?")) {
+      return makeSkipDecision("ask", "leading-question-mark");
+    }
+    if (opts.attachmentKinds && opts.attachmentKinds.length > 0 && !text) {
+      return makeSkipDecision("capture", "attachment-only");
+    }
+
+    const model = opts.model ?? DEFAULT_MODEL;
+    const userContent = buildUserContent(opts);
+
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const controller = new AbortController();
+      const tid = setTimeout(() => controller.abort(), TIMEOUT_MS);
+      try {
+        const raw = await this.callOllama(model, userContent, controller.signal);
+        clearTimeout(tid);
+        const parsed = parseOutput(raw);
+        if (parsed) {
+          return {
+            label: parsed.label as IntentLabel,
+            confidence: parsed.confidence,
+            rationale: parsed.rationale,
+            source: "llm",
+            latencyMs: Date.now() - start,
+            promptVersion: PROMPT_VERSION,
+          };
+        }
+        lastError = new Error("Invalid classifier output shape");
+      } catch (err) {
+        clearTimeout(tid);
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (lastError.name === "AbortError") break; // timeout — don't retry
+      }
+    }
+
+    // Fallback: route to ask, caller shows disambiguation chip
+    return {
+      label: "ask",
+      confidence: 0,
+      rationale: lastError?.message ?? "Classifier failed",
+      source: "llm",
+      latencyMs: Date.now() - start,
+      promptVersion: PROMPT_VERSION,
+    };
+  }
+
+  private async callOllama(model: string, userContent: string, signal: AbortSignal): Promise<string> {
+    const res = await fetch(`${this.baseUrl}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: userContent },
+        ],
+        stream: false,
+        format: "json",
+      }),
+      signal,
+    });
+    if (!res.ok) throw new Error(`Ollama classifier error: ${res.status}`);
+    const data = (await res.json()) as OllamaResponse;
+    return data.message?.content ?? "";
+  }
+}

--- a/src/services/ollama-classifier.ts
+++ b/src/services/ollama-classifier.ts
@@ -10,7 +10,7 @@ import { DEFAULT_THRESHOLDS } from "../contracts/classifier";
 const PROMPT_VERSION = "v1.0";
 const TIMEOUT_MS = 2000;
 const DEFAULT_BASE = "http://127.0.0.1:11434";
-const DEFAULT_MODEL = "gemma3:latest";
+const DEFAULT_MODEL = "gemma3:4b";
 
 const SYSTEM_PROMPT = `You are an intent classifier for a personal knowledge-base assistant.
 

--- a/src/services/ollama-classifier.ts
+++ b/src/services/ollama-classifier.ts
@@ -8,7 +8,7 @@ import type {
 import { DEFAULT_THRESHOLDS } from "../contracts/classifier";
 
 const PROMPT_VERSION = "v1.0";
-const TIMEOUT_MS = 500;
+const TIMEOUT_MS = 2000;
 const DEFAULT_BASE = "http://127.0.0.1:11434";
 const DEFAULT_MODEL = "gemma3:latest";
 
@@ -159,7 +159,7 @@ export class OllamaClassifierService implements ClassifierService {
       }
     }
 
-    // Fallback: route to ask, caller shows disambiguation chip
+    // Fallback: route to ask silently — caller must NOT show disambiguation chip
     return {
       label: "ask",
       confidence: 0,
@@ -167,6 +167,7 @@ export class OllamaClassifierService implements ClassifierService {
       source: "llm",
       latencyMs: Date.now() - start,
       promptVersion: PROMPT_VERSION,
+      failed: true,
     };
   }
 

--- a/src/services/ollama-llm.ts
+++ b/src/services/ollama-llm.ts
@@ -7,7 +7,7 @@ import type {
 } from "../contracts";
 
 const DEFAULT_BASE = "http://127.0.0.1:11434";
-const DEFAULT_MODEL = "gemma3:latest";
+const DEFAULT_MODEL = "gemma3:4b";
 
 interface OllamaChunk {
   message?: { content: string };

--- a/src/services/ollama-llm.ts
+++ b/src/services/ollama-llm.ts
@@ -46,6 +46,10 @@ export class OllamaLLMService implements LLMService {
 
   async chat(opts: ChatOptions): Promise<LLMResponse> {
     const { messages, model = DEFAULT_MODEL, onToken, signal } = opts;
+    const controller = new AbortController();
+    const combinedSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;
+    const timeout = setTimeout(() => controller.abort(), 60_000);
+
     const res = await fetch(`${this.baseUrl}/api/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -54,7 +58,7 @@ export class OllamaLLMService implements LLMService {
         messages: messages.map(toOllamaMessage),
         stream: true,
       }),
-      signal,
+      signal: combinedSignal,
     });
     if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
     if (!res.body) throw new Error("No response body");
@@ -62,27 +66,32 @@ export class OllamaLLMService implements LLMService {
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
-    let full = "";
+    const tokens: string[] = [];
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      let newlineAt: number;
-      while ((newlineAt = buffer.indexOf("\n")) !== -1) {
-        const line = buffer.slice(0, newlineAt).trim();
-        buffer = buffer.slice(newlineAt + 1);
-        if (!line) continue;
-        const chunk = JSON.parse(line) as OllamaChunk;
-        const token = chunk.message?.content ?? "";
-        if (token) {
-          full += token;
-          onToken?.(token);
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        let newlineAt: number;
+        buffer += chunk;
+        while ((newlineAt = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, newlineAt).trim();
+          buffer = buffer.slice(newlineAt + 1);
+          if (!line) continue;
+          const parsed = JSON.parse(line) as OllamaChunk;
+          const token = parsed.message?.content ?? "";
+          if (token) {
+            tokens.push(token);
+            onToken?.(token);
+          }
         }
       }
+    } finally {
+      clearTimeout(timeout);
     }
 
-    return { content: full };
+    return { content: tokens.join("") };
   }
 }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, MarkdownRenderer, WorkspaceLeaf } from "obsidian";
 import type { ChatMessage, IndexSearchResult } from "./contracts";
 import type { ClassifierDecision, IntentLabel } from "./contracts/classifier";
 import { DEFAULT_THRESHOLDS } from "./contracts/classifier";
@@ -20,7 +20,7 @@ export class GemmeraChatView extends ItemView {
   private chipDecision: ClassifierDecision | null = null;
   private history: ChatMessage[] = [];
   private recentTurns: RecentTurn[] = [];
-  private model = "gemma3:latest";
+  private model = "gemma3:4b";
 
   constructor(leaf: WorkspaceLeaf, private readonly services: Services) {
     super(leaf);
@@ -182,19 +182,26 @@ export class GemmeraChatView extends ItemView {
 
   private async runAskPath(text: string): Promise<void> {
     const { el: assistantEl, textEl } = this.appendStreamingMessage();
+    textEl.textContent = "Tänker...";
     try {
       const searchResults = await this.services.index.search(text);
       const messages = withContext(this.history, searchResults);
 
+      let firstToken = true;
+      const tokens: string[] = [];
       const reply = await this.services.llm.chat({
         model: this.model,
         messages,
         onToken: (token) => {
-          textEl.textContent += token;
+          if (firstToken) { textEl.textContent = ""; firstToken = false; }
+          tokens.push(token);
+          textEl.textContent = tokens.join("");
           this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
         },
       });
       this.history.push({ role: "assistant", content: reply.content });
+      await MarkdownRenderer.render(this.app, reply.content, textEl, "", this);
+      this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
 
       if (searchResults.length > 0) {
         this.appendCitations(assistantEl, searchResults.map((r) => r.basename));
@@ -306,7 +313,7 @@ export class GemmeraChatView extends ItemView {
   private appendStreamingMessage(): { el: HTMLElement; textEl: HTMLElement } {
     const el = this.messagesEl.createEl("div", { cls: "gemmera-message gemmera-message--assistant" });
     el.createEl("span", { cls: "gemmera-message__role", text: "Gemma" });
-    const textEl = el.createEl("p", { cls: "gemmera-message__text", text: "" });
+    const textEl = el.createEl("div", { cls: "gemmera-message__text" });
     this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
     return { el, textEl };
   }
@@ -314,7 +321,12 @@ export class GemmeraChatView extends ItemView {
   private appendMessage(role: "user" | "assistant", text: string): void {
     const msg = this.messagesEl.createEl("div", { cls: `gemmera-message gemmera-message--${role}` });
     msg.createEl("span", { cls: "gemmera-message__role", text: role === "user" ? "Du" : "Gemma" });
-    msg.createEl("p", { cls: "gemmera-message__text", text });
+    const textEl = msg.createEl("div", { cls: "gemmera-message__text" });
+    if (role === "assistant") {
+      void MarkdownRenderer.render(this.app, text, textEl, "", this);
+    } else {
+      textEl.textContent = text;
+    }
     this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -134,7 +134,7 @@ export class GemmeraChatView extends ItemView {
   }
 
   private belowThreshold(decision: ClassifierDecision): boolean {
-    if (decision.confidence === 0) return true;
+    if (decision.failed) return false; // silent fallback — never show chip
     return decision.confidence < DEFAULT_THRESHOLDS[decision.label];
   }
 
@@ -195,6 +195,11 @@ export class GemmeraChatView extends ItemView {
         },
       });
       this.history.push({ role: "assistant", content: reply.content });
+
+      if (searchResults.length > 0) {
+        this.appendCitations(assistantEl, searchResults.map((r) => r.basename));
+      }
+
       const ops = parseFileOps(reply.content);
       if (ops.length > 0) await handleFileOps(this.app, ops);
     } catch (err) {
@@ -204,6 +209,14 @@ export class GemmeraChatView extends ItemView {
     } finally {
       this.setInputDisabled(false);
       this.inputEl.focus();
+    }
+  }
+
+  private appendCitations(container: HTMLElement, basenames: string[]): void {
+    const el = container.createEl("div", { cls: "gemmera-citations" });
+    el.createEl("span", { cls: "gemmera-citations__label", text: "Källor:" });
+    for (const name of basenames) {
+      el.createEl("span", { cls: "gemmera-citations__chip", text: name });
     }
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -17,6 +17,7 @@ export class GemmeraChatView extends ItemView {
   private inputEl!: HTMLTextAreaElement;
   private sendBtn!: HTMLButtonElement;
   private chipEl: HTMLElement | null = null;
+  private chipDecision: ClassifierDecision | null = null;
   private history: ChatMessage[] = [];
   private recentTurns: RecentTurn[] = [];
   private model = "gemma3:latest";
@@ -25,17 +26,9 @@ export class GemmeraChatView extends ItemView {
     super(leaf);
   }
 
-  getViewType(): string {
-    return VIEW_TYPE;
-  }
-
-  getDisplayText(): string {
-    return "Gemmera";
-  }
-
-  getIcon(): string {
-    return "message-square";
-  }
+  getViewType(): string { return VIEW_TYPE; }
+  getDisplayText(): string { return "Gemmera"; }
+  getIcon(): string { return "message-square"; }
 
   async onOpen(): Promise<void> {
     const container = this.containerEl.children[1] as HTMLElement;
@@ -53,10 +46,7 @@ export class GemmeraChatView extends ItemView {
       cls: "gemmera-input",
       attr: { placeholder: "Skriv ett meddelande... (? för fråga, Ctrl+Enter för spara)", rows: "3" },
     });
-    this.sendBtn = inputArea.createEl("button", {
-      cls: "gemmera-send",
-      text: "Skicka",
-    });
+    this.sendBtn = inputArea.createEl("button", { cls: "gemmera-send", text: "Skicka" });
     this.sendBtn.addEventListener("click", () => this.handleSend());
     this.inputEl.addEventListener("keydown", (e) => {
       if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
@@ -85,32 +75,30 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  private async handleSend(opts?: { text?: string; forcedLabel?: IntentLabel }): Promise<void> {
+  private async handleSend(opts?: {
+    text?: string;
+    forcedLabel?: IntentLabel;
+    originalDecision?: ClassifierDecision;
+  }): Promise<void> {
     const text = opts?.text ?? this.inputEl.value.trim();
     if (!text) return;
 
-    if (!opts?.text) {
-      this.inputEl.value = "";
-    }
+    if (!opts?.text) this.inputEl.value = "";
     this.dismissChip();
     this.setInputDisabled(true);
 
     const decision = await this.classifyMessage(text, opts?.forcedLabel);
 
     // Below-threshold or classifier failure → show disambiguation chip
-    if (
-      decision.source === "llm" &&
-      !opts?.forcedLabel &&
-      this.belowThreshold(decision)
-    ) {
-      this.showDisambiguationChip(text, decision.rationale);
+    if (decision.source === "llm" && !opts?.forcedLabel && this.belowThreshold(decision)) {
+      this.showDisambiguationChip(text, decision);
       this.setInputDisabled(false);
       return;
     }
 
     this.history.push({ role: "user", content: text });
-    this.appendMessage("user", text);
     this.recentTurns = [...this.recentTurns.slice(-2), { userText: text, label: decision.label }];
+    this.appendUserTurn(text, decision, opts?.originalDecision);
 
     switch (decision.label) {
       case "ask":
@@ -146,19 +134,21 @@ export class GemmeraChatView extends ItemView {
   }
 
   private belowThreshold(decision: ClassifierDecision): boolean {
-    if (decision.confidence === 0) return true; // classifier failure fallback
-    const threshold = DEFAULT_THRESHOLDS[decision.label];
-    return decision.confidence < threshold;
+    if (decision.confidence === 0) return true;
+    return decision.confidence < DEFAULT_THRESHOLDS[decision.label];
   }
 
-  private showDisambiguationChip(text: string, rationale: string): void {
+  // ── Disambiguation chip ────────────────────────────────────────────────────
+
+  private showDisambiguationChip(text: string, decision: ClassifierDecision): void {
     this.dismissChip();
+    this.chipDecision = decision;
 
     const inputArea = this.inputEl.closest(".gemmera-input-area") as HTMLElement | null;
     if (!inputArea?.parentElement) return;
 
     const chip = inputArea.parentElement.createEl("div", { cls: "gemmera-chip" });
-    chip.title = rationale;
+    chip.title = decision.rationale;
     this.chipEl = chip;
 
     chip.createEl("span", { cls: "gemmera-chip__label", text: "Vad menade du?" });
@@ -168,23 +158,27 @@ export class GemmeraChatView extends ItemView {
     const cancelBtn = chip.createEl("button", { cls: "gemmera-chip__btn gemmera-chip__btn--cancel", text: "Avbryt" });
 
     saveBtn.addEventListener("click", () => {
+      const original = this.chipDecision;
       this.dismissChip();
-      void this.handleSend({ text, forcedLabel: "capture" });
+      void this.handleSend({ text, forcedLabel: "capture", originalDecision: original ?? undefined });
     });
     askBtn.addEventListener("click", () => {
+      const original = this.chipDecision;
       this.dismissChip();
-      void this.handleSend({ text, forcedLabel: "ask" });
+      void this.handleSend({ text, forcedLabel: "ask", originalDecision: original ?? undefined });
     });
     cancelBtn.addEventListener("click", () => this.dismissChip());
 
-    // Insert the chip just before the input area
     inputArea.parentElement.insertBefore(chip, inputArea);
   }
 
   private dismissChip(): void {
     this.chipEl?.remove();
     this.chipEl = null;
+    this.chipDecision = null;
   }
+
+  // ── Routing paths ──────────────────────────────────────────────────────────
 
   private async runAskPath(text: string): Promise<void> {
     const { el: assistantEl, textEl } = this.appendStreamingMessage();
@@ -213,7 +207,7 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  // Capture routes to the ask path for now — the LLM creates notes via fileops.
+  // Capture routes to the ask path for now — LLM creates notes via fileops.
   // Full ingest-state-machine wiring tracked in #68.
   private async runCapturePath(text: string): Promise<void> {
     return this.runAskPath(text);
@@ -233,9 +227,67 @@ export class GemmeraChatView extends ItemView {
     this.inputEl.focus();
   }
 
-  private setInputDisabled(disabled: boolean): void {
-    this.inputEl.disabled = disabled;
-    this.sendBtn.disabled = disabled;
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  private appendUserTurn(
+    text: string,
+    decision: ClassifierDecision,
+    originalDecision?: ClassifierDecision,
+  ): void {
+    const wrap = this.messagesEl.createEl("div", { cls: "gemmera-turn" });
+    const msg = wrap.createEl("div", { cls: "gemmera-message gemmera-message--user" });
+    msg.createEl("span", { cls: "gemmera-message__role", text: "Du" });
+    msg.createEl("p", { cls: "gemmera-message__text", text });
+    this.appendInspectorPanel(wrap, decision, originalDecision);
+    this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
+  }
+
+  private appendInspectorPanel(
+    container: HTMLElement,
+    decision: ClassifierDecision,
+    originalDecision?: ClassifierDecision,
+  ): void {
+    const panel = container.createEl("div", { cls: "gemmera-inspector" });
+
+    if (decision.source === "skip") {
+      const badge = panel.createEl("span", { cls: "gemmera-inspector__badge gemmera-inspector__badge--skip", text: "skip" });
+      badge.title = "Intent was determined without calling the LLM";
+      panel.createEl("span", { cls: "gemmera-inspector__label", text: decision.label });
+      panel.createEl("span", { cls: "gemmera-inspector__meta", text: decision.skipReason ?? "" });
+      return;
+    }
+
+    // LLM path
+    const wasDisambiguated = !!originalDecision;
+    const badgeText = wasDisambiguated ? "disambig" : "llm";
+    const badge = panel.createEl("span", {
+      cls: `gemmera-inspector__badge gemmera-inspector__badge--llm${wasDisambiguated ? " gemmera-inspector__badge--disambig" : ""}`,
+      text: badgeText,
+    });
+    badge.title = wasDisambiguated
+      ? `Original: ${originalDecision!.label} (${pct(originalDecision!.confidence)}) → user chose ${decision.label}`
+      : "Intent classified by LLM";
+
+    panel.createEl("span", { cls: "gemmera-inspector__label", text: decision.label });
+
+    if (wasDisambiguated) {
+      panel.createEl("span", {
+        cls: "gemmera-inspector__meta",
+        text: `was ${originalDecision!.label} ${pct(originalDecision!.confidence)}`,
+      });
+    } else {
+      panel.createEl("span", { cls: "gemmera-inspector__confidence", text: pct(decision.confidence) });
+    }
+
+    panel.createEl("span", { cls: "gemmera-inspector__rationale", text: decision.rationale });
+    panel.createEl("span", { cls: "gemmera-inspector__latency", text: `${decision.latencyMs}ms` });
+
+    // Collapsible raw JSON
+    const details = panel.createEl("details", { cls: "gemmera-inspector__raw" });
+    details.createEl("summary", { text: "raw" });
+    const payload: Record<string, unknown> = { ...decision };
+    if (wasDisambiguated) payload["originalDecision"] = originalDecision;
+    details.createEl("pre", { text: JSON.stringify(payload, null, 2) });
   }
 
   private appendStreamingMessage(): { el: HTMLElement; textEl: HTMLElement } {
@@ -252,6 +304,15 @@ export class GemmeraChatView extends ItemView {
     msg.createEl("p", { cls: "gemmera-message__text", text });
     this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: "smooth" });
   }
+
+  private setInputDisabled(disabled: boolean): void {
+    this.inputEl.disabled = disabled;
+    this.sendBtn.disabled = disabled;
+  }
+}
+
+function pct(confidence: number): string {
+  return `${Math.round(confidence * 100)}%`;
 }
 
 export function withContext(

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,15 +1,24 @@
 import { ItemView, WorkspaceLeaf } from "obsidian";
 import type { ChatMessage, IndexSearchResult } from "./contracts";
+import type { ClassifierDecision, IntentLabel } from "./contracts/classifier";
+import { DEFAULT_THRESHOLDS } from "./contracts/classifier";
 import type { Services } from "./services";
 import { parseFileOps, handleFileOps } from "./fileops";
 
 export const VIEW_TYPE = "gemmera-chat";
 
+interface RecentTurn {
+  userText: string;
+  label: IntentLabel;
+}
+
 export class GemmeraChatView extends ItemView {
   private messagesEl!: HTMLElement;
   private inputEl!: HTMLTextAreaElement;
   private sendBtn!: HTMLButtonElement;
+  private chipEl: HTMLElement | null = null;
   private history: ChatMessage[] = [];
+  private recentTurns: RecentTurn[] = [];
   private model = "gemma3:latest";
 
   constructor(leaf: WorkspaceLeaf, private readonly services: Services) {
@@ -42,7 +51,7 @@ export class GemmeraChatView extends ItemView {
     const inputArea = container.createEl("div", { cls: "gemmera-input-area" });
     this.inputEl = inputArea.createEl("textarea", {
       cls: "gemmera-input",
-      attr: { placeholder: "Skriv ett meddelande...", rows: "3" },
+      attr: { placeholder: "Skriv ett meddelande... (? för fråga, Ctrl+Enter för spara)", rows: "3" },
     });
     this.sendBtn = inputArea.createEl("button", {
       cls: "gemmera-send",
@@ -50,7 +59,10 @@ export class GemmeraChatView extends ItemView {
     });
     this.sendBtn.addEventListener("click", () => this.handleSend());
     this.inputEl.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        this.handleSend({ forcedLabel: "capture" });
+      } else if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         this.handleSend();
       }
@@ -58,7 +70,7 @@ export class GemmeraChatView extends ItemView {
   }
 
   async onClose(): Promise<void> {
-    // cleanup if needed
+    this.dismissChip();
   }
 
   private async checkOllamaStatus(el: HTMLElement): Promise<void> {
@@ -73,18 +85,109 @@ export class GemmeraChatView extends ItemView {
     }
   }
 
-  private async handleSend(): Promise<void> {
-    const text = this.inputEl.value.trim();
+  private async handleSend(opts?: { text?: string; forcedLabel?: IntentLabel }): Promise<void> {
+    const text = opts?.text ?? this.inputEl.value.trim();
     if (!text) return;
 
-    this.inputEl.value = "";
+    if (!opts?.text) {
+      this.inputEl.value = "";
+    }
+    this.dismissChip();
     this.setInputDisabled(true);
+
+    const decision = await this.classifyMessage(text, opts?.forcedLabel);
+
+    // Below-threshold or classifier failure → show disambiguation chip
+    if (
+      decision.source === "llm" &&
+      !opts?.forcedLabel &&
+      this.belowThreshold(decision)
+    ) {
+      this.showDisambiguationChip(text, decision.rationale);
+      this.setInputDisabled(false);
+      return;
+    }
 
     this.history.push({ role: "user", content: text });
     this.appendMessage("user", text);
+    this.recentTurns = [...this.recentTurns.slice(-2), { userText: text, label: decision.label }];
 
+    switch (decision.label) {
+      case "ask":
+      case "mixed":
+        await this.runAskPath(text);
+        break;
+      case "capture":
+        await this.runCapturePath(text);
+        break;
+      case "meta":
+        this.runMetaPath();
+        break;
+    }
+  }
+
+  private async classifyMessage(text: string, forcedLabel?: IntentLabel): Promise<ClassifierDecision> {
+    if (forcedLabel) {
+      return {
+        label: forcedLabel,
+        confidence: 1.0,
+        rationale: "User-forced intent",
+        source: "skip",
+        skipReason: "forced",
+        latencyMs: 0,
+        promptVersion: "",
+      };
+    }
+    return this.services.classifier.classify({
+      messageText: text,
+      model: this.model,
+      recentTurns: this.recentTurns,
+    });
+  }
+
+  private belowThreshold(decision: ClassifierDecision): boolean {
+    if (decision.confidence === 0) return true; // classifier failure fallback
+    const threshold = DEFAULT_THRESHOLDS[decision.label];
+    return decision.confidence < threshold;
+  }
+
+  private showDisambiguationChip(text: string, rationale: string): void {
+    this.dismissChip();
+
+    const inputArea = this.inputEl.closest(".gemmera-input-area") as HTMLElement | null;
+    if (!inputArea?.parentElement) return;
+
+    const chip = inputArea.parentElement.createEl("div", { cls: "gemmera-chip" });
+    chip.title = rationale;
+    this.chipEl = chip;
+
+    chip.createEl("span", { cls: "gemmera-chip__label", text: "Vad menade du?" });
+
+    const saveBtn = chip.createEl("button", { cls: "gemmera-chip__btn", text: "Spara" });
+    const askBtn = chip.createEl("button", { cls: "gemmera-chip__btn", text: "Fråga" });
+    const cancelBtn = chip.createEl("button", { cls: "gemmera-chip__btn gemmera-chip__btn--cancel", text: "Avbryt" });
+
+    saveBtn.addEventListener("click", () => {
+      this.dismissChip();
+      void this.handleSend({ text, forcedLabel: "capture" });
+    });
+    askBtn.addEventListener("click", () => {
+      this.dismissChip();
+      void this.handleSend({ text, forcedLabel: "ask" });
+    });
+    cancelBtn.addEventListener("click", () => this.dismissChip());
+
+    // Insert the chip just before the input area
+    inputArea.parentElement.insertBefore(chip, inputArea);
+  }
+
+  private dismissChip(): void {
+    this.chipEl?.remove();
+    this.chipEl = null;
+  }
+
+  private async runAskPath(text: string): Promise<void> {
     const { el: assistantEl, textEl } = this.appendStreamingMessage();
-
     try {
       const searchResults = await this.services.index.search(text);
       const messages = withContext(this.history, searchResults);
@@ -108,6 +211,26 @@ export class GemmeraChatView extends ItemView {
       this.setInputDisabled(false);
       this.inputEl.focus();
     }
+  }
+
+  // Capture routes to the ask path for now — the LLM creates notes via fileops.
+  // Full ingest-state-machine wiring tracked in #68.
+  private async runCapturePath(text: string): Promise<void> {
+    return this.runAskPath(text);
+  }
+
+  private runMetaPath(): void {
+    const help =
+      "**Gemmera** hjälper dig att spara och hitta information i din vault.\n\n" +
+      "- Skriv något för att spara det som en anteckning\n" +
+      "- Ställ en fråga för att söka i din vault\n" +
+      "- Börja med **?** för att ställa en fråga direkt\n" +
+      "- Tryck **Ctrl+Enter** för att spara utan att klassificera";
+
+    this.history.push({ role: "assistant", content: help });
+    this.appendMessage("assistant", help);
+    this.setInputDisabled(false);
+    this.inputEl.focus();
   }
 
   private setInputDisabled(disabled: boolean): void {

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,35 @@
   align-self: flex-end;
 }
 
+/* ── Citation chips ───────────────────────────────────────────────────────── */
+.gemmera-citations {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  font-size: 0.72rem;
+}
+
+.gemmera-citations__label {
+  color: var(--text-faint);
+  font-weight: 600;
+}
+
+.gemmera-citations__chip {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  cursor: default;
+  white-space: nowrap;
+}
+
+.gemmera-citations__chip:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 15%, transparent);
+  color: var(--text-normal);
+}
+
 /* ── Turn wrapper ─────────────────────────────────────────────────────────── */
 .gemmera-turn {
   display: flex;

--- a/styles.css
+++ b/styles.css
@@ -81,3 +81,124 @@
 .gemmera-send {
   align-self: flex-end;
 }
+
+/* ── Turn wrapper ─────────────────────────────────────────────────────────── */
+.gemmera-turn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+}
+
+/* ── Classifier inspector panel ───────────────────────────────────────────── */
+.gemmera-inspector {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  max-width: 90%;
+  line-height: 1.4;
+}
+
+.gemmera-inspector__badge {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+}
+
+.gemmera-inspector__badge--skip {
+  background: var(--background-modifier-border);
+}
+
+.gemmera-inspector__badge--llm {
+  background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+  color: var(--interactive-accent);
+}
+
+.gemmera-inspector__badge--disambig {
+  background: color-mix(in srgb, var(--color-yellow) 18%, transparent);
+  color: var(--color-yellow);
+}
+
+.gemmera-inspector__label {
+  font-weight: 600;
+  color: var(--text-normal);
+}
+
+.gemmera-inspector__confidence {
+  font-variant-numeric: tabular-nums;
+}
+
+.gemmera-inspector__rationale {
+  color: var(--text-muted);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 240px;
+}
+
+.gemmera-inspector__latency {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-faint);
+}
+
+.gemmera-inspector__meta {
+  color: var(--text-faint);
+}
+
+.gemmera-inspector__raw {
+  width: 100%;
+}
+
+.gemmera-inspector__raw summary {
+  cursor: pointer;
+  color: var(--text-faint);
+  user-select: none;
+}
+
+.gemmera-inspector__raw pre {
+  font-size: 0.65rem;
+  margin: 4px 0 0;
+  padding: 6px;
+  background: var(--background-secondary);
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* ── Disambiguation chip ──────────────────────────────────────────────────── */
+.gemmera-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--background-secondary);
+  border-top: 1px solid var(--background-modifier-border);
+  font-size: 0.8rem;
+}
+
+.gemmera-chip__label {
+  color: var(--text-muted);
+  flex: 1;
+}
+
+.gemmera-chip__btn {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.gemmera-chip__btn--cancel {
+  color: var(--text-faint);
+  background: transparent;
+  border: none;
+}


### PR DESCRIPTION
## What
Fixes the streaming token rendering performance and hardens the demo for tomorrow.

## Why
- **O(n²) streaming**: `textEl.textContent += token` in a tight loop was quadratic. Switched to array+join for O(n) — prevents lag on long responses.
- **Model pin**: Changed `gemma3:latest` → `gemma3:4b` across all services. `latest` could resolve to a different model after a pull, breaking the demo.
- **Markdown rendering**: Assistant messages now use Obsidian's `MarkdownRenderer` so headings, lists, code blocks, and wikilinks render properly.
- **Demo vault config**: Disabled spellcheck and properties panel to reduce visual noise during the demo.

## How to test
- `npm test` — all 120 tests pass
- Load the plugin in Obsidian with the demo vault and verify chat responses render as formatted markdown
- Verify the model shown in the inspector is `gemma3:4b`